### PR TITLE
Update chinese text (Testing 07502A version)

### DIFF
--- a/chinese.po
+++ b/chinese.po
@@ -25,7 +25,7 @@ msgstr "这就是我的最终形态了。这感觉真神奇，而且我闻起来
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePlay_RL.Default__MegaSlimePlay_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",00164C5345E544D784CC289035CEF701"
 msgid "About that orb..."
-msgstr ""
+msgstr "关于那个球体…"
 
 #. Key:	002DAFE7433D240D0A5822A932016D65
 #. SourceLocation:	/Game/Ranch/Upgrades/BovaurShed.Default__BovaurShed_C.Upgrade.DisplayName
@@ -39,7 +39,7 @@ msgstr "奶牛棚"
 #: /Game/Dialogue/Leylanna/Default/LeylannaHadSex01.Default__LeylannaHadSex01_C.SessionData.LinesToFuta(3).LinesToFuta
 msgctxt ",002F7FED4D68AF160CEAFFB092D0F2E2"
 msgid "Bring that hard cock over here... I want to feel it inside me."
-msgstr ""
+msgstr "把那个坚硬的鸡巴带过来…我想要细品他在我身体内的感觉"
 
 #. Key:	0061A5124B098F61DE991D81AB884112
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDefault01_Meow.Default__CassieDefault01_Meow_C.SessionData.LinesToFemale(3).LinesToFemale
@@ -53,7 +53,7 @@ msgstr "这条小皮制工具带几乎装不下我的黄油棒!"
 #: /Game/Dialogue/QueenBee/Default/BeeHaveKeystone.Default__BeeHaveKeystone_C.SessionData.Lines(1).Lines
 msgctxt ",00D1AE354BA8FEC1FB7DB5A02D3F12AA"
 msgid "Ahh... oh! Ahem."
-msgstr ""
+msgstr "啊…哦！哼嗯。"
 
 #. Key:	01386D9C478E6BE9974F00942E5EA1E0
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_RL.Default__MirruDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
@@ -74,7 +74,7 @@ msgstr "欸，尼不全部咽干净尼就别想走！"
 #: /Game/Dialogue/Monarch/Default/MonarchStartShySex.Default__MonarchStartShySex_C.SessionData.LinesToMale(3).LinesToMale
 msgctxt ",0169F2A34BA4C1104CDDEE99B3A3B50E"
 msgid "So I can, y-y-you know... feel your cock deep inside me."
-msgstr ""
+msgstr "所以我会，你-你-你懂的…感受你的鸡巴进入我的感觉"
 
 #. Key:	017B23B341D5CE5BB9CC0293262CBD91
 #. SourceLocation:	/Game/Ranch/Upgrades/HarpyAviary.Default__HarpyAviary_C.Upgrade.Description
@@ -116,28 +116,28 @@ msgstr "哦瞧瞧吧，这可真是位稀客。"
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03_RL_F.Default__FernDefault03_RL_F_C.ResponseData(5).ResponseData.BreederPrompt
 msgctxt ",0207AC704D78649132718BBF7F0F0CA1"
 msgid "The Queen Bee demands flowers."
-msgstr ""
+msgstr "蜂后渴望鲜花的簇拥"
 
 #. Key:	022313C047D185193F98C48BE5852E62
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruHadSex01.Default__MirruHadSex01_C.SessionData.LinesToMale(4).LinesToMale
 #: /Game/Dialogue/Mirru/Default/MirruHadSex01.Default__MirruHadSex01_C.SessionData.LinesToMale(4).LinesToMale
 msgctxt ",022313C047D185193F98C48BE5852E62"
 msgid "It's not often one so small has the courage to dick a kraken. I hope my fleshy body pleased you."
-msgstr ""
+msgstr "很少有这么小的人有勇气去干一只克拉肯，我希望我的肉体能取悦你"
 
 #. Key:	026D19BC4A6B81E2694FF6B5E6EC3D9C
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMDefault_RL5_F.Default__DMDefault_RL5_F_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/DragonMatriarch/Default/DMDefault_RL5_F.Default__DMDefault_RL5_F_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",026D19BC4A6B81E2694FF6B5E6EC3D9C"
 msgid "Eeek... big genitals!"
-msgstr ""
+msgstr "哎哟……好大的鸡巴！"
 
 #. Key:	028C9ACB45CFD05DB106DBA06B056886
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.StarfallenMonolith.ManageActionMessage
 #: /Game/World/Overworld.Overworld:PersistentLevel.StarfallenMonolith.ManageActionMessage
 msgctxt ",028C9ACB45CFD05DB106DBA06B056886"
 msgid "Manage your Starfallen"
-msgstr "管理你的星陨人"
+msgstr "管理你的星陨人们"
 
 #. Key:	02A5F6F34ADE67C0A32ECE8E542DCC88
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(26).LinesToMale
@@ -151,7 +151,7 @@ msgstr "当然了，他们于此还是很温柔的。到目前为止还没出现
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_AboutLamias.Default__NeelaDefault01_AboutLamias_C.SessionData.Lines(2).Lines
 msgctxt ",02FA062A4ABF915F50D8B38C08105557"
 msgid "From what I remember, I was of Liasis descent. A race said to roam Lewd Desert long ago."
-msgstr ""
+msgstr "据我所知，我是利娅西丝的血统。是据说很久以前在淫秽的沙漠中游荡的一个种族。"
 
 #. Key:	02FDE6D44BCEE7E9CD0113AACDF9C4E2
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_RechargeSpiritForm_RL_T.Default__LeylannaDefault01_RechargeSpiritForm_RL_T_C.ResponseData(1).ResponseData.BreederPrompt
@@ -165,7 +165,7 @@ msgstr "事情好像变得有些奇怪了……"
 #: /Game/Dialogue/Fesssi/Default/FesssiCave.Default__FesssiCave_C.SessionData.Lines(1).Lines
 msgctxt ",03434DDC47EC9AE95DD6FF899A0ECE62"
 msgid "Deep in the dark caverns of the world live the more \"unsavory\" @MONSTER_RACE@."
-msgstr ""
+msgstr "在世界黑暗的洞穴深处，住着更让人'讨厌'的怪物种族"
 
 #. Key:	034A5C0F4CB9984BC7F902A4AE65BB8A
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R05.Default__CamillaDefault01_R05_C.SessionData.Lines(0).Lines
@@ -186,7 +186,7 @@ msgstr "泰坦体液。"
 #: /Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToMale(4).LinesToMale
 msgctxt ",035F52234F8DA96ED37A5AAC5DD88039"
 msgid "Ahh, plant your delicious seed in my little body! Give me... ohhh... all of it!"
-msgstr "啊，把你美味的种子种在我小小的身体里吧!给我. .哦. .所有的!"
+msgstr "啊，把你美味的种子种在我小小的身体里吧!给我. .哦. .全都给我!"
 
 #. Key:	03BD054E4D9907C2DF497EA4DCC0D8C3
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(6).LinesToFemale
@@ -214,21 +214,21 @@ msgstr "喵呜！爽死了！小野猫要被自己的猫咪精液呛到了！"
 #: /Game/Dialogue/Widow/Default/WidowKeystone.Default__WidowKeystone_C.SessionData.Lines(1).Lines
 msgctxt ",0417FF204F76BA02C95525915D7673A9"
 msgid "A clumsy lamia with an oversized behind came down here a few years ago and left it there."
-msgstr ""
+msgstr "几年前，一个笨手笨脚的有着一个超大的屁股拉米娅来到这里，把它留在了那里"
 
 #. Key:	04205AC945DE4E603D9147AFE4BB7547
 #. SourceLocation:	/Game/Dialogue/Neela/SexScenes/NeelaSnakeCuddleT.Default__NeelaSnakeCuddleT_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Neela/SexScenes/NeelaSnakeCuddleT.Default__NeelaSnakeCuddleT_C.SessionData.Lines(0).Lines
 msgctxt ",04205AC945DE4E603D9147AFE4BB7547"
 msgid "Ohh yes! Ahhh... penetrate my ancient vagina..."
-msgstr "啊…用力！啊啊啊~用力操穿我空虚已久的小穴…"
+msgstr "啊…用力！啊啊啊~用力抽插我空虚已久的小穴…"
 
 #. Key:	0468AC1040BB9A10D1960B833F9A8305
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruHadSex01.Default__MirruHadSex01_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/Mirru/Default/MirruHadSex01.Default__MirruHadSex01_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",0468AC1040BB9A10D1960B833F9A8305"
 msgid "For that I am thankful."
-msgstr ""
+msgstr "为此我十分感激"
 
 #. Key:	04744CA84CBAE9AB13EA1989A23A0DDC
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01.Default__FaleneDefault01_C.SessionData.Lines(0).Lines
@@ -242,7 +242,7 @@ msgstr "我马上要离开你的农场了！不过别担心，你能在海顿小
 #: /Game/Dialogue/QueenBee/Default/BeeHaveKeystone.Default__BeeHaveKeystone_C.SessionData.Lines(0).Lines
 msgctxt ",047A2B2C4D533C816757C8B486F04CC0"
 msgid "Of course not. It's been a symbol of my hive for ages."
-msgstr ""
+msgstr "当然不是。多年来它一直是我蜂巢的象征。"
 
 #. Key:	04809803498EAC7920E3F09D8A29F0BF
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernGreeting01.Default__FernGreeting01_C.SessionData.Lines(4).Lines
@@ -256,7 +256,7 @@ msgstr "是您……嘶嘶要来滋润我了嘶？"
 #: /Game/Dialogue/Fesssi/Default/FesssiDefault01.Default__FesssiDefault01_C.SessionData.Lines(0).Lines
 msgctxt ",04B934DA4280B01E3757EB87CAD514BE"
 msgid "Sure, letting the dryad play with my ass in exchange for fruit was fun for awhile. Her decadent cherries are delicious."
-msgstr ""
+msgstr "当然，让树妖玩弄我的屁股来换取水果是一段时间的乐趣。她樱桃很好吃。"
 
 #. Key:	0500B4944007820F3A7BB096A4E699AB
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieGreeting01.Default__CassieGreeting01_C.SessionData.Lines(6).Lines
@@ -270,49 +270,49 @@ msgstr "如果你想要为你的野生魔弗灵们搭建新家一定要告诉我
 #: /Game/Dialogue/Cassie/Default/CassieDungeon.Default__CassieDungeon_C.SessionData.Lines(4).Lines
 msgctxt ",051883BC403A71EC7220ACAE27A63552"
 msgid "That old rusty set of gears above the town entrance probably controls a pulley system."
-msgstr ""
+msgstr "城门上方那套生锈的旧齿轮可能控制着滑轮系统。"
 
 #. Key:	0522652344116C917836F4A1A78C8815
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R07.Default__CamillaDefault01_R07_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R07.Default__CamillaDefault01_R07_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",0522652344116C917836F4A1A78C8815"
 msgid "Don't waste your beautiful tall body on me human. Just wait for Falene to come back, or go suck on Amber's tits."
-msgstr "不要把你的美味精液浪费在我身上。等着法琳娜回来，或者去吸安布尔的奶子。"
+msgstr "不要把你的美味精液浪费在我身上。等着法莲娜回来，或者去吸安布尔的奶子。"
 
 #. Key:	052657834F6DBDBBC49BDAADA6E5E88A
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_RL.Default__NeelaDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_RL.Default__NeelaDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
 msgctxt ",052657834F6DBDBBC49BDAADA6E5E88A"
 msgid "Tell me about Lamias."
-msgstr "和我讲讲Lamias吧"
+msgstr "和我讲讲拉米娅一族吧。"
 
 #. Key:	0529D0BB4C3047950C7EE496E1F0E5BC
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeTaskFulfilled.Default__BeeTaskFulfilled_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/QueenBee/Default/BeeTaskFulfilled.Default__BeeTaskFulfilled_C.SessionData.Lines(0).Lines
 msgctxt ",0529D0BB4C3047950C7EE496E1F0E5BC"
 msgid "Rejoice, for the flowers have returned!"
-msgstr ""
+msgstr "欢喜吧，因为花儿回来了！"
 
 #. Key:	0559493D46F48B86A2683FB3AC087112
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_FutaBalls.Default__CamillaDefault01_FutaBalls_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_FutaBalls.Default__CamillaDefault01_FutaBalls_C.SessionData.Lines(0).Lines
 msgctxt ",0559493D46F48B86A2683FB3AC087112"
 msgid "Sugar walls before balls!"
-msgstr "Sugar walls before balls!"
+msgstr "Sugar walls before balls!（梗，阴茎如糖墙，在球的前面）"
 
 #. Key:	056C9C1748701D33A4113FB426A3981C
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraGetKeystone.Default__PetraGetKeystone_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Petra/Default/PetraGetKeystone.Default__PetraGetKeystone_C.SessionData.Lines(1).Lines
 msgctxt ",056C9C1748701D33A4113FB426A3981C"
 msgid "However..."
-msgstr ""
+msgstr "但是…"
 
 #. Key:	06271AC24974DE1182364AAD430A9574
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaHadSex02.Default__CamillaHadSex02_C.SessionData.LinesToMale(3).LinesToMale
 #: /Game/Dialogue/Camilla/Default/CamillaHadSex02.Default__CamillaHadSex02_C.SessionData.LinesToMale(3).LinesToMale
 msgctxt ",06271AC24974DE1182364AAD430A9574"
 msgid "If you... uh... ever get desperate again, you know where to find me!"
-msgstr ""
+msgstr "但是如果你…呃…如果你又很渴望的话，你知道哪里能找到我！"
 
 #. Key:	0629816F428092E0C5B0169DD3E8F968
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R02.Default__FaleneDefault01_R02_C.SessionData.Lines(8).Lines
@@ -340,7 +340,7 @@ msgstr "你知道的，@WORLD_NAME@处处遍布我的脚印……滑痕，如果
 #: /Game/Dialogue/QueenBee/Default/BeeDefault02_RL.Default__BeeDefault02_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",06A529F441EB1545EE626A8ECC49CBCC"
 msgid "Do you masturbate all day?"
-msgstr ""
+msgstr "你整天都在自我满足吗？"
 
 #. Key:	06DCC78B4F1DECA217645DA58B3BB2A4
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01_R02_R01.Default__FernDefault01_R02_R01_C.SessionData.Lines(0).Lines
@@ -368,21 +368,21 @@ msgstr "这个世界是属于魔弗灵的乐园——这是一个神秘的，由
 #: /Game/Dialogue/Autumn/Default/DryadBossomCherries.Default__DryadBossomCherries_C.SessionData.Lines(3).Lines
 msgctxt ",07035EA54B778F47897F278270889BBF"
 msgid "Aww... it's so adorable watching them figure out how to reach the fruit on the high branches."
-msgstr ""
+msgstr "哦…看着他们在高高的树枝上找到果实的样子真是太可爱了。"
 
 #. Key:	075A16DA4BA7F51C3A07099921F7F1B3
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyHadSex01.Default__RomyHadSex01_C.SessionData.LinesGrungy(1).LinesGrungy
 #: /Game/Dialogue/Romy/Default/RomyHadSex01.Default__RomyHadSex01_C.SessionData.LinesGrungy(1).LinesGrungy
 msgctxt ",075A16DA4BA7F51C3A07099921F7F1B3"
 msgid "You need a bath. Come now, place your body between my breasts and let's get you clean."
-msgstr ""
+msgstr "你需要洗个澡。来吧，把你的身体放在我的双峰之间，让它们帮你弄干净。"
 
 #. Key:	07B2E95342A617616201F19B87E3655A
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimePlay1.Default__MegaSlimePlay1_C.SessionData.LinesToFuta(3).LinesToFuta
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePlay1.Default__MegaSlimePlay1_C.SessionData.LinesToFuta(3).LinesToFuta
 msgctxt ",07B2E95342A617616201F19B87E3655A"
 msgid "You will feel so good as I milk your cock for all of its delicious semen..."
-msgstr ""
+msgstr "你会感觉我为了你的精液就像在为你的鸡巴挤牛奶般舒服…"
 
 #. Key:	07F233504BDA1232640FB1846CBFE868
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01.Default__FernDefault01_C.SessionData.Lines(0).Lines
@@ -396,7 +396,7 @@ msgstr "主人，小蕨永远爱您。"
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_AboutLamias.Default__NeelaDefault01_AboutLamias_C.SessionData.Lines(0).Lines
 msgctxt ",07F5EE754EC13715610F3E8746D2A3D2"
 msgid "Honestly, I don't know much about my kind."
-msgstr "有一说一，我对我的族类并不了解。"
+msgstr "有一说一，我对我的族类并不了解太多。"
 
 #. Key:	08236DA548D9257F9FE293A6ACBC8A84
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_RL_T.Default__FernDefault02_RL_T_C.ResponseData(3).ResponseData.BreederPrompt
@@ -410,49 +410,49 @@ msgstr "你可以用我的乳汁滋润自己了！"
 #: /Game/Dialogue/OrcChief/Default/OrcDefault03_RL.Default__OrcDefault03_RL_C.ResponseData(4).ResponseData.BreederPrompt
 msgctxt ",085EF70E45D784AFAEFB07BC461A23D9"
 msgid "Are all orcs as brash and dumb as you?"
-msgstr ""
+msgstr "是不是所有的兽人都像你一样傲慢和愚蠢？"
 
 #. Key:	08A1991945921B46D9EF9A94894EF846
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeDefault01.Default__BeeDefault01_C.SessionData.LinesToMale(0).LinesToMale
 #: /Game/Dialogue/QueenBee/Default/BeeDefault01.Default__BeeDefault01_C.SessionData.LinesToMale(0).LinesToMale
 msgctxt ",08A1991945921B46D9EF9A94894EF846"
 msgid "This corner is n-n-nice and safe!"
-msgstr ""
+msgstr "这个角落真的是-真-真的是又棒又安全！"
 
 #. Key:	08A2508F4D57261E790AB8BEA258D6B2
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryHadSex01.Default__EmissaryHadSex01_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/Emissary/Default/EmissaryHadSex01.Default__EmissaryHadSex01_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",08A2508F4D57261E790AB8BEA258D6B2"
 msgid "Understand, thou has licked a vagina as old as time itself."
-msgstr ""
+msgstr "明白吗，汝舔过一个和时间一样古老的阴道。"
 
 #. Key:	08DE001E4420BE30688798BF6B70729D
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryCockblockGates.Default__EmissaryCockblockGates_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryCockblockGates.Default__EmissaryCockblockGates_C.SessionData.Lines(4).Lines
 msgctxt ",08DE001E4420BE30688798BF6B70729D"
 msgid "You will need to satisfy their desires before they will give them up."
-msgstr ""
+msgstr "你需要先满足他们的欲望，然后他们才会放下身段"
 
 #. Key:	0925499D4273278AA298A99B40C4550F
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMYourChildren.Default__DMYourChildren_C.SessionData.LinesToFuta(2).LinesToFuta
 #: /Game/Dialogue/DragonMatriarch/Default/DMYourChildren.Default__DMYourChildren_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",0925499D4273278AA298A99B40C4550F"
 msgid "Believe me human, I have birthed many offspring."
-msgstr ""
+msgstr "相信我，人类，我生了很多后代"
 
 #. Key:	093760FD4181D0AA284C4D96884A3801
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon2.Default__AmberMaeLockedDungeon2_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon2.Default__AmberMaeLockedDungeon2_C.SessionData.Lines(1).Lines
 msgctxt ",093760FD4181D0AA284C4D96884A3801"
 msgid "Took me love for milk too far, 'an the 'ol bovaur genes kicked in."
-msgstr ""
+msgstr "'对我来说'俺爱乳汁爱的无法自拔了'这已经被狠狠地加入了奶牛一族的基因了。"
 
 #. Key:	094AB3854E6DACE10C94B28ADCB83FE0
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaFaleneWeek.Default__CamillaFaleneWeek_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaFaleneWeek.Default__CamillaFaleneWeek_C.SessionData.Lines(2).Lines
 msgctxt ",094AB3854E6DACE10C94B28ADCB83FE0"
 msgid "The best thing she finds, she brings back here to examine."
-msgstr ""
+msgstr "她找到了最好的东西，带回来测试"
 
 #. Key:	0968DD0D4744523D6AFCEABE502C530F
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R07.Default__FaleneDefault01_R07_C.SessionData.LinesToFemale(1).LinesToFemale
@@ -466,77 +466,77 @@ msgstr "我已经饥渴难耐！张开你的大腿，人类，因为我要来啦
 #: /Game/Dialogue/Mirru/Default/MirruHadSex01.Default__MirruHadSex01_C.SessionData.LinesToFemale(4).LinesToFemale
 msgctxt ",099488164DB48F48395E94B86F3EE565"
 msgid "My lust is quickly regenerating, and I would gladly mate with you again."
-msgstr ""
+msgstr "我的性欲正在迅速再生，我很乐意再次与你交欢"
 
 #. Key:	09C95B9C48668D0B269B88826710F912
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryHadSex01.Default__EmissaryHadSex01_C.SessionData.LinesToFuta(2).LinesToFuta
 #: /Game/Dialogue/Emissary/Default/EmissaryHadSex01.Default__EmissaryHadSex01_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",09C95B9C48668D0B269B88826710F912"
 msgid "Is that a comforting feeling?"
-msgstr ""
+msgstr "这是一种安慰吗？"
 
 #. Key:	0A1E776A4877D11A8A4716A6FEE789C1
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(7).LinesToMale
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(7).LinesToMale
 msgctxt ",0A1E776A4877D11A8A4716A6FEE789C1"
 msgid "@MONSTER_RACE@ origins are ancient and unknown, but we desire one thing above all else..."
-msgstr "魔弗灵的起源不仅古老且未知，但是我们比其他生灵都更渴望一件事…..."
+msgstr "魔弗灵的起源不仅古老且未知，但是我们比其他生灵都更渴望一件事…"
 
 #. Key:	0A6AA641405E829B424AFE8894AB0083
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraAboutPawsmaati.Default__PetraAboutPawsmaati_C.SessionData.Lines(6).Lines
 #: /Game/Dialogue/Petra/Default/PetraAboutPawsmaati.Default__PetraAboutPawsmaati_C.SessionData.Lines(6).Lines
 msgctxt ",0A6AA641405E829B424AFE8894AB0083"
 msgid "When Pawsmaati finally unleashed her river of cum, I entered a dreamlike state in which I felt my mind unite with her's."
-msgstr ""
+msgstr "在帕丝玛媞如同泄洪一般的高潮中，我进入了一种梦幻般的状态，在这种状态下，我感到我的思想与她的思想结合在一起。"
 
 #. Key:	0A6CE0B4469F4068DE66F4AB8EC4EDA9
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimePlay1.Default__MegaSlimePlay1_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePlay1.Default__MegaSlimePlay1_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",0A6CE0B4469F4068DE66F4AB8EC4EDA9"
 msgid "I think... you might be my best friend of all time."
-msgstr ""
+msgstr "我想…你可能是我最好的朋友"
 
 #. Key:	0AA608164C47369E28D0C6BFDB27289A
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_AboutKrakens.Default__MirruDefault01_AboutKrakens_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_AboutKrakens.Default__MirruDefault01_AboutKrakens_C.SessionData.Lines(0).Lines
 msgctxt ",0AA608164C47369E28D0C6BFDB27289A"
 msgid "The most noble, mighty, and feared race beneath the waves we are!"
-msgstr "浪潮之下的万族，若论尊贵，论强大，论可畏，无可出吾等之右！"
+msgstr "浪潮之下的我族，若论尊贵，论强大，论可畏，无可出吾等之右！"
 
 #. Key:	0B1F283F4C4E0D0752DF53AB312D45F9
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMClimaxPeak.Default__DMClimaxPeak_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMClimaxPeak.Default__DMClimaxPeak_C.SessionData.Lines(3).Lines
 msgctxt ",0B1F283F4C4E0D0752DF53AB312D45F9"
 msgid "I've heard about fertile Bovaur roaming in the south which produce vast quantities of breast milk."
-msgstr ""
+msgstr "我听说肥硕的奶牛族在南部漫游，她们能产生大量的母乳。"
 
 #. Key:	0B2CFD3342EAE68FB552BF9F7876374B
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaHadSex01.Default__NeelaHadSex01_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Neela/Default/NeelaHadSex01.Default__NeelaHadSex01_C.SessionData.Lines(2).Lines
 msgctxt ",0B2CFD3342EAE68FB552BF9F7876374B"
 msgid "Ahhh... I feel so good!"
-msgstr ""
+msgstr "哦…我感觉棒极了！"
 
 #. Key:	0B4EC1164A6993BFA78D2589D15A3FEB
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowDefault01.Default__WidowDefault01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Widow/Default/WidowDefault01.Default__WidowDefault01_C.SessionData.Lines(0).Lines
 msgctxt ",0B4EC1164A6993BFA78D2589D15A3FEB"
 msgid "What is this stuck in my web... a tasty morsel coursing with warm juice."
-msgstr ""
+msgstr "是什么小可爱落入了我的网中…原来是带着温暖果汁美味的小菜"
 
 #. Key:	0B66D1724E54B8860E24D3A0B83981AB
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcDefault03_RL.Default__OrcDefault03_RL_C.ResponseData(3).ResponseData.BreederPrompt
 #: /Game/Dialogue/OrcChief/Default/OrcDefault03_RL.Default__OrcDefault03_RL_C.ResponseData(3).ResponseData.BreederPrompt
 msgctxt ",0B66D1724E54B8860E24D3A0B83981AB"
 msgid "Your orc tribe sucks."
-msgstr ""
+msgstr "你的兽人部落弱爆了"
 
 #. Key:	0B796FF84644C0154CA874BFDFA16D50
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyHadSex01.Default__RomyHadSex01_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Romy/Default/RomyHadSex01.Default__RomyHadSex01_C.SessionData.Lines(2).Lines
 msgctxt ",0B796FF84644C0154CA874BFDFA16D50"
 msgid "Let us spend the day together, for here in the warmth of this water we can sing again for hours."
-msgstr ""
+msgstr "让我们一起度过这一天，因为在这温暖的水里，我们可以再吟唱上几个小时"
 
 #. Key:	0BB0A695454FD69DAA129F82F023EB23
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(1).LinesToFemale
@@ -550,14 +550,14 @@ msgstr "一个人类！ 超级可爱的人类，我的幸运日就在今天。 �
 #: /Game/World/Overworld.Overworld:PersistentLevel.VulwargKennel.ManageActionMessage
 msgctxt ",0BBD00B64AD7488CC6A8008C2BAF8B41"
 msgid "Manage your Vulwargs"
-msgstr "管理你的狼人"
+msgstr "管理你的狼人们"
 
 #. Key:	0BC94BF94437671AAC651EBA39693570
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowKeystone.Default__WidowKeystone_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Widow/Default/WidowKeystone.Default__WidowKeystone_C.SessionData.Lines(4).Lines
 msgctxt ",0BC94BF94437671AAC651EBA39693570"
 msgid "Long I have wished to taste an elf, but they never come up this way."
-msgstr ""
+msgstr "很久以来，我一直想尝尝精灵的味道，但它们从来没有经过这里。"
 
 #. Key:	0BD52B434C91C8F5172BC0BB8C1B00BA
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_Leylanna.Default__EmissaryDefault01_Leylanna_C.SessionData.Lines(0).Lines
@@ -571,42 +571,42 @@ msgstr "瞧瞧吧，这可是一位至高女神的爱仆。赞美归于至高女
 #: /Game/World/Overworld.Overworld:PersistentLevel.ThriaeHive.ManageActionMessage
 msgctxt ",0C1F84244DE410EF33BD2B924829370C"
 msgid "Manage your Thriae"
-msgstr "管理你的蜂人"
+msgstr "管理你的蜂人们"
 
 #. Key:	0C6185B247E0B89045AEA68A0EF63C17
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraPracticeMe.Default__PetraPracticeMe_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Petra/Default/PetraPracticeMe.Default__PetraPracticeMe_C.SessionData.Lines(3).Lines
 msgctxt ",0C6185B247E0B89045AEA68A0EF63C17"
 msgid "Get over here and teach this naughty bunny a lesson!"
-msgstr ""
+msgstr "过来给这只淘气的小兔子来上一课！"
 
 #. Key:	0C7FA2DC4E91993DEDDA2CA03E98C251
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiTaskFulfilled.Default__FesssiTaskFulfilled_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiTaskFulfilled.Default__FesssiTaskFulfilled_C.SessionData.Lines(1).Lines
 msgctxt ",0C7FA2DC4E91993DEDDA2CA03E98C251"
 msgid "Hiss!"
-msgstr ""
+msgstr "嘶！"
 
 #. Key:	0CA6EE7548B8D90D10FC67A138E7F076
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R06.Default__FaleneDefault01_R06_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R06.Default__FaleneDefault01_R06_C.SessionData.Lines(4).Lines
 msgctxt ",0CA6EE7548B8D90D10FC67A138E7F076"
 msgid "The ones the Goddess personally mated with are said to have experienced so much pleasure, they died in Her loving embrace."
-msgstr "与女神亲自交配的那些人据说体验到了人生极乐，他们在她充满爱的怀抱中死去。"
+msgstr "与女神亲自交配的那些人据说体验到了人生极乐，他们在她充满爱的怀抱中睡去。"
 
 #. Key:	0CBE9A9A40E9ADB708F7C28FA2F1B657
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchShySexF_RL.Default__MonarchShySexF_RL_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/Monarch/Default/MonarchShySexF_RL.Default__MonarchShySexF_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",0CBE9A9A40E9ADB708F7C28FA2F1B657"
 msgid "My body is ready"
-msgstr ""
+msgstr "我的身体准备好了"
 
 #. Key:	0CD45BB44BFDB28371B663B5B53FD368
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDefault01.Default__CassieDefault01_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Cassie/Default/CassieDefault01.Default__CassieDefault01_C.SessionData.Lines(5).Lines
 msgctxt ",0CD45BB44BFDB28371B663B5B53FD368"
 msgid "*Purr*"
-msgstr "*咕噜咕噜声*"
+msgstr "*咕噜咕噜*"
 
 #. Key:	0CE3BF194F0AEDEFF8FD32BC70EC9A18
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy_RL_F.Default__MirruDefault01_BodySexToy_RL_F_C.ResponseData(1).ResponseData.BreederPrompt
@@ -641,28 +641,28 @@ msgstr "蝴蝶式"
 #: /Game/Dialogue/Romy/Default/RomyDefault01.Default__RomyDefault01_C.SessionData.Lines(2).Lines
 msgctxt ",0D3C4D8D4F6C01DE00A1B88BD745C860"
 msgid "A bath perhaps? Or maybe one of your wild ones made love with the dirt. I will wash them all."
-msgstr ""
+msgstr "不沐浴一下吗？亦或者你的动物做爱时候弄脏了，我将褪去他们的尘土."
 
 #. Key:	0D41FE0947E3B6D0F4FD10AF14FE68BE
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleCentaur.Default__KybeleCentaur_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Kybele/Default/KybeleCentaur.Default__KybeleCentaur_C.SessionData.Lines(5).Lines
 msgctxt ",0D41FE0947E3B6D0F4FD10AF14FE68BE"
 msgid "For one of the @MONSTER_RACE@ race it is torture!"
-msgstr ""
+msgstr "对于魔弗灵们来说，这是一场折磨！"
 
 #. Key:	0DB9C395441D2A229D61EE963260C09C
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.TitanCave.ManageActionMessage
 #: /Game/World/Overworld.Overworld:PersistentLevel.TitanCave.ManageActionMessage
 msgctxt ",0DB9C395441D2A229D61EE963260C09C"
 msgid "Manage your Titans"
-msgstr "管理你的泰坦"
+msgstr "管理你的泰坦们"
 
 #. Key:	0DF191BF45A432F3BF190CAA63DF44DA
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeVerySad2.Default__MegaSlimeVerySad2_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeVerySad2.Default__MegaSlimeVerySad2_C.SessionData.Lines(0).Lines
 msgctxt ",0DF191BF45A432F3BF190CAA63DF44DA"
 msgid "*Continued sobbing*"
-msgstr ""
+msgstr "不停的啜泣"
 
 #. Key:	0DFBAC884A0E11B073E5269E92E6DC30
 #. SourceLocation:	/Game/Breeding/Positions/Doggy.Default__Doggy_C.SessionData.PositionName
@@ -676,7 +676,7 @@ msgstr "狗爬式"
 #: /Game/Dialogue/Fesssi/Default/FesssiDefault03_RL_F.Default__FesssiDefault03_RL_F_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",0E10569D4932D4D9DE1B73A05A7FC5FB"
 msgid "Wow... this world is full of idiots."
-msgstr ""
+msgstr "哇哦…这个世界充满了傻子"
 
 #. Key:	0E2A96C54ACC4571431587B73459221E
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(19 - Value).TraitIcons.DisplayName
@@ -690,14 +690,14 @@ msgstr "性狂热"
 #: /Game/Dialogue/Parvati/Default/ParvatiHadSex01.Default__ParvatiHadSex01_C.SessionData.Lines(3).Lines
 msgctxt ",0E3AF3704D88CDB26D17458852A1792E"
 msgid "Using our bodies in ways all too perverse."
-msgstr ""
+msgstr "都太不通情的使用我们的身体。"
 
 #. Key:	0E4B3CBA440B587A805453A5FAC01859
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDungeon2.Default__CassieDungeon2_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Cassie/Default/CassieDungeon2.Default__CassieDungeon2_C.SessionData.Lines(1).Lines
 msgctxt ",0E4B3CBA440B587A805453A5FAC01859"
 msgid "Meow... no one has been down there for as long as I remember."
-msgstr ""
+msgstr "喵呜…从我记事起我就感觉没人去过那儿。"
 
 #. Key:	0E6E1156457FB3513C060D979FF6B9AE
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(29 - Value).TraitIcons.HelpText
@@ -711,28 +711,28 @@ msgstr "不孕不育：无法产生后代"
 #: /Game/Ranch/Upgrades/DragonHoard.Default__DragonHoard_C.Upgrade.TypeDisplay
 msgctxt ",0EA04A8B485AD7C29BE98E893200A8E3"
 msgid "Nephelym Barn"
-msgstr "魔弗灵谷仓"
+msgstr "魔弗灵牧场"
 
 #. Key:	0EA2FCF24AF05A8FBEF98C9F2C767D3A
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryRaiseTraitLvl_RL.Default__EmissaryRaiseTraitLvl_RL_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/Emissary/Default/EmissaryRaiseTraitLvl_RL.Default__EmissaryRaiseTraitLvl_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",0EA2FCF24AF05A8FBEF98C9F2C767D3A"
 msgid "Decline"
-msgstr "回绝"
+msgstr "衰退"
 
 #. Key:	0EC0E30B4EEFEC910A9F1D90DC5AB286
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryHadSex01.Default__EmissaryHadSex01_C.SessionData.LinesToMale(3).LinesToMale
 #: /Game/Dialogue/Emissary/Default/EmissaryHadSex01.Default__EmissaryHadSex01_C.SessionData.LinesToMale(3).LinesToMale
 msgctxt ",0EC0E30B4EEFEC910A9F1D90DC5AB286"
 msgid "Judging by the mess on the temple floor, quite good."
-msgstr ""
+msgstr "从圣殿的地板混乱程度来看，真不错"
 
 #. Key:	0EEEC9A34AD6162338FCA699384590D4
 #. SourceLocation:	/Game/Ranch/Upgrades/NekoCondo.Default__NekoCondo_C.Upgrade.TypeDisplay
 #: /Game/Ranch/Upgrades/NekoCondo.Default__NekoCondo_C.Upgrade.TypeDisplay
 msgctxt ",0EEEC9A34AD6162338FCA699384590D4"
 msgid "Nephelym Barn"
-msgstr "魔弗灵谷仓"
+msgstr "魔弗灵牧场"
 
 #. Key:	0F0B2E364C42C3D6BACC018A46DB5BE4
 #. SourceLocation:	/Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToFuta(5).LinesToFuta
@@ -746,14 +746,14 @@ msgstr "*吮吸，舔*"
 #: /Game/Dialogue/Widow/Default/WidowHadSex01.Default__WidowHadSex01_C.SessionData.Lines(1).Lines
 msgctxt ",0F2C0FD149F892CC3CC45FA0F73FA3DB"
 msgid "There is no need to fear me. Stay awhile in my web, and let us see how far we can take our love."
-msgstr ""
+msgstr "不用害怕我。在我的网里呆一会儿吧，让我们看看我们的爱能持续多久。"
 
 #. Key:	0F2C916F409983084088D7B8C734556F
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_Leylanna.Default__EmissaryDefault01_Leylanna_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_Leylanna.Default__EmissaryDefault01_Leylanna_C.SessionData.Lines(4).Lines
 msgctxt ",0F2C916F409983084088D7B8C734556F"
 msgid "However, she must learn to restrain herself from inhaling so much of that blue smoke."
-msgstr "但是，她必须学会克制自己，避免吸入那么多的蓝色烟雾"
+msgstr "但是，她必须学会克制自己，不要吸入那么多的蓝烟"
 
 #. Key:	0F3DB30048A1D95AFB32AEBCA67D8C96
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01.Default__RomyDefault01_C.SessionData.LinesGrungy(1).LinesGrungy
@@ -767,35 +767,35 @@ msgstr "你需要洗个澡。来吧，将你的身体放在我的乳房之间，
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_AboutKrakens.Default__MirruDefault01_AboutKrakens_C.SessionData.Lines(2).Lines
 msgctxt ",0F5F4BBA4C14BF84662CB09F0D97B147"
 msgid "While we have destructive past, most Krakens today are peaceful and seek only love and pleasure as other @MONSTER_RACE@."
-msgstr "尽管我们拥有悲惨的过去，但如今大多数Krakens都很和平，都像其他魔弗灵一样寻求爱与快乐。"
+msgstr "尽管我们拥有悲惨的过去，但如今大多数克拉肯们都很和平，都像其他魔弗灵一样寻求爱与快乐。"
 
 #. Key:	0F62EE694ADB2071C7247C8AA042A065
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeDefault01_RL.Default__MegaSlimeDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeDefault01_RL.Default__MegaSlimeDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",0F62EE694ADB2071C7247C8AA042A065"
 msgid "I want you to have this pearl."
-msgstr ""
+msgstr "我希望你留着这颗珍珠。"
 
 #. Key:	0FAF6E0B4308E0F116E3C3BC117672E3
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToMale(7).LinesToMale
 #: /Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToMale(7).LinesToMale
 msgctxt ",0FAF6E0B4308E0F116E3C3BC117672E3"
 msgid "That creepy golden seraphim, the one in the temple. She appeared only a few days ago, constantly asking to speak with \"the human\"."
-msgstr ""
+msgstr "那个可怕的金色六翼天使，圣殿里的那个。她几天前才出现，不断地要求和“人类”说话。"
 
 #. Key:	0FB73EF84E0DB71722FC9BAB2C24DFEE
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowDefault01_RL.Default__WidowDefault01_RL_C.ResponseData(3).ResponseData.BreederPrompt
 #: /Game/Dialogue/Widow/Default/WidowDefault01_RL.Default__WidowDefault01_RL_C.ResponseData(3).ResponseData.BreederPrompt
 msgctxt ",0FB73EF84E0DB71722FC9BAB2C24DFEE"
 msgid "That poor elf..."
-msgstr ""
+msgstr "那个可怜的精灵…"
 
 #. Key:	0FC69F2441505B7DAACAC7807627892D
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03_R05.Default__FernDefault03_R05_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03_R05.Default__FernDefault03_R05_C.SessionData.Lines(1).Lines
 msgctxt ",0FC69F2441505B7DAACAC7807627892D"
 msgid "We made her together when your bodily fluids merged with mine."
-msgstr "当我吞食您的体液时，我们可以让她加入我们"
+msgstr "当主人您的体液和我的体液融合时，我们一起创造了她"
 
 #. Key:	0FDE723F46BC47FD23DB75A6EDA9C79C
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_BlueSmoke.Default__LeylannaDefault01_BlueSmoke_C.SessionData.Lines(2).Lines
@@ -809,7 +809,7 @@ msgstr "啊..."
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFuta(30).LinesToFuta
 msgctxt ",1019EEE14B67704DE6DE0B9FD7D0D596"
 msgid "If you want to learn about how to catch @MONSTER_RACE@, head to the town located up the plateau ahead and speak to my assistant Camilla. You can't miss her... actually wait you might, she's so tiny and cute hehehe."
-msgstr "如果你想学习如何抓住魔弗灵，从前面那条小路往上走到高处的小镇，去问问我的助手Camilla。你可千万不能错过她……事实上她有可能也在等你，她是那么娇小可爱…嘿嘿嘿……"
+msgstr "如果你想学习如何抓住魔弗灵，从前面那条小路往上走到高处的小镇，去问问我的助手卡米拉。你可千万不能错过她……事实上她有可能也在等你，她是那么娇小可爱…嘿嘿嘿……"
 
 #. Key:	106EA6A747A0901892BD12A925DA79A5
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy_RL_F.Default__MirruDefault01_BodySexToy_RL_F_C.ResponseData(0).ResponseData.BreederPrompt
@@ -823,7 +823,7 @@ msgstr "和我一起放纵吧！"
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault02.Default__EmissaryDefault02_C.SessionData.Lines(2).Lines
 msgctxt ",1074EFCF47610848DA1E09AED2EF9B29"
 msgid "That disgusting creature will not see the light of day so long as this emissary remains."
-msgstr ""
+msgstr "只要这位使者还活着，那恶心的家伙就见不到光明了"
 
 #. Key:	107C6B8448B1F139A90AFDBD17AE1AA9
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(25).LinesToFemale
@@ -851,14 +851,14 @@ msgstr "等你抓住一只雌性狐灵再回来找我吧。"
 #: /Game/Dialogue/Kybele/Default/KybeleHaveKeystone.Default__KybeleHaveKeystone_C.SessionData.Lines(4).Lines
 msgctxt ",10E4A32B499DC549B6EE719D6FEAFD45"
 msgid "I want a strong mate large enough to please me, a Vulwarg fleshy in the right areas will do."
-msgstr ""
+msgstr "我想要一个足够强壮的伴侣来取悦我，一具鲜美的狼人肉体会帮上忙"
 
 #. Key:	1101687D48DB923571BCF99F288D40BC
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyGreeting01.Default__RomyGreeting01_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Romy/Default/RomyGreeting01.Default__RomyGreeting01_C.SessionData.Lines(3).Lines
 msgctxt ",1101687D48DB923571BCF99F288D40BC"
 msgid "Won't you stay in my loving embrace and feel my music?"
-msgstr "您是否会停留在我充满爱的怀抱中并感受我的音乐？"
+msgstr "你不想留在我爱的怀抱里感受我的音乐吗？"
 
 #. Key:	11020A854E2D02F780F8BEA52E1E313C
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryBlessedInquiry02_R01.Default__EmissaryBlessedInquiry02_R01_C.SessionData.Lines(0).Lines
@@ -879,63 +879,63 @@ msgstr "我真想把你榨的……一滴不剩……"
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_AboutKrakens.Default__MirruDefault01_AboutKrakens_C.SessionData.Lines(3).Lines
 msgctxt ",115E28B04787E362B52C17AF826B86A5"
 msgid "You must understand human, our large fleshy bodies pulse with lust and are difficult to satisfy."
-msgstr "你要明白，人类，我们巨大而丰硕的肉体满溢着欲望，难以满足。"
+msgstr "你要明白，人类，我们丰满的肉体满溢着欲望，难以满足。"
 
 #. Key:	1187860A495AEE8B52286F8DA6A1DF53
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01_RL_F.Default__FernDefault01_RL_F_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/Fern/Default/FernDefault01_RL_F.Default__FernDefault01_RL_F_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",1187860A495AEE8B52286F8DA6A1DF53"
 msgid "What a lovely talking fern..."
-msgstr "真是个可爱的小蕨。"
+msgstr "真是个又可爱又会说话的小蕨。"
 
 #. Key:	119BE39146D97EAD68AF26B063950DFD
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_Emissary.Default__LeylannaDefault01_Emissary_C.SessionData.Lines(6).Lines
 #: /Game/Dialogue/Leylanna/Default/LeylannaDefault01_Emissary.Default__LeylannaDefault01_Emissary_C.SessionData.Lines(6).Lines
 msgctxt ",119BE39146D97EAD68AF26B063950DFD"
 msgid "Forgive my daydreaming human, Emissary is your archangel. She will help you."
-msgstr "哦凡人，请原谅我做这一场白日淫梦。圣殿天使是你的大天使。她会帮助你的."
+msgstr "哦凡人，请原谅我做这一场白日淫梦。使者是你的大天使。她会帮助你的."
 
 #. Key:	11A588964451AB702EC48CA542D16E81
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToMale(6).LinesToMale
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToMale(6).LinesToMale
 msgctxt ",11A588964451AB702EC48CA542D16E81"
 msgid "Stick that lovely human dick deep into my Lamia body... yes..."
-msgstr "用那人类的阴茎深深埋进我Lamia族的身体里吧……就是那里……啊啊~"
+msgstr "用那人类的鸡巴深入我拉米娅族的身体里吧……就是这样……啊啊~"
 
 #. Key:	11A9B90644E91677CD9DEFB4CC831C2C
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.CBGate_Jungle.PlaceMessage
 #: /Game/World/Overworld.Overworld:PersistentLevel.CBGate_Jungle.PlaceMessage
 msgctxt ",11A9B90644E91677CD9DEFB4CC831C2C"
 msgid "Sultry Plateau is now accessible."
-msgstr ""
+msgstr "现在可以访问潮热高原了"
 
 #. Key:	11B6FBE746EB52494E5B6E83052E0D98
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiCave.Default__FesssiCave_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiCave.Default__FesssiCave_C.SessionData.Lines(4).Lines
 msgctxt ",11B6FBE746EB52494E5B6E83052E0D98"
 msgid "Naturally I slithered my big butt in there and found myself right at home."
-msgstr ""
+msgstr "我很自然地把我的大屁股滑进去了发现自己就如同在家里一样舒适"
 
 #. Key:	11BBEDC74B6704427E32B6A7F9FB5D77
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchStartShySex.Default__MonarchStartShySex_C.SessionData.LinesToFuta(2).LinesToFuta
 #: /Game/Dialogue/Monarch/Default/MonarchStartShySex.Default__MonarchStartShySex_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",11BBEDC74B6704427E32B6A7F9FB5D77"
 msgid "May I... ride you?"
-msgstr ""
+msgstr "我…可以骑你吗？"
 
 #. Key:	11C0FBB845185DFCD5E67DA5B758B432
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon2.Default__AmberMaeLockedDungeon2_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon2.Default__AmberMaeLockedDungeon2_C.SessionData.Lines(2).Lines
 msgctxt ",11C0FBB845185DFCD5E67DA5B758B432"
 msgid "At me peak I could barely walk! The jugs 'an belly were mighty heavy."
-msgstr ""
+msgstr "在山顶俺几乎走不动了！俺的两个大奶和肚子太重了压得俺。"
 
 #. Key:	12036FB64912193341380BA267A64971
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernGreeting03.Default__FernGreeting03_C.SessionData.LinesToFemale(4).LinesToFemale
 #: /Game/Dialogue/Fern/DefaultP3/FernGreeting03.Default__FernGreeting03_C.SessionData.LinesToFemale(4).LinesToFemale
 msgctxt ",12036FB64912193341380BA267A64971"
 msgid "Slide yourself in here with me, my body is silky and filled with sweet nectar. I will make you feel so good..."
-msgstr "滑入我充满了花蜜，犹如丝绸般柔软的身体吧，我会让你好好享受的..."
+msgstr "滑入我充满了花蜜，犹如丝绸般柔软的身体吧，我会让您好好享受的..."
 
 #. Key:	123F93684828FFF522F86B84110A5712
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01_RL_F.Default__FernDefault01_RL_F_C.ResponseData(0).ResponseData.BreederPrompt
@@ -956,14 +956,14 @@ msgstr "我们真的只是一群发自内心寻找快乐的追寻者！"
 #: /Game/World/Events/EM_Keystone.EM_Keystone_C:ExecuteUbergraph_EM_Keystone [Script Bytecode]
 msgctxt ",1276E5EB4781A0238A9705AC9FEE680E"
 msgid "Keystone acquired."
-msgstr ""
+msgstr "使用了钥石"
 
 #. Key:	129A33314E1BA60BA7698394A0DEDCD7
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieHadSex01.Default__CassieHadSex01_C.SessionData.LinesToFuta(3).LinesToFuta
 #: /Game/Dialogue/Cassie/Default/CassieHadSex01.Default__CassieHadSex01_C.SessionData.LinesToFuta(3).LinesToFuta
 msgctxt ",129A33314E1BA60BA7698394A0DEDCD7"
 msgid "So many splinters in my back, but it was worth it!"
-msgstr ""
+msgstr "我的后背都磨疼了呀，但这太值了！"
 
 #. Key:	129E92F14686D57C52A26598C5257AF6
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(12).LinesToFemale
@@ -991,7 +991,7 @@ msgstr "反转女牛仔!(男下女上女性反转体位)"
 #: /Game/Dialogue/Mirru/SexScenes/MirruSnatchT.Default__MirruSnatchT_C.SessionData.Lines(2).Lines
 msgctxt ",12D3C80246AEABBC7C78CD8D7A2FD415"
 msgid "Do you like my thick deep vagina? Ahh... penetrate it with all your might..."
-msgstr "喜欢我又肥又厚的小穴吗？对、用你的所有力量操穿它……"
+msgstr "喜欢我又肥又厚的小穴吗？对、用你全力操穿它…"
 
 #. Key:	12F0D8C14278EB1A73FD4289B39B7E87
 #. SourceLocation:	/Game/Dialogue/Blossom/Default/BlossomDefault01_RL_F.Default__BlossomDefault01_RL_F_C.ResponseData(2).ResponseData.BreederPrompt
@@ -1012,14 +1012,14 @@ msgstr "泰坦洞穴"
 #: /Game/Dialogue/Monarch/Default/MonarchShySexT_RL.Default__MonarchShySexT_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",1313BBB44A4D1E05E98E26A226B6226B"
 msgid "No!"
-msgstr ""
+msgstr "不！"
 
 #. Key:	1314F6404A2F1B2C9E0F9F856E1D18C6
 #. SourceLocation:	/Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToFuta(1).LinesToFuta
 #: /Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToFuta(1).LinesToFuta
 msgctxt ",1314F6404A2F1B2C9E0F9F856E1D18C6"
 msgid "Yes... oh yes, it feels so good! Penetrate me deeper!"
-msgstr "你的……哦，好棒，感觉好舒服! 更深点!"
+msgstr "啊……哦，好棒，感觉好舒服! 再深点!"
 
 #. Key:	132FEAC24092921E25A0F68A9AA99D0B
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_RL.Default__NeelaDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
@@ -1033,70 +1033,70 @@ msgstr "虚空是什么？"
 #: /Game/Dialogue/OrcChief/Default/OrcAkabekoCheck.Default__OrcAkabekoCheck_C.SessionData.Lines(4).Lines
 msgctxt ",13523F8143CE0377FC6658A757678D38"
 msgid "Take stupid keystone if you haven't already."
-msgstr ""
+msgstr "如果你还没有的话，拿走这个愚蠢的钥石吧。"
 
 #. Key:	1375B52C45BC0C13C5B21D954838AE4B
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchQueen.Default__MonarchQueen_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Monarch/Default/MonarchQueen.Default__MonarchQueen_C.SessionData.Lines(3).Lines
 msgctxt ",1375B52C45BC0C13C5B21D954838AE4B"
 msgid "As a butterfly, my t-t-task is to fly around the world and collect exotic nectar."
-msgstr ""
+msgstr "作为一只蝴蝶，我…我的……任务是飞遍世界，采集异国的花蜜。"
 
 #. Key:	13E887904839CEF7B4D79EBD63EA0F05
 #. SourceLocation:	/Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToFuta(2).LinesToFuta
 #: /Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",13E887904839CEF7B4D79EBD63EA0F05"
 msgid "I don't care if you aren't a Titan! Ahhhhhhh... ohhh..."
-msgstr "我不管你是不是巨人了!啊。"
+msgstr "我才不管你是不是巨人了!啊……哦……"
 
 #. Key:	13F822424D7968B826D8E79C10C52DBC
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03_R02_R01.Default__FernDefault03_R02_R01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03_R02_R01.Default__FernDefault03_R02_R01_C.SessionData.Lines(1).Lines
 msgctxt ",13F822424D7968B826D8E79C10C52DBC"
 msgid "But we can make love now! Let's do that. Maybe something magical will happen."
-msgstr "但我们可以做爱！现在就来吧！没准会有什么奇妙的事情发生"
+msgstr "但我们可以做爱！现在就开始嘛！没准会有什么奇妙的事情发生。"
 
 #. Key:	14065F34477043D39DE5A2A95756167D
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowSpiders.Default__WidowSpiders_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Widow/Default/WidowSpiders.Default__WidowSpiders_C.SessionData.Lines(5).Lines
 msgctxt ",14065F34477043D39DE5A2A95756167D"
 msgid "Or a human in my case... a truly rare event. One tasty morsel I would never pass up."
-msgstr ""
+msgstr "以我为例，人类……是一个稀客。是一口我永远不会错过的美味。"
 
 #. Key:	14597A3447ACFD81E4E72CB43D419E39
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_R01.Default__FernDefault02_R01_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02_R01.Default__FernDefault02_R01_C.SessionData.Lines(4).Lines
 msgctxt ",14597A3447ACFD81E4E72CB43D419E39"
 msgid "If I have to spend the rest of eternity in one spot, I wouldn't want it to be with anyone else..."
-msgstr "如果我非得在一个地方度过余生，我只求与您相伴"
+msgstr "如果我非得在一个地方度过余生，我只求与您相随…"
 
 #. Key:	146C8ABB4CFE56E192BE198657474339
 #. SourceLocation:	/Game/Dialogue/Blossom/Default/BlossomDefault01_R01.Default__BlossomDefault01_R01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Blossom/Default/BlossomDefault01_R01.Default__BlossomDefault01_R01_C.SessionData.Lines(0).Lines
 msgctxt ",146C8ABB4CFE56E192BE198657474339"
 msgid "You are... the one that pleasured Fern mother."
-msgstr "你是…我的妈妈！"
+msgstr "你是。。。让小蕨妈妈高兴的那个。"
 
 #. Key:	1494AA5040692D75A2E458AE890541FA
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_FloatRhyme.Default__ParvatiDefault01_FloatRhyme_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_FloatRhyme.Default__ParvatiDefault01_FloatRhyme_C.SessionData.Lines(3).Lines
 msgctxt ",1494AA5040692D75A2E458AE890541FA"
 msgid "Allow me to show you what She shared, if I may."
-msgstr "请允许我向你展示她所分享的东西"
+msgstr "如果可以的话，请允许我给你看看她分享了什么"
 
 #. Key:	1495FB154E5C773C51452295CAF9F467
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R02.Default__FaleneDefault01_R02_C.SessionData.Lines(10).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R02.Default__FaleneDefault01_R02_C.SessionData.Lines(10).Lines
 msgctxt ",1495FB154E5C773C51452295CAF9F467"
 msgid "We are so happy when humans love us and fill our desires, and we will reward you."
-msgstr "当人类爱我们并满足我们的欲望的时候我们会非常的幸福，我们会奖励你。"
+msgstr "当人类爱我们并满足我们的欲望的时候我们会非常的幸福，我们会回报你。"
 
 #. Key:	14E2045C4451D2597C51F4AAF56AE3B7
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_Teach.Default__ParvatiDefault01_Teach_C.SessionData.LinesToFuta(0).LinesToFuta
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_Teach.Default__ParvatiDefault01_Teach_C.SessionData.LinesToFuta(0).LinesToFuta
 msgctxt ",14E2045C4451D2597C51F4AAF56AE3B7"
 msgid "Remove your garments, for you must be nude."
-msgstr "脱掉你的衣服，因为你必须要裸体"
+msgstr "脱掉你的衣服，因为你必须要赤忱相见。"
 
 #. Key:	14F5C7E34772BFD4F5E7039EF72ACF9E
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaGreeting01.Default__NeelaGreeting01_C.SessionData.Lines(1).Lines
@@ -1110,21 +1110,21 @@ msgstr "穿过漫漫岁月长河和无尽的游行，我从未想过我的命途
 #: /Game/Dialogue/Fesssi/Default/FesssiCave.Default__FesssiCave_C.SessionData.Lines(5).Lines
 msgctxt ",1558B86B4DAABB7D51D53FB9D3508EBD"
 msgid "The surface is boring and full of self-righteous angels and simpletons. Hiss!"
-msgstr ""
+msgstr "地表是无聊而且充满了自以为是的天使和傻瓜。嘶！"
 
 #. Key:	158D44FA46C00C7898EF1C99A9A99EA7
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_Leylanna.Default__EmissaryDefault01_Leylanna_C.SessionData.Lines(7).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_Leylanna.Default__EmissaryDefault01_Leylanna_C.SessionData.Lines(7).Lines
 msgctxt ",158D44FA46C00C7898EF1C99A9A99EA7"
 msgid "Claiming \"the spirits told me to make love with the golden angel\" or something similar."
-msgstr "声称/灵魂告诉我要与金色的天使或者类似的东西做爱"
+msgstr "声称'鬼魂让我和金色天使做爱'或类似的话"
 
 #. Key:	15C00C874838EB1710DECF9C8F9A8AB0
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraGreeting01.Default__PetraGreeting01_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Petra/Default/PetraGreeting01.Default__PetraGreeting01_C.SessionData.Lines(2).Lines
 msgctxt ",15C00C874838EB1710DECF9C8F9A8AB0"
 msgid "Her name is Pawsmaati, she is not far from here. You should seek her wisdom."
-msgstr ""
+msgstr "她的名字叫帕丝玛媞，离这儿不远。你应该寻求她的智慧。"
 
 #. Key:	16049E004B001A3FEF8E25BEBE498398
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_RL.Default__ParvatiDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
@@ -1145,14 +1145,14 @@ msgstr "那我现在就要出发去捕捉魔弗灵啦。"
 #: /Game/Dialogue/Fesssi/Default/FesssiAreYouOk.Default__FesssiAreYouOk_C.SessionData.Lines(2).Lines
 msgctxt ",16513C5A4632BB961094E887464CD1B1"
 msgid "Hiss!"
-msgstr ""
+msgstr "嘶！"
 
 #. Key:	169058BF4DE41C3E4D03D0ABE7BC7F77
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_FloatRhyme.Default__ParvatiDefault01_FloatRhyme_C.SessionData.Lines(8).Lines
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_FloatRhyme.Default__ParvatiDefault01_FloatRhyme_C.SessionData.Lines(8).Lines
 msgctxt ",169058BF4DE41C3E4D03D0ABE7BC7F77"
 msgid "We can make love, for it is lonely at times."
-msgstr "我们可以做爱！我总是很孤独"
+msgstr "我们可以做爱啦，因为我总是感觉很孤单。"
 
 #. Key:	16E336BD48B5FD77EAAE96BC1BAAF7D4
 #. SourceLocation:	/Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToMale(2).LinesToMale
@@ -1166,14 +1166,14 @@ msgstr "我不管你是不是巨人了!啊。"
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeHowLong.Default__MegaSlimeHowLong_C.SessionData.Lines(2).Lines
 msgctxt ",16EC466F4A9673C3FA08CF9ED0AD4534"
 msgid "Until now! These last few days have been the happiest of my life."
-msgstr ""
+msgstr "直到现在！这几天是我一生中最快乐的日子。"
 
 #. Key:	17088A3C40A455B65AC29F8824A40BA1
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadDefault01_RL.Default__DryadDefault01_RL_C.ResponseData(6).ResponseData.BreederPrompt
 #: /Game/Dialogue/Autumn/Default/DryadDefault01_RL.Default__DryadDefault01_RL_C.ResponseData(6).ResponseData.BreederPrompt
 msgctxt ",17088A3C40A455B65AC29F8824A40BA1"
 msgid "Can you make flowers grow in the Hivelands?"
-msgstr ""
+msgstr "你可以让鲜花在蜂巢大地长出来吗？"
 
 #. Key:	170B9C2D49AD3C9EDFB2F98BB3947924
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(13).LinesToMale
@@ -1187,56 +1187,56 @@ msgstr "我的蜜穴在不停嚅嗫着..."
 #: /Game/Dialogue/Fesssi/Default/FesssiHowLong.Default__FesssiHowLong_C.SessionData.Lines(6).Lines
 msgctxt ",17607CE74517243E14D7458209F5B954"
 msgid "Actually that wouldn't be useful now that I think about it, but anyway where was I..."
-msgstr ""
+msgstr "实际上我现在想起来那没什么用，但不管怎么说，我说到哪儿了……"
 
 #. Key:	176F7A314E26B5F6293327AB991F4EAA
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcAkabekoCheck.Default__OrcAkabekoCheck_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcAkabekoCheck.Default__OrcAkabekoCheck_C.SessionData.Lines(0).Lines
 msgctxt ",176F7A314E26B5F6293327AB991F4EAA"
 msgid "*Snarl* Glorious!"
-msgstr ""
+msgstr "*咆哮*荣耀！"
 
 #. Key:	17A76DB943E2CB6F9ACC2A823244D892
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMMuchEnergy.Default__DMMuchEnergy_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/DragonMatriarch/Default/DMMuchEnergy.Default__DMMuchEnergy_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",17A76DB943E2CB6F9ACC2A823244D892"
 msgid "Now I want to mate! I've been slumbering for many days, and I am extremely horny."
-msgstr ""
+msgstr "现在我要开动了！我已经休眠了好些日子了，我现在极其饥渴。"
 
 #. Key:	17D6A70C4116B743F6CB26ADEB18DFD0
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeHadSex01.Default__MegaSlimeHadSex01_C.SessionData.LinesToFuta(2).LinesToFuta
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeHadSex01.Default__MegaSlimeHadSex01_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",17D6A70C4116B743F6CB26ADEB18DFD0"
 msgid "It's been so long since I have tasted warm cum."
-msgstr ""
+msgstr "已经好久没有尝到温热的一发了。"
 
 #. Key:	186FDC7F49586189532EC29D0F8296D3
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMDefault_RL3.Default__DMDefault_RL3_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/DragonMatriarch/Default/DMDefault_RL3.Default__DMDefault_RL3_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",186FDC7F49586189532EC29D0F8296D3"
 msgid "It's presently grasslands and trees..."
-msgstr ""
+msgstr "眼下，草地和树木…"
 
 #. Key:	18CAD01243ECA034DDADA1A0880C715D
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_Forgot.Default__ParvatiDefault01_Forgot_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_Forgot.Default__ParvatiDefault01_Forgot_C.SessionData.Lines(2).Lines
 msgctxt ",18CAD01243ECA034DDADA1A0880C715D"
 msgid "You are in the presence of Pawsmaati, and I am kind."
-msgstr ""
+msgstr "你在伟大的帕丝玛媞面前，我很慈祥。"
 
 #. Key:	18D7599649118CDCF2E1C78FFB34E034
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_ChangeSpiritForm.Default__LeylannaDefault01_ChangeSpiritForm_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Leylanna/Default/LeylannaDefault01_ChangeSpiritForm.Default__LeylannaDefault01_ChangeSpiritForm_C.SessionData.Lines(0).Lines
 msgctxt ",18D7599649118CDCF2E1C78FFB34E034"
 msgid "Through me you may commune with the spirits and change your form."
-msgstr "通过我你就能与魂灵沟通交融，并以此来改变你的魂灵形态。"
+msgstr "借用我的力量就能让你和灵魂产生共情，并以此来改变你的魂灵形态。"
 
 #. Key:	18F557C243E97F6A690B608405D897DF
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R01.Default__FaleneDefault01_R01_C.SessionData.Lines(10).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R01.Default__FaleneDefault01_R01_C.SessionData.Lines(10).Lines
 msgctxt ",18F557C243E97F6A690B608405D897DF"
 msgid "It's a fact that @MONSTER_RACE@ semen is a powerful substance--just applying it to your skin has all sorts of effects."
-msgstr "事实上，魔弗灵的精子是一种强大的物质——仅仅是被皮肤吸收它都会有各种各样的效果。"
+msgstr "事实上，魔弗灵的精子是一种强大的物质——仅仅是擦在你的皮肤上会有各种各样的效果。"
 
 #. Key:	193B4CF045056BF6C0B7E0AF2A4A65FF
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(23 - Value).TraitIcons.HelpText
@@ -1257,91 +1257,91 @@ msgstr "能有和人类交配的机会，简直让我所有的心脏都怦怦直
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeSad_RL2.Default__MegaSlimeSad_RL2_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",195D4E38448666E82EA5BEA6A446E98A"
 msgid "What have I done..."
-msgstr ""
+msgstr "我都做了些什么……"
 
 #. Key:	19A2E9D044587CE3E0AC5B8D366B6974
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeDefault01.Default__AmberMaeDefault01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeDefault01.Default__AmberMaeDefault01_C.SessionData.Lines(0).Lines
 msgctxt ",19A2E9D044587CE3E0AC5B8D366B6974"
 msgid "Have ye come back to feel 'mai jugs?"
-msgstr "尼是回来来感受俺的大咪咪的吗？"
+msgstr "尼是肥莱感受俺的大咪咪的吗？"
 
 #. Key:	19AB0BB8417E1310F35D1D922EF9CFD5
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadFatAssLamia.Default__DryadFatAssLamia_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Autumn/Default/DryadFatAssLamia.Default__DryadFatAssLamia_C.SessionData.Lines(5).Lines
 msgctxt ",19AB0BB8417E1310F35D1D922EF9CFD5"
 msgid "My fruit was all I had to give, and she loved it. So much in fact, she let me have full access to her body in return."
-msgstr ""
+msgstr "我只能给她水果，她爱的无法自拔。作为回报，她允许我交融她的身体。"
 
 #. Key:	19C50B51465308E41B608B8EAE206DA7
 #. SourceLocation:	/Game/Dialogue/Neela/SexScenes/NeelaSnakeCuddleT.Default__NeelaSnakeCuddleT_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Neela/SexScenes/NeelaSnakeCuddleT.Default__NeelaSnakeCuddleT_C.SessionData.Lines(5).Lines
 msgctxt ",19C50B51465308E41B608B8EAE206DA7"
 msgid "*Pleasurable Moaning*"
-msgstr "*满足的呻吟*"
+msgstr "*满足的娇喘*"
 
 #. Key:	1A04D48D493996FF8EDD59A9DDB7C1A6
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_R01.Default__FernDefault02_R01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02_R01.Default__FernDefault02_R01_C.SessionData.Lines(0).Lines
 msgctxt ",1A04D48D493996FF8EDD59A9DDB7C1A6"
 msgid "You are the lord of this soil--or owner of Homestead in the common tongue."
-msgstr "您是这片土地的主人，简单点说就是家园的主人"
+msgstr "您是这片土地的领主，换句话说您就是这片家园的主人。"
 
 #. Key:	1A36435A4EC979C7162B59A0A03846B6
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeDefault01.Default__BeeDefault01_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/QueenBee/Default/BeeDefault01.Default__BeeDefault01_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",1A36435A4EC979C7162B59A0A03846B6"
 msgid "Soon my nectar collection will be complete, and I can return to the Hivelands."
-msgstr ""
+msgstr "很快我的花蜜收集工作就要完成了，我可以回到蜂巢大地了。"
 
 #. Key:	1A66A5974B5893066D25B7A93AD8BA38
 #. SourceLocation:	/Game/Dialogue/AmberMae/SexScenes/AmberMilkyF.Default__AmberMilkyF_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/AmberMae/SexScenes/AmberMilkyF.Default__AmberMilkyF_C.SessionData.Lines(4).Lines
 msgctxt ",1A66A5974B5893066D25B7A93AD8BA38"
 msgid "Does it taste good?"
-msgstr "俺的奶美味吗？"
+msgstr "俺的奶尝起来吼喝吗？"
 
 #. Key:	1A7572BD4073E9E25BE3D1889A08E000
 #. SourceLocation:	/Game/Dialogue/Cassie/SexScenes/CassieButterButtF.Default__CassieButterButtF_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Cassie/SexScenes/CassieButterButtF.Default__CassieButterButtF_C.SessionData.Lines(2).Lines
 msgctxt ",1A7572BD4073E9E25BE3D1889A08E000"
 msgid "Experience my amazing butter stick human! Ahhhh..."
-msgstr "感受我的黄油棒吧人类！啊..."
+msgstr "感受我的黄油棒吧人类！噢..."
 
 #. Key:	1A7B16814705FD34BE5FF69AB7855D7B
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiGreeting01.Default__ParvatiGreeting01_C.SessionData.LinesToFuta(3).LinesToFuta
 #: /Game/Dialogue/Parvati/Default/ParvatiGreeting01.Default__ParvatiGreeting01_C.SessionData.LinesToFuta(3).LinesToFuta
 msgctxt ",1A7B16814705FD34BE5FF69AB7855D7B"
 msgid "You seek to learn a new way to use a pleasure hole."
-msgstr "来这里寻求一种新的开发方法"
+msgstr "你寻求至此希望学习一种新的方法来开发快感的蜜穴。"
 
 #. Key:	1AF544224BFAECD89C2CE99B8EE6EB2D
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_Formuria.Default__MirruDefault01_Formuria_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_Formuria.Default__MirruDefault01_Formuria_C.SessionData.Lines(4).Lines
 msgctxt ",1AF544224BFAECD89C2CE99B8EE6EB2D"
 msgid "It is custom for future queens to make pilgrimage to the dry lands and..."
-msgstr "将要继位的女王有着登上旱地朝圣的传统习俗，而且…"
+msgstr "将要继位的女王有着去旱地朝圣的传统习俗，而且…"
 
 #. Key:	1B5A3D3E4B34533CC5E7E599C01B1A38
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(30).LinesToFemale
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(30).LinesToFemale
 msgctxt ",1B5A3D3E4B34533CC5E7E599C01B1A38"
 msgid "If you want to learn about how to catch @MONSTER_RACE@, head to the town located up the plateau ahead and speak to my assistant Camilla. You can't miss her... actually wait you might, she's so tiny and cute hehehe."
-msgstr "如果你想学习如何抓住魔弗灵，从前面那条小路往上走到高处的小镇，去问问我的助手Camilla。你可千万不能错过她……事实上她有可能也在等你，她是那么娇小可爱…嘿嘿嘿……"
+msgstr "如果你想学习如何抓住魔弗灵，从前面那条小路往上走到高处的小镇，去问问我的助手卡米拉。你不会错过她的……事实上她有可能也在等你，她是那么娇小可爱…嘿嘿嘿……"
 
 #. Key:	1B9EA938413881EEDE041F85884A4BC3
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_RL.Default__FaleneDefault01_RL_C.ResponseData(8).ResponseData.BreederPrompt
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_RL.Default__FaleneDefault01_RL_C.ResponseData(8).ResponseData.BreederPrompt
 msgctxt ",1B9EA938413881EEDE041F85884A4BC3"
 msgid "How do I learn sex positions?"
-msgstr "我该如何学习新的性姿势呢？"
+msgstr "我该如何学习新的体位呢？"
 
 #. Key:	1BC964AA48FF5DA907B29295607F513D
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeHadSex01.Default__BeeHadSex01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/QueenBee/Default/BeeHadSex01.Default__BeeHadSex01_C.SessionData.Lines(1).Lines
 msgctxt ",1BC964AA48FF5DA907B29295607F513D"
 msgid "Now... ahhh... ohhh..."
-msgstr ""
+msgstr "现在……哦……噢……"
 
 #. Key:	1BD44FF4429194137A0C4CAF227F2CA1
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_Teach.Default__ParvatiDefault01_Teach_C.SessionData.Lines(1).Lines
@@ -1362,98 +1362,98 @@ msgstr "那我现在就要出发去捕捉魔弗灵啦"
 #: /Game/Dialogue/Cassie/Default/CassieDungeon.Default__CassieDungeon_C.SessionData.Message
 msgctxt ",1BE4B0584A935AE797E21B89CFDDEBF9"
 msgid "A mechanism was repaired."
-msgstr ""
+msgstr "那个机械装置我修好了~"
 
 #. Key:	1C15952A4859910408BA90BF113F067B
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraTaskFulfilled.Default__PetraTaskFulfilled_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Petra/Default/PetraTaskFulfilled.Default__PetraTaskFulfilled_C.SessionData.Lines(3).Lines
 msgctxt ",1C15952A4859910408BA90BF113F067B"
 msgid "Maybe we can go for a threesome with my new succubus!!!"
-msgstr ""
+msgstr "也许我们可以和我的新魅魔去玩3P啦！！！"
 
 #. Key:	1C3E96114020C3F1D5514C998DF520B9
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeHadSex01.Default__MegaSlimeHadSex01_C.SessionData.LinesToFuta(4).LinesToFuta
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeHadSex01.Default__MegaSlimeHadSex01_C.SessionData.LinesToFuta(4).LinesToFuta
 msgctxt ",1C3E96114020C3F1D5514C998DF520B9"
 msgid "So much excitement for one day, getting sleepy."
-msgstr ""
+msgstr "今天也太兴奋了，都有一些困了。"
 
 #. Key:	1C71641945A1D7E57E40EEB16FB66E75
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMMuchEnergy.Default__DMMuchEnergy_C.SessionData.LinesToFemale(3).LinesToFemale
 #: /Game/Dialogue/DragonMatriarch/Default/DMMuchEnergy.Default__DMMuchEnergy_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",1C71641945A1D7E57E40EEB16FB66E75"
 msgid "The lucky Titan will not expect such a massive load!"
-msgstr ""
+msgstr "幸运的泰坦不会预料会是如此巨大的负荷！"
 
 #. Key:	1C771B6F4DD1FF210888A5BB37418D44
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMYourChildren.Default__DMYourChildren_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/DragonMatriarch/Default/DMYourChildren.Default__DMYourChildren_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",1C771B6F4DD1FF210888A5BB37418D44"
 msgid "Many of them, but like all wild ones, they frequently phase in and out of the Void."
-msgstr ""
+msgstr "他们中的许多人，但像所有的野生魔弗灵一样，经常出入虚空。"
 
 #. Key:	1C97795346C0DCFF24FCF7965DB04AFF
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R06.Default__FaleneDefault01_R06_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R06.Default__FaleneDefault01_R06_C.SessionData.Lines(2).Lines
 msgctxt ",1C97795346C0DCFF24FCF7965DB04AFF"
 msgid "They then mated with the natural creatures of the world. Yeah... the first thing the servants of heaven did was bang everything in sight."
-msgstr "然后他们与所有的自然生物交配.是的...天堂的侍者来到人间做的第一件事就是和所有在视野范围内的东西啪啪啪"
+msgstr "然后他们与世界上的自然生物交配。是啊……天堂的使者来到人间做的第一件事就是啪翻一切可以看到的东西。"
 
 #. Key:	1C9CDC1147105A3D3F0A43BB6C94695C
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_RechargeSpiritForm.Default__LeylannaDefault01_RechargeSpiritForm_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Leylanna/Default/LeylannaDefault01_RechargeSpiritForm.Default__LeylannaDefault01_RechargeSpiritForm_C.SessionData.Lines(2).Lines
 msgctxt ",1C9CDC1147105A3D3F0A43BB6C94695C"
 msgid "Alternatively, you can recharge your spirit form partially by engaging in sex with blessed ones."
-msgstr "又或是，只能找些收庇佑之众来来堪堪一爱，以此为你的魂灵形态补充能量。"
+msgstr "或者，你也可以通过与受祝福的魔弗灵啪啪啪来部分补充你的灵魂能量。"
 
 #. Key:	1CB51DBE4D43642F605E479B59AC73A0
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.EM_HedonDungeonSwitch.Message
 #: /Game/World/Overworld.Overworld:PersistentLevel.EM_HedonDungeonSwitch.Message
 msgctxt ",1CB51DBE4D43642F605E479B59AC73A0"
 msgid "A mechanism was activated."
-msgstr ""
+msgstr "一个机器装置被激活了。"
 
 #. Key:	1CCC14A74CE9A9AC038704B5BCC41068
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(7).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(7).Lines
 msgctxt ",1CCC14A74CE9A9AC038704B5BCC41068"
 msgid "Pleased with this, the Goddess created worlds for Her creations to reside in."
-msgstr ""
+msgstr "很荣幸，女神为了她所创造的一切而创造了庇佑之所"
 
 #. Key:	1CE3D3C14381A71E21FE5C9262A5AB20
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadAboutDryads.Default__DryadAboutDryads_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Autumn/Default/DryadAboutDryads.Default__DryadAboutDryads_C.SessionData.Lines(0).Lines
 msgctxt ",1CE3D3C14381A71E21FE5C9262A5AB20"
 msgid "Once every 1200 years, the Tree of Bliss will produce a fruit."
-msgstr ""
+msgstr "每隔1200年，极乐之树就会结出一颗果实"
 
 #. Key:	1CF80140486F2A7F4E727D8E50B64B37
 #. SourceLocation:	/Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToFemale(7).LinesToFemale
 #: /Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToFemale(7).LinesToFemale
 msgctxt ",1CF80140486F2A7F4E727D8E50B64B37"
 msgid "*Lick* *Lick*"
-msgstr "*吮吸*"
+msgstr "*舔**舔*"
 
 #. Key:	1D02B0E54A3658E393B6FFB20782E4EC
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiWantTongue.Default__FesssiWantTongue_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiWantTongue.Default__FesssiWantTongue_C.SessionData.Lines(2).Lines
 msgctxt ",1D02B0E54A3658E393B6FFB20782E4EC"
 msgid "Come closer, this is going make you feel sssso good!"
-msgstr ""
+msgstr "靠近点，这会让你爽翻的！"
 
 #. Key:	1D0542A344504517417F3A8F68348BA3
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowTaskFulfilled.Default__WidowTaskFulfilled_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Widow/Default/WidowTaskFulfilled.Default__WidowTaskFulfilled_C.SessionData.Lines(0).Lines
 msgctxt ",1D0542A344504517417F3A8F68348BA3"
 msgid "Oh my sweet little elf... I will cherish you forever."
-msgstr ""
+msgstr "哦，我可爱的精灵……我会永远珍惜你的。"
 
 #. Key:	1D0919E245DEEDE87FD63C8852480108
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault02.Default__CamillaDefault02_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaDefault02.Default__CamillaDefault02_C.SessionData.Lines(1).Lines
 msgctxt ",1D0919E245DEEDE87FD63C8852480108"
 msgid "I wonder what she brought me this time."
-msgstr ""
+msgstr "我很好奇这次她给我带了什么。"
 
 #. Key:	1D44F1774A53A6682BEE0BB2C13C2732
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDefault01.Default__CassieDefault01_C.SessionData.Lines(0).Lines
@@ -1467,28 +1467,28 @@ msgstr "喵呜！"
 #: /Game/Dialogue/Falene/Default/FaleneDefault01.Default__FaleneDefault01_C.SessionData.Lines(1).Lines
 msgctxt ",1D53B4634A50A322CFC243AF9F5C48DC"
 msgid "My tiny little adorable assistant Camilla can help you as well."
-msgstr "我娇小可爱的小助手Camilla也会帮你的。"
+msgstr "我娇小可爱的小助手卡米拉也会帮你的。"
 
 #. Key:	1D5D92BD4B78C422411CC1AB0BD34552
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadFatAssLamia.Default__DryadFatAssLamia_C.SessionData.Lines(8).Lines
 #: /Game/Dialogue/Autumn/Default/DryadFatAssLamia.Default__DryadFatAssLamia_C.SessionData.Lines(8).Lines
 msgctxt ",1D5D92BD4B78C422411CC1AB0BD34552"
 msgid "Poor Fesssi is probably running low on bosom cherries by now!"
-msgstr ""
+msgstr "可怜的费西现在可能已经吃不到乳房樱桃了！"
 
 #. Key:	1D81ECE4468C6B5A5BE467964A7CFE43
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03_R02_R01.Default__FernDefault03_R02_R01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03_R02_R01.Default__FernDefault03_R02_R01_C.SessionData.Lines(0).Lines
 msgctxt ",1D81ECE4468C6B5A5BE467964A7CFE43"
 msgid "Sadly I can no longer help you harvest fluids from wild @MONSTER_RACE@."
-msgstr "对不起，我已经不能替您去收获魔弗灵的体液了"
+msgstr "很抱歉的是，我已经不能替主人您去收获魔弗灵的体液了"
 
 #. Key:	1D9FC9EA4EBB827C25C418BF316240BB
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleDragonMatriarch.Default__KybeleDragonMatriarch_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Kybele/Default/KybeleDragonMatriarch.Default__KybeleDragonMatriarch_C.SessionData.Lines(4).Lines
 msgctxt ",1D9FC9EA4EBB827C25C418BF316240BB"
 msgid "This lust is driving me mad human! You have no idea."
-msgstr ""
+msgstr "这欲望把我逼疯了！你不会懂这种感觉的，人类！。"
 
 #. Key:	1DA742CA40AC6A3A7EC5B6834EEA93B8
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_AboutMusic.Default__RomyDefault01_AboutMusic_C.SessionData.Lines(2).Lines
@@ -1502,35 +1502,35 @@ msgstr "美人鱼则是独特的深海族人，我们可以听到大部分魔弗
 #: /Game/Dialogue/AmberMae/Default/AmberMaeHadSex01.Default__AmberMaeHadSex01_C.SessionData.Lines(0).Lines
 msgctxt ",1DB7FBDD4A80D06FCF9019965B0E0008"
 msgid "Ye drank so much for a wee lass!"
-msgstr ""
+msgstr "为了一个小姑娘你居然喝了那么多！"
 
 #. Key:	1E0C491A43E8C2F67FA568B20B5A6743
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_Teach.Default__ParvatiDefault01_Teach_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_Teach.Default__ParvatiDefault01_Teach_C.SessionData.Lines(5).Lines
 msgctxt ",1E0C491A43E8C2F67FA568B20B5A6743"
 msgid "Pay close attention to my form, and learn you should."
-msgstr "注意我的姿势，学着点"
+msgstr "注意我的姿势，学着点。"
 
 #. Key:	1E23F2524EB7DC68DC07EC92E709C65F
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernGreeting03.Default__FernGreeting03_C.SessionData.LinesToFuta(4).LinesToFuta
 #: /Game/Dialogue/Fern/DefaultP3/FernGreeting03.Default__FernGreeting03_C.SessionData.LinesToFuta(4).LinesToFuta
 msgctxt ",1E23F2524EB7DC68DC07EC92E709C65F"
 msgid "Slide yourself in here with me, my body is silky and filled with sweet nectar. I will make you feel so good..."
-msgstr ""
+msgstr "滑入我充满了花蜜，犹如丝绸般柔软的身体吧，我会让您好好享受的…"
 
 #. Key:	1E2A2FC04EF0D4BCC92A3A911348230A
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeVerySad.Default__MegaSlimeVerySad_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeVerySad.Default__MegaSlimeVerySad_C.SessionData.Lines(4).Lines
 msgctxt ",1E2A2FC04EF0D4BCC92A3A911348230A"
 msgid "I thought... finally... I would have friends again..."
-msgstr ""
+msgstr "我以为。。。终于。。。我又交到朋友了。。。"
 
 #. Key:	1E3AD95641E1D41AAA9115A007EDC28A
 #. SourceLocation:	/Game/Dialogue/Cassie/SexScenes/CassieSplintersT.Default__CassieSplintersT_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Cassie/SexScenes/CassieSplintersT.Default__CassieSplintersT_C.SessionData.Lines(2).Lines
 msgctxt ",1E3AD95641E1D41AAA9115A007EDC28A"
 msgid "So much pleasure! Ahhh..."
-msgstr "太爽了！啊啊…"
+msgstr "不断冲击的快感！啊啊…"
 
 #. Key:	1E80A3A048E90BE3C26622BC4F2230F7
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryGreeting01.Default__EmissaryGreeting01_C.SessionData.Lines(5).Lines
@@ -1551,42 +1551,42 @@ msgstr "你能为我做什么？"
 #: /Game/Dialogue/Cassie/Default/CassieHadSex01.Default__CassieHadSex01_C.SessionData.LinesToFemale(5).LinesToFemale
 msgctxt ",1EB41EAD40088E3874A4E0A7F3C437DC"
 msgid "I need to release again already... you humans have it so easy."
-msgstr ""
+msgstr "我想要再高潮一次…你们人类很轻松就能让我高潮了。"
 
 #. Key:	1EB7986D40F6A7B90EB5ADB781104A11
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_RL.Default__LeylannaDefault01_RL_C.ResponseData(6).ResponseData.BreederPrompt
 #: /Game/Dialogue/Leylanna/Default/LeylannaDefault01_RL.Default__LeylannaDefault01_RL_C.ResponseData(6).ResponseData.BreederPrompt
 msgctxt ",1EB7986D40F6A7B90EB5ADB781104A11"
 msgid "How do I access the area under the temple?"
-msgstr ""
+msgstr "我怎么进入寺庙下面的区域？"
 
 #. Key:	1EBEB6D94E78F0B72A365EAD5BD52461
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeHadSex01.Default__MegaSlimeHadSex01_C.SessionData.LinesToFuta(5).LinesToFuta
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeHadSex01.Default__MegaSlimeHadSex01_C.SessionData.LinesToFuta(5).LinesToFuta
 msgctxt ",1EBEB6D94E78F0B72A365EAD5BD52461"
 msgid "*Yawn*"
-msgstr ""
+msgstr "*打哈欠*"
 
 #. Key:	1EC1BDF8474319018DE2CBA3602448F1
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryBlessedInquiry01_R01.Default__EmissaryBlessedInquiry01_R01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryBlessedInquiry01_R01.Default__EmissaryBlessedInquiry01_R01_C.SessionData.Lines(1).Lines
 msgctxt ",1EC1BDF8474319018DE2CBA3602448F1"
 msgid "I have overcome all desire and emotion. Such is a requirement to become an archangel of the Goddess, for she wants nothing to distract me from my task."
-msgstr "吾能克服所有的欲念与情感。这是身为至高女神的大天使的本职，这亦是祂要求吾除完成吾之职责外再无杂念。"
+msgstr "吾能克服所有的欲念与情感。这是身为至高女神的大天使的本职，这亦是祂要求吾完成吾之职责外再无杂念。"
 
 #. Key:	1EC307F7473EF201F5433B8DCF40B401
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeTaskFulfilled.Default__BeeTaskFulfilled_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/QueenBee/Default/BeeTaskFulfilled.Default__BeeTaskFulfilled_C.SessionData.Lines(1).Lines
 msgctxt ",1EC307F7473EF201F5433B8DCF40B401"
 msgid "My girls are already hard at work harvesting them."
-msgstr ""
+msgstr "我的女孩们已经在努力的采集它们了"
 
 #. Key:	1EC6ED68400A0EEDE25F8BA9CAB37F8E
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchHaveKeystone2.Default__MonarchHaveKeystone2_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Monarch/Default/MonarchHaveKeystone2.Default__MonarchHaveKeystone2_C.SessionData.Lines(2).Lines
 msgctxt ",1EC6ED68400A0EEDE25F8BA9CAB37F8E"
 msgid "T-t-thank you human!"
-msgstr ""
+msgstr "太-太感-太感谢你了人类！"
 
 #. Key:	1EDF51EB413B2D360FB8C6B5AD2E62ED
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_Forgot_RL.Default__ParvatiDefault01_Forgot_RL_C.ResponseData(1).ResponseData.BreederPrompt
@@ -1600,63 +1600,63 @@ msgstr "蝴蝶式！"
 #: /Game/World/Events/EM_Keystone.Default__EM_Keystone_C.ActivateMessage
 msgctxt ",1F1CAEA0490338B83DFFE19139FBE3C2"
 msgid "Take Keystone"
-msgstr ""
+msgstr "拿上钥石"
 
 #. Key:	1F2830D14059782BF943B5BD1F8A5942
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleTaskFulfilled.Default__KybeleTaskFulfilled_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/Kybele/Default/KybeleTaskFulfilled.Default__KybeleTaskFulfilled_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",1F2830D14059782BF943B5BD1F8A5942"
 msgid "Ah such a glorious mate you have given me!"
-msgstr ""
+msgstr "啊，你给了我充满荣耀的伴侣！"
 
 #. Key:	1F39C5E04BCD3150F989F3994E948682
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeHaveKeystone.Default__BeeHaveKeystone_C.SessionData.Lines(7).Lines
 #: /Game/Dialogue/QueenBee/Default/BeeHaveKeystone.Default__BeeHaveKeystone_C.SessionData.Lines(7).Lines
 msgctxt ",1F39C5E04BCD3150F989F3994E948682"
 msgid "We shall continue to wait for our savior. Someone who is one with the soil itself, a true maiden of nature."
-msgstr ""
+msgstr "我们将继续等待我们的救世主。一个与土壤融为一体的人，一个真正的大自然处子。"
 
 #. Key:	1F41165A452FBA12C2CF81A71C1DE5AC
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadFatAssLamia.Default__DryadFatAssLamia_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Autumn/Default/DryadFatAssLamia.Default__DryadFatAssLamia_C.SessionData.Lines(1).Lines
 msgctxt ",1F41165A452FBA12C2CF81A71C1DE5AC"
 msgid "I wandered into that cave at the far end of the pastures, and that's where I met her."
-msgstr ""
+msgstr "我漫步到牧场尽头的那个山洞里，在那里遇见了她。"
 
 #. Key:	1FA8B3E8448F66CB1045EAB3F54ADE2B
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDefault01_Meow.Default__CassieDefault01_Meow_C.SessionData.LinesToFemale(5).LinesToFemale
 #: /Game/Dialogue/Cassie/Default/CassieDefault01_Meow.Default__CassieDefault01_Meow_C.SessionData.LinesToFemale(5).LinesToFemale
 msgctxt ",1FA8B3E8448F66CB1045EAB3F54ADE2B"
 msgid "Would you... meow... help poor Cassie with this problem?"
-msgstr "你会...喵呜...帮助可怜的凯希解决这个问题吗？"
+msgstr "你会...喵呜...帮助可怜的凯茜解决这个问题吗？"
 
 #. Key:	1FC53FEF4A2414ADEC40FA84C1B8848D
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(16 - Value).TraitIcons.HelpText
 #: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(16 - Value).TraitIcons.HelpText
 msgctxt ",1FC53FEF4A2414ADEC40FA84C1B8848D"
 msgid "Kindhearted: Grants twice as much XP to mates but only receives half as much."
-msgstr "热心肠：自身获得经验减半，但是配种对象获得经验翻倍"
+msgstr "善良的：给予同伴两倍的经验值，但自身只得到一半的经验值。"
 
 #. Key:	1FEA2992437543C7A8B378B9046E4AE5
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieHadSex01.Default__CassieHadSex01_C.SessionData.LinesToFemale(2).LinesToFemale
 #: /Game/Dialogue/Cassie/Default/CassieHadSex01.Default__CassieHadSex01_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",1FEA2992437543C7A8B378B9046E4AE5"
 msgid "Such sweet release for Cassie!"
-msgstr ""
+msgstr "对凯茜来说是如此甜蜜的喷射！"
 
 #. Key:	20149E5046FF32B65667FBA243C9BED4
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_HowToSpiritForm.Default__LeylannaDefault01_HowToSpiritForm_C.SessionData.LinesToFemale(2).LinesToFemale
 #: /Game/Dialogue/Leylanna/Default/LeylannaDefault01_HowToSpiritForm.Default__LeylannaDefault01_HowToSpiritForm_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",20149E5046FF32B65667FBA243C9BED4"
 msgid "Catch a female Foxen if you have not done so, and then return to me. We will then make love and form a covenant."
-msgstr "如果你还没有抓过雌性狐灵，去抓一只。然后回来找我，我们会颠鸾倒凤一场并以此为你的魂灵形态定下盟约。"
+msgstr "如果你还没有抓过雌性狐灵，去抓一只。然后回来找我，我们会颠鸾倒凤一场并以此为你的魂灵形态定下契约。"
 
 #. Key:	201B358D4CE5E4D894910C97F98AA433
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_EnlightenedOne.Default__NeelaDefault01_EnlightenedOne_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_EnlightenedOne.Default__NeelaDefault01_EnlightenedOne_C.SessionData.Lines(5).Lines
 msgctxt ",201B358D4CE5E4D894910C97F98AA433"
 msgid "Keep this between us, but I think she is as old as the Great Conception itself."
-msgstr ""
+msgstr "让这个秘密只让我们俩知道，但我认为她和伟大的构想本身一样老。。"
 
 #. Key:	202CB97A40D83492E9EFE18430F24A11
 #. SourceLocation:	/Game/Ranch/Upgrades/VulwargKennel.Default__VulwargKennel_C.Upgrade.DisplayName
@@ -1691,14 +1691,14 @@ msgstr "测试5"
 #: /Game/Dialogue/OrcChief/Default/OrcTribeSucks.Default__OrcTribeSucks_C.SessionData.Lines(2).Lines
 msgctxt ",20D02E2F4C47F242698FA2B18D41F1BE"
 msgid "Need mighty fertile mates to make strong daughters."
-msgstr ""
+msgstr "需要强大的有生育能力的伴侣才能生出强壮的女儿们。"
 
 #. Key:	20D5FBB14DDFF45AA9B224862543CAFD
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadGreeting01.Default__DryadGreeting01_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Autumn/Default/DryadGreeting01.Default__DryadGreeting01_C.SessionData.Lines(3).Lines
 msgctxt ",20D5FBB14DDFF45AA9B224862543CAFD"
 msgid "Sweet and juicy... oh!"
-msgstr ""
+msgstr "甜蜜且多汁…噢！"
 
 #. Key:	20FEDBA24B5C623E162B85A3D6ACF514
 #. SourceLocation:	/Game/Ranch/Upgrades/StarfallenMonolith.Default__StarfallenMonolith_C.Upgrade.DisplayName
@@ -1712,14 +1712,14 @@ msgstr "星陨人丰碑"
 #: /Game/Dialogue/Blossom/Default/BlossomDefault01_R01.Default__BlossomDefault01_R01_C.SessionData.Lines(1).Lines
 msgctxt ",210B50F94F9FCF3416F33C880389C277"
 msgid "With Mastah's body fluid... mother made me. Still sapling... want fluidsss!"
-msgstr "有了主人的体液后…小蕨生下了我。但是我还小…我也想要主人的汁液！"
+msgstr "有了主银的体液后…妈妈生下了我。但是我还小…我也想要主人的汁液嘶嘶！"
 
 #. Key:	21152EB846587AFAAB8809931357BD5F
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowSpiders.Default__WidowSpiders_C.SessionData.Lines(7).Lines
 #: /Game/Dialogue/Widow/Default/WidowSpiders.Default__WidowSpiders_C.SessionData.Lines(7).Lines
 msgctxt ",21152EB846587AFAAB8809931357BD5F"
 msgid "Those sweet little magical creatures taste so good... even if they run dry too quickly."
-msgstr ""
+msgstr "那些可爱的小魔兽味道好极了。。。尽管他们太容易被榨干了。"
 
 #. Key:	2126F09F4B710631419B5DABA6528521
 #. SourceLocation:	/Game/Dialogue/Fern/SexScenes/FernMilk_01.Default__FernMilk_01_C.SessionData.Lines(5).Lines
@@ -1733,21 +1733,21 @@ msgstr "*吮吸 吮吸*"
 #: /Game/Dialogue/Fern/DefaultP3/FernHadSex03.Default__FernHadSex03_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",212DDF504562E903B436369721416CBC"
 msgid "This flower body is great, I hope you enjoyed it too master."
-msgstr ""
+msgstr "这个花一样的身体棒极了，我希望您也能享受，主人。"
 
 #. Key:	213C826F44FC31430F08EE8F97663F9A
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMGreeting01.Default__DMGreeting01_C.SessionData.Lines(6).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMGreeting01.Default__DMGreeting01_C.SessionData.Lines(6).Lines
 msgctxt ",213C826F44FC31430F08EE8F97663F9A"
 msgid "Go play with the wild dragons, I'm sure they would love to get to know you better."
-msgstr ""
+msgstr "去和野生的龙儿们玩吧，我相信他们会很乐意深入了解你的。"
 
 #. Key:	214776AF4C822D0B66293DB4BC1D955C
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiDefault03_RL_F.Default__FesssiDefault03_RL_F_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/Fesssi/Default/FesssiDefault03_RL_F.Default__FesssiDefault03_RL_F_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",214776AF4C822D0B66293DB4BC1D955C"
 msgid "How long have you been stuck?"
-msgstr ""
+msgstr "你卡在这儿多久了？"
 
 #. Key:	217058F6486D81B1085B329585491A13
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(14 - Value).TraitIcons.HelpText
@@ -1761,7 +1761,7 @@ msgstr "欲壑难填：交配时性欲消耗降低35%"
 #: /Game/Dialogue/DragonMatriarch/Default/DMGreeting01.Default__DMGreeting01_C.SessionData.Lines(2).Lines
 msgctxt ",219DB5F74ED7CB5AAC90FA94BF883682"
 msgid "How interesting... *yawn*"
-msgstr ""
+msgstr "真有趣…*打哈欠*"
 
 #. Key:	21A08FF347BC7DE708B258BAD0F4BEF3
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(22).LinesToMale
@@ -1782,49 +1782,49 @@ msgstr "反转女牛仔式"
 #: /Game/Dialogue/Leylanna/Default/LeylannaOldTempleDungeon1.Default__LeylannaOldTempleDungeon1_C.SessionData.Lines(2).Lines
 msgctxt ",21F3FE504159303A7B601594A76A9D1D"
 msgid "Have you come here to make love with me?"
-msgstr ""
+msgstr "你是来和我云雨一番的吗？"
 
 #. Key:	221EB3E64F8474A44715CA969A344204
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchHaveKeystone.Default__MonarchHaveKeystone_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Monarch/Default/MonarchHaveKeystone.Default__MonarchHaveKeystone_C.SessionData.Lines(3).Lines
 msgctxt ",221EB3E64F8474A44715CA969A344204"
 msgid "The wild @MONSTER_RACE@ around here are so big and s-s-strong."
-msgstr ""
+msgstr "这附近的魔弗灵又大只又强-强-强壮。"
 
 #. Key:	2232F66F4BB565CC2A75538123292067
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(19).LinesToMale
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(19).LinesToMale
 msgctxt ",2232F66F4BB565CC2A75538123292067"
 msgid "That makes your job a lot easier!"
-msgstr "这可会让你你的工作轻松很多！"
+msgstr "这可会让你的工作轻松很多！"
 
 #. Key:	2262A6F64B6CB59E0A4D93A13609ED6A
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFuta(1).LinesToFuta
 #: /Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFuta(1).LinesToFuta
 msgctxt ",2262A6F64B6CB59E0A4D93A13609ED6A"
 msgid "Human cum tastes just like I dreamt it would!"
-msgstr ""
+msgstr "人类的味道就像我梦到的那般美味！"
 
 #. Key:	226CAB5E40652DCF455036A02B7F0BEF
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyGreeting01.Default__RomyGreeting01_C.SessionData.LinesGrungy(3).LinesGrungy
 #: /Game/Dialogue/Romy/Default/RomyGreeting01.Default__RomyGreeting01_C.SessionData.LinesGrungy(3).LinesGrungy
 msgctxt ",226CAB5E40652DCF455036A02B7F0BEF"
 msgid "Human, look how dirty you have become. No, no, this won't do."
-msgstr "人类，看看你身上变得多脏。 不，不，这不好。"
+msgstr "人类，看看你身上变得多脏。 不，不，这不行。"
 
 #. Key:	22721E7243A0F89426773BB6C47E987A
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03_R02.Default__FernDefault03_R02_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03_R02.Default__FernDefault03_R02_C.SessionData.Lines(2).Lines
 msgctxt ",22721E7243A0F89426773BB6C47E987A"
 msgid "We can have a lot of fun with my flower body! I have wanted to make love with you Master..."
-msgstr "我们可以在我的花瓣中找不少乐子！我早就希望和主人做爱了"
+msgstr "我可以用我花一样的身体取悦您了，我一直想和您云雨，主人"
 
 #. Key:	22A642E14AB14A866F4A749782B623B0
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToFemale(3).LinesToFemale
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",22A642E14AB14A866F4A749782B623B0"
 msgid "Ahhh... yes. My desires are surging, won't you indulge in my body? I will try to be gentle."
-msgstr "啊哈…没错。我的欲望涌上来了。想用我的肉体放纵一回么？我会尽量温柔点的。"
+msgstr "啊哈…没错。我的欲望涌上来了。想在我的身体内驰骋放纵一下吗？我会尽量温柔点的。"
 
 #. Key:	22DBDC6341C9C5D8D427F0A18A87ED40
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.BovaurShed.ManageActionMessage
@@ -1838,7 +1838,7 @@ msgstr "管理你的奶牛人"
 #: /Game/Dialogue/Leylanna/Default/LeylannaOldTempleDungeon1.Default__LeylannaOldTempleDungeon1_C.SessionData.Lines(0).Lines
 msgctxt ",233ACAAA4B9A80E38B57579ACF78F5DF"
 msgid "Sooooo very high human."
-msgstr ""
+msgstr "啊啊啊……棒极了 人类。"
 
 #. Key:	2341F9304FDFA81B77486F840A0E749C
 #. SourceLocation:	/Game/Ranch/Upgrades/MuttHut.Default__MuttHut_C.Upgrade.Description
@@ -1859,91 +1859,91 @@ msgstr "这将允许你捕捉和存放所有的精灵族（包括史莱姆以及
 #: /Game/Dialogue/Fern/SexScenes/FernCum_01.Default__FernCum_01_C.SessionData.Lines(0).Lines
 msgctxt ",236BBFF14A62BA287C86179E8ACDDCA9"
 msgid "Mastah... your dick so big! Many fluids will it give me."
-msgstr "主人……嘶…你的屌好大！它应该会喷出来很多该我吃。"
+msgstr "主人……嘶…您的棒棒好大！它应该会喷出来给我很多吃的汁液。"
 
 #. Key:	2373050C45C9AA9783D038B170402B88
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_R02_R01.Default__FernDefault02_R02_R01_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02_R02_R01.Default__FernDefault02_R02_R01_C.SessionData.Lines(2).Lines
 msgctxt ",2373050C45C9AA9783D038B170402B88"
 msgid "You could... always keep giving me your fluids. I will reward you with intense pleasure and that shiny stuff you like so much."
-msgstr "如果主人用体液滋润滋润小蕨，小蕨会您一些亮晶晶！嘶嘶......!"
+msgstr "如果主人用体液滋润滋润小蕨，小蕨也会给您强烈的快感和一些小蕨收集的您喜欢的亮片！嘶嘶......!"
 
 #. Key:	239678F6481C22C297A01BAF6A94E397
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy_RL_T.Default__MirruDefault01_BodySexToy_RL_T_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy_RL_T.Default__MirruDefault01_BodySexToy_RL_T_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",239678F6481C22C297A01BAF6A94E397"
 msgid "I want to experience Kraken vagina..."
-msgstr "我想品尝下海妖族的小穴……"
+msgstr "我想品尝下海妖族的蜜穴……"
 
 #. Key:	23A18A464B463F98B66625813C8B1459
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiStuck.Default__FesssiStuck_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiStuck.Default__FesssiStuck_C.SessionData.Lines(3).Lines
 msgctxt ",23A18A464B463F98B66625813C8B1459"
 msgid "She should have known of the gluttony inherent within serpentssss."
-msgstr ""
+msgstr "她应该知道蛇的生性贪吃。"
 
 #. Key:	23BDA20D4CE368D882C153A4AF960F3B
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_Leylanna.Default__EmissaryDefault01_Leylanna_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_Leylanna.Default__EmissaryDefault01_Leylanna_C.SessionData.Lines(5).Lines
 msgctxt ",23BDA20D4CE368D882C153A4AF960F3B"
 msgid "It makes her act... quite strange."
-msgstr ""
+msgstr "这让她的行为。。。很奇怪。"
 
 #. Key:	23E7B88A464A51712A11B1A07FE361A3
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernGreeting02.Default__FernGreeting02_C.SessionData.LinesToFemale(2).LinesToFemale
 #: /Game/Dialogue/Fern/DefaultP2/FernGreeting02.Default__FernGreeting02_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",23E7B88A464A51712A11B1A07FE361A3"
 msgid "I am a growing Alraune, perhaps you have fluids to spare?"
-msgstr "我成长为成年的曼陀罗啦！主人看起来还没有被榨干？！"
+msgstr "我是正在成长的曼陀罗，也许主人您有可以赐予的体液？"
 
 #. Key:	23F2F9554DE5B355FC5887BC91313DC2
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcBrashDumb.Default__OrcBrashDumb_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcBrashDumb.Default__OrcBrashDumb_C.SessionData.Lines(3).Lines
 msgctxt ",23F2F9554DE5B355FC5887BC91313DC2"
 msgid "*Snarl*"
-msgstr ""
+msgstr "*咆哮*"
 
 #. Key:	240A4A634DB7018141BD60B5A94B716C
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeDefault01_Accent.Default__AmberMaeDefault01_Accent_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeDefault01_Accent.Default__AmberMaeDefault01_Accent_C.SessionData.Lines(0).Lines
 msgctxt ",240A4A634DB7018141BD60B5A94B716C"
 msgid "Oh no! Me hopes ye can understand."
-msgstr "噢别啊！希望尼能听懂俺讲话。"
+msgstr "噢别啊！西望尼能听懂俺的讲话。"
 
 #. Key:	240E4A09421F907A3C7714B84A5BF051
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiHowLong.Default__FesssiHowLong_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiHowLong.Default__FesssiHowLong_C.SessionData.Lines(1).Lines
 msgctxt ",240E4A09421F907A3C7714B84A5BF051"
 msgid "At first I was annoyed, but then it became fun... hiss!"
-msgstr ""
+msgstr "起初我很生气，但后来变得很有趣。。。嘶！"
 
 #. Key:	244693F347E948FB69765A8A6CFF9E08
 #. SourceLocation:	/Game/Dialogue/Fern/SexScenes/FernCum_01.Default__FernCum_01_C.SessionData.Lines(6).Lines
 #: /Game/Dialogue/Fern/SexScenes/FernCum_01.Default__FernCum_01_C.SessionData.Lines(6).Lines
 msgctxt ",244693F347E948FB69765A8A6CFF9E08"
 msgid "Ohhh... mastah... ahhh... taste your fluids please. Fern feels them coming..."
-msgstr "呃啊啊…主人…嘶嘶啊…我尝到了一些精液的味道，小蕨感觉要被精液浇透了哦……"
+msgstr "呃啊啊…主银…嘶嘶啊…请让小蕨尝尝您的体液吧。小蕨能感受到要被灌溉了"
 
 #. Key:	244C8E5D4982978D00C8C4AD305CB067
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcDefault03_RL.Default__OrcDefault03_RL_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/OrcChief/Default/OrcDefault03_RL.Default__OrcDefault03_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",244C8E5D4982978D00C8C4AD305CB067"
 msgid "I'm still not fixing your damn gate."
-msgstr ""
+msgstr "我还没修好你那该死的门。"
 
 #. Key:	245BCC9A45EB7B47E46534A6AE4EE9CF
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowDefault01.Default__WidowDefault01_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Widow/Default/WidowDefault01.Default__WidowDefault01_C.SessionData.Lines(3).Lines
 msgctxt ",245BCC9A45EB7B47E46534A6AE4EE9CF"
 msgid "In exchange for your fluids that is... oh how delicious you look."
-msgstr ""
+msgstr "为了交换你的体液……哦，哇哦，你知道有多美味吗！"
 
 #. Key:	24679A7147C3C737DE65DBA1F7CE9FAB
 #. SourceLocation:	/Game/Ranch/Upgrades/NekoCondo.Default__NekoCondo_C.Upgrade.DisplayName
 #: /Game/Ranch/Upgrades/NekoCondo.Default__NekoCondo_C.Upgrade.DisplayName
 msgctxt ",24679A7147C3C737DE65DBA1F7CE9FAB"
 msgid "Neko Condo"
-msgstr "猫娘公寓"
+msgstr "喵咪公寓"
 
 #. Key:	249E987842C35A9986491A967E86BEC3
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(21 - Value).TraitIcons.HelpText
@@ -1957,7 +1957,7 @@ msgstr "坚挺：增加性欲上限20%"
 #: /Game/Dialogue/Autumn/Default/DryadDefault01_RL.Default__DryadDefault01_RL_C.ResponseData(5).ResponseData.BreederPrompt
 msgctxt ",2501139743DDD3B68A226FB25573A87A"
 msgid "Yum... can I have the keystone now?"
-msgstr ""
+msgstr "呃……所以我现在可以拿到钥石了吗？"
 
 #. Key:	25085F2F407D8D979CA1B39E030426E5
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_RL.Default__LeylannaDefault01_RL_C.ResponseData(3).ResponseData.BreederPrompt
@@ -1971,35 +1971,35 @@ msgstr "更改我的魂灵形态。"
 #: /Game/Dialogue/Monarch/Default/MonarchPrettyButterfly.Default__MonarchPrettyButterfly_C.SessionData.Lines(4).Lines
 msgctxt ",253A15E2499151C9550E6A80742E78B6"
 msgid "We love it, but every butterfly's dream is... w-w-well..."
-msgstr ""
+msgstr "我们爱极了，但每只蝴蝶的梦想都是……是………怎么说好呢……"
 
 #. Key:	25580E6145BF9216DA12689E0973DCD0
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleAnyMeans.Default__KybeleAnyMeans_C.SessionData.LinesToFemale(2).LinesToFemale
 #: /Game/Dialogue/Kybele/Default/KybeleAnyMeans.Default__KybeleAnyMeans_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",25580E6145BF9216DA12689E0973DCD0"
 msgid "I am a well trained centaur warmaiden, you would not stand a chance."
-msgstr ""
+msgstr "我是训练有素的半人马女战士，你没有任何胜算。"
 
 #. Key:	255D031B4240EE3EF4E557AE245DE751
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiHadSex01.Default__FesssiHadSex01_C.SessionData.LinesToFuta(1).LinesToFuta
 #: /Game/Dialogue/Fesssi/Default/FesssiHadSex01.Default__FesssiHadSex01_C.SessionData.LinesToFuta(1).LinesToFuta
 msgctxt ",255D031B4240EE3EF4E557AE245DE751"
 msgid "I'm certain you found it quite pleasurable."
-msgstr ""
+msgstr "我很肯定你会找到相当大的快乐。"
 
 #. Key:	2562C2DF4A1E2558709AB9BF6D7F7974
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaHadSex01.Default__NeelaHadSex01_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Neela/Default/NeelaHadSex01.Default__NeelaHadSex01_C.SessionData.Lines(3).Lines
 msgctxt ",2562C2DF4A1E2558709AB9BF6D7F7974"
 msgid "You don't have to run off now do you? Stay awhile... and..."
-msgstr ""
+msgstr "你现在不用跑了对嘛？待一会儿。。。还有……”"
 
 #. Key:	25A665DA43117878012D26AE56A39F23
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_AboutLamias.Default__NeelaDefault01_AboutLamias_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_AboutLamias.Default__NeelaDefault01_AboutLamias_C.SessionData.Lines(5).Lines
 msgctxt ",25A665DA43117878012D26AE56A39F23"
 msgid "Maybe if you see my fat ass younger sister, she could tell you more."
-msgstr ""
+msgstr "如果你看到我的肥臀妹妹，她能告诉你更多你想知道的。"
 
 #. Key:	25D626114231ECB08961C6AB69737AE1
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_UpHere.Default__RomyDefault01_UpHere_C.SessionData.Lines(1).Lines
@@ -2013,21 +2013,21 @@ msgstr "你一定觉得这很奇怪，因为你是唯一的人类，而且我从
 #: /Game/World/Overworld.Overworld:PersistentLevel.CBGate_Cove.BlockMessage
 msgctxt ",25F0F67B48B7F4AEF73F849ED76DC655"
 msgid "Roots block this gate."
-msgstr ""
+msgstr "树的根茎挡住了这扇门"
 
 #. Key:	2632B36446A9D5F9E018209CB73837B8
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(4 - Value).TraitIcons.DisplayName
 #: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(4 - Value).TraitIcons.DisplayName
 msgctxt ",2632B36446A9D5F9E018209CB73837B8"
 msgid "Massive Size"
-msgstr "巨大体型"
+msgstr "巨大的尺寸"
 
 #. Key:	268AD0D344A4D1238CEC5798F2ED5EF0
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaHadSex02.Default__CamillaHadSex02_C.SessionData.LinesToFuta(3).LinesToFuta
 #: /Game/Dialogue/Camilla/Default/CamillaHadSex02.Default__CamillaHadSex02_C.SessionData.LinesToFuta(3).LinesToFuta
 msgctxt ",268AD0D344A4D1238CEC5798F2ED5EF0"
 msgid "If you... uh... ever get desperate again, you know where to find me!"
-msgstr ""
+msgstr "如果你。。。呃。。。如果你又渴望了的话，你知道哪里能找到我！"
 
 #. Key:	26BF34E64E91FAF8BA6ACF94AB76AB90
 #. SourceLocation:	/Game/Dialogue/Emissary/SexScenes/EmissaryAngelGroinLove.Default__EmissaryAngelGroinLove_C.SessionData.LinesToMale(2).LinesToMale
@@ -2048,7 +2048,7 @@ msgstr "和我一起放纵吧！"
 #: /Game/Dialogue/Autumn/Default/DryadHadSex01.Default__DryadHadSex01_C.SessionData.Lines(2).Lines
 msgctxt ",26DAA5B74F8BBB68C15E26ADBB255431"
 msgid "It's true what they say about humans, you really can please us like nothing else."
-msgstr ""
+msgstr "他们说的关于人类的话都是真的，你取悦我们的技巧无与伦比。"
 
 #. Key:	26DCB9EA476437386094CA87FFE3E422
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryBlessedInquiry01_R02.Default__EmissaryBlessedInquiry01_R02_C.SessionData.Lines(0).Lines
@@ -2062,28 +2062,28 @@ msgstr "吾如何才能更进一步的协助汝呢，人类？"
 #: /Game/Dialogue/Monarch/Default/MonarchHadSex01.Default__MonarchHadSex01_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",274F1AF94ECA42FE2B8A2E8E36BB6611"
 msgid "*Blush*"
-msgstr ""
+msgstr "*脸红*"
 
 #. Key:	2754CCC847A38E21CD70C58BFAE0F514
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernBeeFlowers3.Default__FernBeeFlowers3_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Fern/DefaultP3/FernBeeFlowers3.Default__FernBeeFlowers3_C.SessionData.Lines(2).Lines
 msgctxt ",2754CCC847A38E21CD70C58BFAE0F514"
 msgid "The soil tells me a dyrad is not that far away... in Pleasure Pastures!"
-msgstr ""
+msgstr "土壤告诉我树妖离我们不远……就在快感牧场！"
 
 #. Key:	27565BD64B41A94885451F8607E68D2F
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.CBGate_Pastures.PlaceMessage
 #: /Game/World/Overworld.Overworld:PersistentLevel.CBGate_Pastures.PlaceMessage
 msgctxt ",27565BD64B41A94885451F8607E68D2F"
 msgid "Pleasure Pastures is now accessible."
-msgstr ""
+msgstr "现在可以进入快感牧场了。"
 
 #. Key:	276B525843A991FAE2D5FAAE9243EFC9
 #. SourceLocation:	/Game/Dialogue/Blossom/Default/BlossomDefault01.Default__BlossomDefault01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Blossom/Default/BlossomDefault01.Default__BlossomDefault01_C.SessionData.Lines(0).Lines
 msgctxt ",276B525843A991FAE2D5FAAE9243EFC9"
 msgid "Mastah! Blossom love you."
-msgstr "主人！小小蕨爱您~"
+msgstr "主银！小…小蕨爱您~"
 
 #. Key:	2792356C47CF43619493DA8F71F0D9A0
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(29).LinesToMale
@@ -2097,14 +2097,14 @@ msgstr "一个充满欲望与冒险的世界在等着你！"
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_Leylanna.Default__EmissaryDefault01_Leylanna_C.SessionData.Lines(1).Lines
 msgctxt ",27AA07F64D837ABACCDEF6902D0199A2"
 msgid "When I first arrived, she embraced me, and made great attempts to please my vessel."
-msgstr "当吾初临此地，她便张开双臂怀抱吾，令吾的肉身容器品尝到无尽的欢愉"
+msgstr "当吾初临此地，她便张开双臂怀抱吾，令吾的肉身品尝到无尽的欢愉。"
 
 #. Key:	27BEBE1A44FE66BEF9575592E9C7F573
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchQueen.Default__MonarchQueen_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Monarch/Default/MonarchQueen.Default__MonarchQueen_C.SessionData.Lines(5).Lines
 msgctxt ",27BEBE1A44FE66BEF9575592E9C7F573"
 msgid "Once she metamorphosizes, we are going to fly to Sensual Heavens together."
-msgstr ""
+msgstr "一旦她蜕变了，我们就要一起飞向肉欲的天堂。"
 
 #. Key:	27CC628A41235ABEF7B863AD06577CD3
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01_RL_F.Default__FernDefault01_RL_F_C.ResponseData(3).ResponseData.BreederPrompt
@@ -2118,49 +2118,49 @@ msgstr "你可以用我的乳汁滋润自己了！"
 #: /Game/Dialogue/Neela/Default/NeelaHadSex01.Default__NeelaHadSex01_C.SessionData.Lines(4).Lines
 msgctxt ",27DC0A5545483DF96A1A72B802E0F3A6"
 msgid "Well you know... it gets lonely being the portal warden."
-msgstr ""
+msgstr "你懂的……做一个传送门看守者是会很寂寞的……"
 
 #. Key:	2811094D446D211B1E656D8729FC40AD
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMMuchEnergy.Default__DMMuchEnergy_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/DragonMatriarch/Default/DMMuchEnergy.Default__DMMuchEnergy_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",2811094D446D211B1E656D8729FC40AD"
 msgid "Indeed, so much newfound energy!"
-msgstr ""
+msgstr "哦是啊，这么多未曾发现的新能量！"
 
 #. Key:	28327C5645A9138AE8E04488402E4848
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeHaveKeystone.Default__BeeHaveKeystone_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/QueenBee/Default/BeeHaveKeystone.Default__BeeHaveKeystone_C.SessionData.Lines(2).Lines
 msgctxt ",28327C5645A9138AE8E04488402E4848"
 msgid "Legends say, it must be given in exchange to the one who will once again make these lands fertile."
-msgstr ""
+msgstr "传闻，必须把它交给那个能让这些土地再次变得肥沃富饶的人"
 
 #. Key:	286C68074B4BC23284A19AB99A24049A
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadCherryHelp.Default__DryadCherryHelp_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/Autumn/Default/DryadCherryHelp.Default__DryadCherryHelp_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",286C68074B4BC23284A19AB99A24049A"
 msgid "A chance to make a cherry with a human..."
-msgstr ""
+msgstr "一个和人类一起制做樱桃的机会……"
 
 #. Key:	288DF95142A24F16C989F78DB564A8B0
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.EM_Keystone_Orc.FailMessage
 #: /Game/World/Overworld.Overworld:PersistentLevel.EM_Keystone_Orc.FailMessage
 msgctxt ",288DF95142A24F16C989F78DB564A8B0"
 msgid "Xena glares at you."
-msgstr ""
+msgstr "齐娜瞪着你"
 
 #. Key:	28D2D40946F49E829D7D26B007908332
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieGreeting01.Default__CassieGreeting01_C.SessionData.Lines(8).Lines
 #: /Game/Dialogue/Cassie/Default/CassieGreeting01.Default__CassieGreeting01_C.SessionData.Lines(8).Lines
 msgctxt ",28D2D40946F49E829D7D26B007908332"
 msgid "Oh gosh darn it, I've said too much!"
-msgstr "哦老天爷，我好像说的有点儿多！"
+msgstr "妈耶，我好像说的有点儿太多了！"
 
 #. Key:	293B31924F2C8CE36DB46AB48441D958
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiHowLong.Default__FesssiHowLong_C.SessionData.Lines(10).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiHowLong.Default__FesssiHowLong_C.SessionData.Lines(10).Lines
 msgctxt ",293B31924F2C8CE36DB46AB48441D958"
 msgid "They found every way to make me climax, and it wassss glorious!"
-msgstr ""
+msgstr "他们用各种办法让我达到高潮，真的是……真的是太棒了！"
 
 #. Key:	29A421FC41D83A2B9DCC669ECA1F708D
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(34 - Value).TraitIcons.HelpText
@@ -2181,7 +2181,7 @@ msgstr "你是一位受到庇佑的魔弗灵吗？"
 #: /Game/Dialogue/Cassie/Default/CassieDungeon.Default__CassieDungeon_C.SessionData.Lines(5).Lines
 msgctxt ",2A2C90CA4F62D70955E3F3A98524FEAA"
 msgid "*Purr* You made me feel so good... Cassie wants to fix it for you!"
-msgstr ""
+msgstr "*猫呼噜声*你让我感觉很好。。。凯茜想帮你修好它！"
 
 #. Key:	2AA4EC89483BB63996FEBE9BC4E4055A
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDefault01_Meow_RL_T.Default__CassieDefault01_Meow_RL_T_C.ResponseData(1).ResponseData.BreederPrompt
@@ -2195,7 +2195,7 @@ msgstr "黄油棒？你认真的？"
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_SexPositions.Default__FaleneDefault01_SexPositions_C.SessionData.Lines(1).Lines
 msgctxt ",2AAA21F34762CDB90A4C749B986B1874"
 msgid "Of course I could go see for myself, but I am too lazy to climb the stairs!!!"
-msgstr ""
+msgstr "“我当然可以自己去看看，但是我懒的去爬楼梯！！！"
 
 #. Key:	2ABC84814DE5DC3039A61BBA0723AF73
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(7 - Value).TraitIcons.HelpText
@@ -2209,7 +2209,7 @@ msgstr "微小体型：身高约4英尺（1.21米）"
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeAboutOrb.Default__MegaSlimeAboutOrb_C.SessionData.Lines(1).Lines
 msgctxt ",2AE92EB74AEF856F0FE56487E2289FD2"
 msgid "My life was empty and meaningless without it."
-msgstr ""
+msgstr "没有它，我的生活一点都不快乐。"
 
 #. Key:	2B2323B74BC7F2E6E2CF40A3E50FEFC2
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_RL_M.Default__FernDefault02_RL_M_C.ResponseData(3).ResponseData.BreederPrompt
@@ -2223,21 +2223,21 @@ msgstr "你可以用我的乳汁滋润自己啦"
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02_RL_T.Default__FernDefault02_RL_T_C.ResponseData(5).ResponseData.BreederPrompt
 msgctxt ",2B4C510D4A32384C298984BDD667C93E"
 msgid "The Queen Bee demands flowers."
-msgstr ""
+msgstr "蜂后渴望着鲜花的簇拥"
 
 #. Key:	2B4CCE054929809171D1D88C30341FB2
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_Princess.Default__MirruDefault01_Princess_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_Princess.Default__MirruDefault01_Princess_C.SessionData.Lines(3).Lines
 msgctxt ",2B4CCE054929809171D1D88C30341FB2"
 msgid "Mother has reigned for 788 years human, and it is law that rulers stepdown at 800."
-msgstr "母亲的统治已持续了788年，人类，按照法律，在第800年时她就会退位。"
+msgstr "母亲的统治已持续了788年了人类，按照规矩，在第800年时她就会退位。"
 
 #. Key:	2B7282574EF4D841A9B0AD9EB06296D5
 #. SourceLocation:	/Game/Breeding/Positions/Surprise.Default__Surprise_C.SessionData.PositionName
 #: /Game/Breeding/Positions/Surprise.Default__Surprise_C.SessionData.PositionName
 msgctxt ",2B7282574EF4D841A9B0AD9EB06296D5"
 msgid "Surprise"
-msgstr "惊喜H式"
+msgstr "突鸡式"
 
 #. Key:	2BA86FB140866995E4F323B86DA72C9A
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_SellMonsters.Default__EmissaryDefault01_SellMonsters_C.SessionData.Lines(0).Lines
@@ -2251,28 +2251,28 @@ msgstr "女神很愉悦，而你将会得到女神的赏赐"
 #: /Game/Dialogue/OrcChief/Default/OrcDefault03_RL.Default__OrcDefault03_RL_C.ResponseData(2).ResponseData.BreederPrompt
 msgctxt ",2BB3415840A0FA9A2D3EF98079751D8D"
 msgid "Can I have your keystone?"
-msgstr ""
+msgstr "我可以拿你的钥石了吗"
 
 #. Key:	2BCA631C4BEC509E1B1DAC824001A31A
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_YourMusic_RL.Default__RomyDefault01_YourMusic_RL_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/Romy/Default/RomyDefault01_YourMusic_RL.Default__RomyDefault01_YourMusic_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",2BCA631C4BEC509E1B1DAC824001A31A"
 msgid "Whoa, actually I'm tone-deaf."
-msgstr "老实说，我有点五音不全"
+msgstr "唔噢，事实上我有点音痴。"
 
 #. Key:	2BD0260D4AF5544E8E7FEE98A41B8289
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchDefault01.Default__MonarchDefault01_C.SessionData.LinesToFemale(3).LinesToFemale
 #: /Game/Dialogue/Monarch/Default/MonarchDefault01.Default__MonarchDefault01_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",2BD0260D4AF5544E8E7FEE98A41B8289"
 msgid "If I wiggle it the right way, it w-w-will distract any potential... mates."
-msgstr ""
+msgstr "只要我轻轻地扭动它，它就会让你爽到失去意识的。。。亲爱的。"
 
 #. Key:	2BF4676042EE4C0FA5B54F8CDCD3C5A6
 #. SourceLocation:	/Game/Dialogue/Cassie/SexScenes/CassieSplintersT.Default__CassieSplintersT_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Cassie/SexScenes/CassieSplintersT.Default__CassieSplintersT_C.SessionData.Lines(1).Lines
 msgctxt ",2BF4676042EE4C0FA5B54F8CDCD3C5A6"
 msgid "*Purr*"
-msgstr "*咕噜咕噜声*"
+msgstr "*咕噜咕噜*"
 
 #. Key:	2C3AAB1041FC7DDA3F11DBBAACA151F1
 #. SourceLocation:	/Game/Characters/Procedural/Variants/Dragon/Harvest/DragonHarvest.Default__DragonHarvest_C.Harvest.Description
@@ -2286,70 +2286,70 @@ msgstr "龙族体液"
 #: /Game/Dialogue/Autumn/Default/DryadDefault01.Default__DryadDefault01_C.SessionData.Lines(1).Lines
 msgctxt ",2C4B1039457C01738B40D6AC73FC0E41"
 msgid "Oh how good it feels to make each one..."
-msgstr ""
+msgstr "哦，让彼此都感觉如此愉悦。。。"
 
 #. Key:	2C6E28494FB2D15A239584A77B01FA67
 #. SourceLocation:	/Game/Ranch/Upgrades/FoxenHouse.Default__FoxenHouse_C.Upgrade.DisplayName
 #: /Game/Ranch/Upgrades/FoxenHouse.Default__FoxenHouse_C.Upgrade.DisplayName
 msgctxt ",2C6E28494FB2D15A239584A77B01FA67"
 msgid "Foxen House"
-msgstr "狐狸人房子"
+msgstr "狐娘房子"
 
 #. Key:	2C85485F41A9CB181E6BF3A7AFBAD94C
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadAboutDryads.Default__DryadAboutDryads_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Autumn/Default/DryadAboutDryads.Default__DryadAboutDryads_C.SessionData.Lines(5).Lines
 msgctxt ",2C85485F41A9CB181E6BF3A7AFBAD94C"
 msgid "Perhaps a little too much... they sure get chubby. Aww... but look how cute they are!"
-msgstr ""
+msgstr "也许喂的有点太多了……。它们肯定会变得胖乎乎的。噢……但是你看看他们有多可爱啊！"
 
 #. Key:	2CBC22E04FC3D2621685D7A54A4B69A8
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleGreeting01.Default__KybeleGreeting01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Kybele/Default/KybeleGreeting01.Default__KybeleGreeting01_C.SessionData.Lines(0).Lines
 msgctxt ",2CBC22E04FC3D2621685D7A54A4B69A8"
 msgid "None may pass!"
-msgstr ""
+msgstr "没人通过！"
 
 #. Key:	2CCE0ADD406CF961196E5BAEDA387652
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_AboutMusic.Default__RomyDefault01_AboutMusic_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Romy/Default/RomyDefault01_AboutMusic.Default__RomyDefault01_AboutMusic_C.SessionData.Lines(0).Lines
 msgctxt ",2CCE0ADD406CF961196E5BAEDA387652"
 msgid "Can you not hear it?"
-msgstr "你听不到吗?"
+msgstr "你难道听不到吗?"
 
 #. Key:	2D2E42E44183AC98D3F98B8BCC03296A
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraAboutPawsmaati.Default__PetraAboutPawsmaati_C.SessionData.Lines(8).Lines
 #: /Game/Dialogue/Petra/Default/PetraAboutPawsmaati.Default__PetraAboutPawsmaati_C.SessionData.Lines(8).Lines
 msgctxt ",2D2E42E44183AC98D3F98B8BCC03296A"
 msgid "If you wish to learn new ways to have sex, go visit Pawmaati. You will not regret it!"
-msgstr ""
+msgstr "如果你想学习新的姿势去啪啪啪，可以去拜访帕斯玛媞。相信我你不会后悔的！"
 
 #. Key:	2D3C1B2D468CB7B71E995CBC072D4767
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeDefault01_RL.Default__BeeDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/QueenBee/Default/BeeDefault01_RL.Default__BeeDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",2D3C1B2D468CB7B71E995CBC072D4767"
 msgid "Uh... no?"
-msgstr ""
+msgstr "呃…不吗？"
 
 #. Key:	2D40A8404D1D3D0D2D24B49349427E5A
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernGreeting03.Default__FernGreeting03_C.SessionData.LinesToFemale(3).LinesToFemale
 #: /Game/Dialogue/Fern/DefaultP3/FernGreeting03.Default__FernGreeting03_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",2D40A8404D1D3D0D2D24B49349427E5A"
 msgid "I suppose there is no need to feed me anymore, but we can always do other things with my amazing flower body!"
-msgstr "您现在已经不需要喂养我了，但小蕨还能给主人的汁液找个好去处"
+msgstr "您现在已经不再需要喂养我了，但小蕨还能给主人的汁液找个好去处！"
 
 #. Key:	2D636C78456A78C86B5305B72E889E11
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",2D636C78456A78C86B5305B72E889E11"
 msgid "Human pussy tastes just like I dreamt it would!"
-msgstr ""
+msgstr "人类的阴道尝起来就像我梦到的那样！"
 
 #. Key:	2D7FF6A641C8DE1EC57F84A825BA2219
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMWantHuman.Default__DMWantHuman_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMWantHuman.Default__DMWantHuman_C.SessionData.Lines(3).Lines
 msgctxt ",2D7FF6A641C8DE1EC57F84A825BA2219"
 msgid "To think I can mate with one... ah... yesss."
-msgstr ""
+msgstr "我以为能和……交媾……啊……棒……棒极了"
 
 #. Key:	2DBE58DB4B0AEBCB9FDD04BC94C039BD
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R04.Default__FaleneDefault01_R04_C.SessionData.Lines(5).Lines
@@ -2370,14 +2370,14 @@ msgstr "把每一滴奶都给小蕨吧……嘶嘶嘶！！奶喝的越多我长
 #: /Game/Dialogue/Romy/Default/RomyDefault01_RL.Default__RomyDefault01_RL_C.ResponseData(4).ResponseData.BreederPrompt
 msgctxt ",2DF7474B4ED132A075973ABFA667399C"
 msgid "I want to hear your music."
-msgstr "我希望能聆听你的音乐"
+msgstr "我希望能聆听你的歌曲"
 
 #. Key:	2E166A6948BC2569CE3FCAB659B7FE7D
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFemale(3).LinesToFemale
 #: /Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",2E166A6948BC2569CE3FCAB659B7FE7D"
 msgid "Maybe my nipples?"
-msgstr ""
+msgstr "不试试我的乳头吗？"
 
 #. Key:	2E18B0B24CC860D3136F0CA493EDDD3B
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R04.Default__FaleneDefault01_R04_C.SessionData.Lines(0).Lines
@@ -2405,7 +2405,7 @@ msgstr "受到神佑的魔弗灵就像人类一样已经开智——拥有自我
 #: /Game/World/Overworld.Overworld:PersistentLevel.CBGate_Hivelands.PlaceMessage
 msgctxt ",2E3E08D0489FB126A2E91CAA491280F4"
 msgid "Hivelands is now accessible."
-msgstr ""
+msgstr "现在可以访问蜂巢大陆了"
 
 #. Key:	2E7BB9B84F5D0CB4DA2DF986BEFCB857
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFuta(0).LinesToFuta
@@ -2419,14 +2419,14 @@ msgstr "哇！这怎么可能!"
 #: /Game/Dialogue/Romy/Default/RomyLockedDungeon.Default__RomyLockedDungeon_C.SessionData.Lines(2).Lines
 msgctxt ",2E8395B6412987FEE6DC3E8FE37DC549"
 msgid "One of extraordinary loneliness and self-loathing."
-msgstr ""
+msgstr "一个非常孤独和自我厌恶的人。"
 
 #. Key:	2E8D7983446334A29BB4E0BCEFBBC092
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(4).Lines
 msgctxt ",2E8D7983446334A29BB4E0BCEFBBC092"
 msgid "Soon She realized something was missing, for the light had no meaning in the universe."
-msgstr ""
+msgstr "很快她就意识到有些东西不见了，因为光在宇宙中毫无意义。"
 
 #. Key:	2E926B8847D675F1C4CAAFAC2732930B
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01_R04.Default__FernDefault01_R04_C.SessionData.Lines(1).Lines
@@ -2440,84 +2440,84 @@ msgstr "小蕨需要人类的乳汁让自己长成茁壮的曼陀罗！！嘶嘶
 #: /Game/Dialogue/DragonMatriarch/Default/DMDefault01.Default__DMDefault01_C.SessionData.Lines(1).Lines
 msgctxt ",2EDA99CC46CBEB3206A527B95F55FAB9"
 msgid "Go away human, this is my comfy spot and you can't have it."
-msgstr ""
+msgstr "边玩去，人类，这是我爽的地方，哪儿凉快哪儿呆着去。"
 
 #. Key:	2EF1966C455529B6A75289AD5EF81C2E
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleTittyPony.Default__KybeleTittyPony_C.SessionData.LinesToFuta(0).LinesToFuta
 #: /Game/Dialogue/Kybele/Default/KybeleTittyPony.Default__KybeleTittyPony_C.SessionData.LinesToFuta(0).LinesToFuta
 msgctxt ",2EF1966C455529B6A75289AD5EF81C2E"
 msgid "That's it human, you have annoyed me long enough. Get against that rock and prepare to be smashed."
-msgstr ""
+msgstr "够了人类！你烦我够久了。靠在那块石头上准备被碾碎吧。"
 
 #. Key:	2EF454D94FCEA805F55F20A94627C808
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiGreeting01.Default__ParvatiGreeting01_C.SessionData.LinesToFuta(6).LinesToFuta
 #: /Game/Dialogue/Parvati/Default/ParvatiGreeting01.Default__ParvatiGreeting01_C.SessionData.LinesToFuta(6).LinesToFuta
 msgctxt ",2EF454D94FCEA805F55F20A94627C808"
 msgid "Give your body to me, and in ecstasy we will work around the clock."
-msgstr "把你全身心交给我，我们将会在喜悦中融为一体"
+msgstr "把你全身心交给我，我们将会在狂喜中忘却日夜更替。"
 
 #. Key:	2F11F20945669A4E95B79EA1B7856C2A
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadAboutDryads.Default__DryadAboutDryads_C.SessionData.Lines(7).Lines
 #: /Game/Dialogue/Autumn/Default/DryadAboutDryads.Default__DryadAboutDryads_C.SessionData.Lines(7).Lines
 msgctxt ",2F11F20945669A4E95B79EA1B7856C2A"
 msgid "A dryad's power reaches its peak at the moment of orgasm."
-msgstr ""
+msgstr "树妖的力量在高潮后达到顶峰"
 
 #. Key:	2F5513164D00080A441C1292E501C786
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(4).Lines
 msgctxt ",2F5513164D00080A441C1292E501C786"
 msgid "If ye have @MONSTER_RACE@ milk to sell, or if ye want te buy some then I'm yer gal!"
-msgstr "如果尼有魔物的奶要卖，或者尼想买点啥奶就尽管来找俺！"
+msgstr "如果尼有魔弗灵的奶要卖，或者尼想买点啥奶就尽管来找俺！"
 
 #. Key:	2F7D02EE4B2C5C30E72919BE9D83BD1F
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleDragonMatriarch.Default__KybeleDragonMatriarch_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Kybele/Default/KybeleDragonMatriarch.Default__KybeleDragonMatriarch_C.SessionData.Lines(5).Lines
 msgctxt ",2F7D02EE4B2C5C30E72919BE9D83BD1F"
 msgid "As reward, the Dragon Matriarch promised me a chance to mate with her, and I can't wait!"
-msgstr ""
+msgstr "作为回报，女族长答应给我一个和她啪的机会，我等不及了！"
 
 #. Key:	2F988E7B4E35BA65FB81488EC3339C51
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(2).Lines
 msgctxt ",2F988E7B4E35BA65FB81488EC3339C51"
 msgid "First, She made love with Herself to bring forth light and the Seraphim, my kin, were born."
-msgstr ""
+msgstr "首先，祂与自己结合，带来了光明和六翼天使，我的亲人，就此诞生了。"
 
 #. Key:	2FA4621047A86335175276AF22BFDE52
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon2.Default__AmberMaeLockedDungeon2_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon2.Default__AmberMaeLockedDungeon2_C.SessionData.Lines(0).Lines
 msgctxt ",2FA4621047A86335175276AF22BFDE52"
 msgid "If ye think I'm a big cow today, 'mai goodness was I larger in me younger days!"
-msgstr ""
+msgstr "如果尼认为我今天是头大母牛的话，窝的女神呀，窝年轻的时候比现在更大只！"
 
 #. Key:	2FA59C8A48A63BD0FE6D0289A8AF9587
 #. SourceLocation:	/Game/Dialogue/Yasmine/Default/YasmineDefault02_RL.Default__YasmineDefault02_RL_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/Yasmine/Default/YasmineDefault02_RL.Default__YasmineDefault02_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",2FA59C8A48A63BD0FE6D0289A8AF9587"
 msgid "This world gets stranger everyday..."
-msgstr ""
+msgstr "这个世界每天……都在变得更奇怪……"
 
 #. Key:	2FC584B146298BF0F75983AB7F59C5E1
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadBossomCherries.Default__DryadBossomCherries_C.SessionData.Lines(7).Lines
 #: /Game/Dialogue/Autumn/Default/DryadBossomCherries.Default__DryadBossomCherries_C.SessionData.Lines(7).Lines
 msgctxt ",2FC584B146298BF0F75983AB7F59C5E1"
 msgid "Don't look at me like that, a dryad needs a break once in awhile!"
-msgstr ""
+msgstr "别这样看着我，树妖需要休息一下，就一会儿！"
 
 #. Key:	2FFC051448D7AD3EA274FF8D334EE641
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeHadSex02.Default__MegaSlimeHadSex02_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeHadSex02.Default__MegaSlimeHadSex02_C.SessionData.Lines(1).Lines
 msgctxt ",2FFC051448D7AD3EA274FF8D334EE641"
 msgid "*She is fast asleep, her slime has relaxed*"
-msgstr ""
+msgstr "*她睡得很熟，粘液已经松弛了*"
 
 #. Key:	3002153B48BD52898AEAE78030617CF7
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_R01.Default__FernDefault02_R01_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02_R01.Default__FernDefault02_R01_C.SessionData.Lines(2).Lines
 msgctxt ",3002153B48BD52898AEAE78030617CF7"
 msgid "Once an Alraune has consumed enough reproductive fluid, she will grow into a massive stationary flower."
-msgstr "当我们这一族收集了足够的汁液后，就会成长为一个巨大静止的花"
+msgstr "当我们曼陀罗一族收集了足够的汁液后，她就会盛开成为一个巨大静止的曼陀罗花"
 
 #. Key:	3033B03F4617AF302335059B87E769FB
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_TheVoid.Default__NeelaDefault01_TheVoid_C.SessionData.Lines(1).Lines
@@ -2538,49 +2538,49 @@ msgstr "不能说我怪他们！"
 #: /Game/Breeding/Positions/LapDance.Default__LapDance_C.SessionData.Description
 msgctxt ",3075ABF441EF5686A57E81971B67D55E"
 msgid "The receiver bounces on the giver's lap while getting nice and close with her breasts."
-msgstr ""
+msgstr "接受恩赐的一方一边在播种者的大腿上上下弹跳，一边和她的胸部亲密接触。"
 
 #. Key:	307B12694EA9D8B0251B9D86E3760DB8
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMWantHuman.Default__DMWantHuman_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMWantHuman.Default__DMWantHuman_C.SessionData.Lines(1).Lines
 msgctxt ",307B12694EA9D8B0251B9D86E3760DB8"
 msgid "..."
-msgstr ""
+msgstr "…"
 
 #. Key:	308622B94E5A8BC25F1160888147CB16
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeHowLong.Default__MegaSlimeHowLong_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeHowLong.Default__MegaSlimeHowLong_C.SessionData.Lines(4).Lines
 msgctxt ",308622B94E5A8BC25F1160888147CB16"
 msgid "The stuff in the water is always cold... oh the slime I could make with a fresh hot load."
-msgstr ""
+msgstr "水里的东西总是冰冷刺骨的。。。哦，和我做的史莱姆居然是滚烫的家伙。"
 
 #. Key:	308B8DB245EC118210674A84BB3AFDC3
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleRideYou_RL_T.Default__KybeleRideYou_RL_T_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/Kybele/Default/KybeleRideYou_RL_T.Default__KybeleRideYou_RL_T_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",308B8DB245EC118210674A84BB3AFDC3"
 msgid "Aww what an adorable titty pony."
-msgstr ""
+msgstr "噢~多么可爱的小马驹。"
 
 #. Key:	3092F47E411D4A54A80D53BAF9BCBC3F
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToFuta(5).LinesToFuta
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToFuta(5).LinesToFuta
 msgctxt ",3092F47E411D4A54A80D53BAF9BCBC3F"
 msgid "It's a nutritious aphrodisiac, a very powerful one so be careful!"
-msgstr ""
+msgstr "这是一种营养丰富的壮阳药，非常强效，所以要万分小心！"
 
 #. Key:	30940E7C46EDA0BA71E783B92668ECFD
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernHadSex01.Default__FernHadSex01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Fern/Default/FernHadSex01.Default__FernHadSex01_C.SessionData.Lines(0).Lines
 msgctxt ",30940E7C46EDA0BA71E783B92668ECFD"
 msgid "Mmmm... mastah tasty!"
-msgstr ""
+msgstr "恩恩恩，主银，好嘶！"
 
 #. Key:	309ABB3C4016F9879A6955B2D2BD5AE8
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleAnyMeans.Default__KybeleAnyMeans_C.SessionData.LinesToFuta(3).LinesToFuta
 #: /Game/Dialogue/Kybele/Default/KybeleAnyMeans.Default__KybeleAnyMeans_C.SessionData.LinesToFuta(3).LinesToFuta
 msgctxt ",309ABB3C4016F9879A6955B2D2BD5AE8"
 msgid "My strong body will easily overpower your human form."
-msgstr ""
+msgstr "我雄壮的身体会轻易地压倒你的，人类。"
 
 #. Key:	30B0262C40D2D8527E2C8EA23D4D4B6D
 #. SourceLocation:	/Game/Dialogue/Emissary/SexScenes/EmissaryAngelGroinLove.Default__EmissaryAngelGroinLove_C.SessionData.LinesToMale(1).LinesToMale
@@ -2594,7 +2594,7 @@ msgstr "吾的蜜唇神圣又充满魔力，愿汝的舌头因其存在而得以
 #: /Game/Dialogue/DragonMatriarch/Default/DMLame.Default__DMLame_C.SessionData.Lines(0).Lines
 msgctxt ",30B4EDAF4D579766E7CE6082217D4CAC"
 msgid "*Yawwwwwwn*"
-msgstr ""
+msgstr "大大的哈欠"
 
 #. Key:	3101A3934639560426484AA6C6AAE3A1
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01_R02.Default__FernDefault01_R02_C.SessionData.Lines(0).Lines
@@ -2608,63 +2608,63 @@ msgstr "小蕨!"
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",3169578649A185428A32E78395F9C48E"
 msgid "This world is home to the @MONSTER_RACE@, an enigmatic race of human-monster hybrids."
-msgstr "这个世界是属于魔弗灵的乐园——这是一个神秘的，由人类与怪物混血而诞生的种族。"
+msgstr "这个世界是属于魔弗灵的乐园——这是一个神秘的，由人形怪物混血而组成的乐园。"
 
 #. Key:	31774B0844F7A12FF85DC5AE10CA3013
 #. SourceLocation:	/Game/Dialogue/Mirru/SexScenes/MirruKrakVag.Default__MirruKrakVag_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Mirru/SexScenes/MirruKrakVag.Default__MirruKrakVag_C.SessionData.Lines(3).Lines
 msgctxt ",31774B0844F7A12FF85DC5AE10CA3013"
 msgid "Oh... ahh... it feels so good."
-msgstr "噢……这感觉棒极了……"
+msgstr "噢……啊……这感觉棒极了……"
 
 #. Key:	31D7D80147B2E3EC2048A689FD79BD27
 #. SourceLocation:	/Game/UI/TaskDescriptions.TaskDescriptions.TextEntries(3).TextEntries
 #: /Game/UI/TaskDescriptions.TaskDescriptions.TextEntries(3).TextEntries
 msgctxt ",31D7D80147B2E3EC2048A689FD79BD27"
 msgid "Well I can certainly say the paper we use for writing these tasks is NOT tasty, meow! But you know what is tasty? Nephelym genitalia! Now bring me some! Meow, make it as big as possible... hmmm... I would say bigger than the whole town, but after what happened that one time... perhaps not. Just make it cute!  -Cassie"
-msgstr ""
+msgstr "嗯，我可以很负责任地说，我们用来写这些任务的一丁点儿都不好吃，喵呜~但你知道什么好吃吗？魔弗灵的生殖器！现在给我带些来！喵呜，让它尽可能大……嗯嗯……我会说比整个镇子都大，但在那一次发生的事情之后……嘛不是。让它可爱点就行啦！-凯茜"
 
 #. Key:	31E2065041FFF628ED41DEB3E33F080F
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_Pregnancy.Default__FaleneDefault01_Pregnancy_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_Pregnancy.Default__FaleneDefault01_Pregnancy_C.SessionData.Lines(3).Lines
 msgctxt ",31E2065041FFF628ED41DEB3E33F080F"
 msgid "It lets the mother know when the offspring will be summoned into this world, upon which the belly will return to normal."
-msgstr "它使母亲知道后代将会被召唤到这个世界，那之后腹部会回归正常。"
+msgstr "它会使母亲知道后代将会被召唤到这个世界，在那之后腹部就会回归正常。"
 
 #. Key:	3214B32B4A49DA94E7D6779180228EC0
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01.Default__NeelaDefault01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Neela/Default/NeelaDefault01.Default__NeelaDefault01_C.SessionData.Lines(0).Lines
 msgctxt ",3214B32B4A49DA94E7D6779180228EC0"
 msgid "No, I do not enjoy standing here all day wearing this ridiculous helmet."
-msgstr "呃，我恨死戴着这可笑的头盔，成天枯站在这儿的日子了。"
+msgstr "呃不，我恨死戴着这可笑的头盔，成天枯站在这儿的日子了。"
 
 #. Key:	322489D0449B3ABC5F1D12BCD6CAD220
 #. SourceLocation:	/Game/Dialogue/Cassie/SexScenes/CassieSplintersT.Default__CassieSplintersT_C.SessionData.Lines(6).Lines
 #: /Game/Dialogue/Cassie/SexScenes/CassieSplintersT.Default__CassieSplintersT_C.SessionData.Lines(6).Lines
 msgctxt ",322489D0449B3ABC5F1D12BCD6CAD220"
 msgid "Ouch, I'm getting splinters in my back! Ohhh... worth it."
-msgstr "呜呃，我的后背都磨疼了呀！呃啊…不过值了"
+msgstr "呜呃，我的后背都磨疼了呀！噢呜…不过太值了"
 
 #. Key:	323DCA0444372E8B59354A9FC665147D
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchGreeting01.Default__MonarchGreeting01_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Monarch/Default/MonarchGreeting01.Default__MonarchGreeting01_C.SessionData.Lines(4).Lines
 msgctxt ",323DCA0444372E8B59354A9FC665147D"
 msgid "Uh, m-m-my name is Monarch."
-msgstr ""
+msgstr "呃，我…我……我的名字是莫娜尔克"
 
 #. Key:	324ED3C844A0E2724766EB9155484064
 #. SourceLocation:	/Game/Dialogue/Neela/SexScenes/NeelaSnakeCuddleT.Default__NeelaSnakeCuddleT_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Neela/SexScenes/NeelaSnakeCuddleT.Default__NeelaSnakeCuddleT_C.SessionData.Lines(1).Lines
 msgctxt ",324ED3C844A0E2724766EB9155484064"
 msgid "You feel so good human... ahhhh."
-msgstr "啊~跟你做爱真是太舒服了人类…啊……"
+msgstr "你真的是……太棒了啊人类…呃啊啊……"
 
 #. Key:	325B057D42B7367B320C54941EEE0BA6
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_Forgot.Default__ParvatiDefault01_Forgot_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_Forgot.Default__ParvatiDefault01_Forgot_C.SessionData.Lines(4).Lines
 msgctxt ",325B057D42B7367B320C54941EEE0BA6"
 msgid "I will show again how to move your body beyond all measure."
-msgstr ""
+msgstr "我将再次展示如何让你的身体丰盈极限的快感"
 
 #. Key:	32E74CA64F7C6339A9D526A19496DD86
 #. SourceLocation:	/Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToFemale(0).LinesToFemale
@@ -2678,210 +2678,210 @@ msgstr "哦！你的皮肤真是柔软！我喜欢你这样顶住我屁股的感
 #: /Game/World/Overworld.Overworld:PersistentLevel.EM_Keystone_Monarch.FailMessage
 msgctxt ",330CF8FE454E1F3A60B2A894F9D4CA31"
 msgid "Monarch's magic prevents you."
-msgstr ""
+msgstr "莫娜尔克的魔法阻止着你。"
 
 #. Key:	330EAC0C483DA43FAFCBCBB789D5AB9E
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(9).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(9).Lines
 msgctxt ",330EAC0C483DA43FAFCBCBB789D5AB9E"
 msgid "'Twas nice meet'n ye @BREEDER_NAME@..."
-msgstr "见到尼真是开心，@BREEDER_NAME@..."
+msgstr "见到尼蒸是开心，@BREEDER_NAME@..."
 
 #. Key:	335AC6B54A917B8EBB17218E2A338F3C
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieGreeting01.Default__CassieGreeting01_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Cassie/Default/CassieGreeting01.Default__CassieGreeting01_C.SessionData.Lines(5).Lines
 msgctxt ",335AC6B54A917B8EBB17218E2A338F3C"
 msgid "Name's Cassie, I'm the architect in town."
-msgstr "我叫凯希，是这镇上的建筑师。"
+msgstr "我叫凯茜，是这镇上的建筑师。"
 
 #. Key:	33869B7A401E77AD997246A9AFD3C136
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcGreeting01.Default__OrcGreeting01_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcGreeting01.Default__OrcGreeting01_C.SessionData.Lines(3).Lines
 msgctxt ",33869B7A401E77AD997246A9AFD3C136"
 msgid "*Snarl*"
-msgstr ""
+msgstr "*咆哮*"
 
 #. Key:	3388B3134E9C8C83D182D5B5C5F89B85
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowSpiders.Default__WidowSpiders_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Widow/Default/WidowSpiders.Default__WidowSpiders_C.SessionData.Lines(0).Lines
 msgctxt ",3388B3134E9C8C83D182D5B5C5F89B85"
 msgid "Ahhh yes. I love spinning stories as much as webs."
-msgstr ""
+msgstr "呃是的，我喜欢编故事，就像我喜欢织网一样。"
 
 #. Key:	33CE1E3D4DCA8528953414ACFA7C540B
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowScary.Default__WidowScary_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Widow/Default/WidowScary.Default__WidowScary_C.SessionData.Lines(0).Lines
 msgctxt ",33CE1E3D4DCA8528953414ACFA7C540B"
 msgid "Why is that so?"
-msgstr ""
+msgstr "真的是这样吗？"
 
 #. Key:	33DB6107453143BAF4F8B0A81EFC2634
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault02.Default__CamillaDefault02_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaDefault02.Default__CamillaDefault02_C.SessionData.Lines(2).Lines
 msgctxt ",33DB6107453143BAF4F8B0A81EFC2634"
 msgid "A swarm of horny bats no doubt, or maybe a giant leech."
-msgstr ""
+msgstr "毫无疑问是一大群妖媚的蝙蝠，也有可能是一只巨大的'吸血鬼'。"
 
 #. Key:	33E5BA9741C0AE4944E1E5BBC54FDCFA
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcDefault01.Default__OrcDefault01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcDefault01.Default__OrcDefault01_C.SessionData.Lines(1).Lines
 msgctxt ",33E5BA9741C0AE4944E1E5BBC54FDCFA"
 msgid "*Snarl*"
-msgstr ""
+msgstr "*咆哮*"
 
 #. Key:	33EFAFD748D8C769BA9A978D5F401884
 #. SourceLocation:	/Game/UI/TaskDescriptions.TaskDescriptions.TextEntries(4).TextEntries
 #: /Game/UI/TaskDescriptions.TaskDescriptions.TextEntries(4).TextEntries
 msgctxt ",33EFAFD748D8C769BA9A978D5F401884"
 msgid "The spirits have spoken! Through divine inspiration I am writing this request. Bring to me a lover, a reward from the heavens for my good service as high priestess. I am humbled that the spirits find my work worthy of such a gift. Oh and they have revealed more! This lover is to be... yes... the pinacle of beauty, large in all the right places.  -Leylanna"
-msgstr ""
+msgstr "魂灵已经说了！通过神的启示，我正在写下这个请求。作为一个大祭司，请给我一个爱人吧，就算是上天对我的赏赐。我诚恳的请求您，我认为我值得这样的礼物。哦！他们揭示了更多的秘密！这个爱人将成为……对……美的极致化身，该大的地方超大。——蕾莱娜"
 
 #. Key:	341A1B1E4F52D36C69BFB9ACE71DBCD4
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimePlay.Default__MegaSlimePlay_C.SessionData.LinesToFuta(2).LinesToFuta
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePlay.Default__MegaSlimePlay_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",341A1B1E4F52D36C69BFB9ACE71DBCD4"
 msgid "I'm going to eat all of it and make lots of new slime..."
-msgstr ""
+msgstr "我要把它全部吞下，做出很多新的黏液。。。"
 
 #. Key:	341E99EA4A6DE606AFFC6D8A11C1B7D5
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R07.Default__CamillaDefault01_R07_C.SessionData.LinesToFuta(1).LinesToFuta
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R07.Default__CamillaDefault01_R07_C.SessionData.LinesToFuta(1).LinesToFuta
 msgctxt ",341E99EA4A6DE606AFFC6D8A11C1B7D5"
 msgid "Amber's tits are bigger than me! Why is this world so cruel..."
-msgstr "安布尔的胸部比我大!为什么这个世界如此残酷……"
+msgstr "为什么安布尔的奶子比我大!为这个世界太残酷了……"
 
 #. Key:	3432E91146A4FE41E5BCC2825E37B64C
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(10).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(10).Lines
 msgctxt ",3432E91146A4FE41E5BCC2825E37B64C"
 msgid "Ages later, the universe was filled with Seraphim and Demon alike."
-msgstr ""
+msgstr "很久以后，宇宙充满了六翼天使和恶魔。"
 
 #. Key:	34678F424650992E3728BD9DE99571DA
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchHaveKeystone2.Default__MonarchHaveKeystone2_C.SessionData.Message
 #: /Game/Dialogue/Monarch/Default/MonarchHaveKeystone2.Default__MonarchHaveKeystone2_C.SessionData.Message
 msgctxt ",34678F424650992E3728BD9DE99571DA"
 msgid "Monarch is satisfied."
-msgstr ""
+msgstr "莫娜尔克满意了。"
 
 #. Key:	34C104D84D1D1734B9408FA6B2BDA125
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDefault01_Meow_ButterStick.Default__CassieDefault01_Meow_ButterStick_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Cassie/Default/CassieDefault01_Meow_ButterStick.Default__CassieDefault01_Meow_ButterStick_C.SessionData.Lines(0).Lines
 msgctxt ",34C104D84D1D1734B9408FA6B2BDA125"
 msgid "Awww... meow... Cassie is sad now."
-msgstr "呜呜呜…喵呜…你可真令凯希伤心。"
+msgstr "呜呜呜…喵呜…你可真令凯茜伤心。"
 
 #. Key:	350B5B304D18A9FD50E44AA8A979877B
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMSoBeIt.Default__DMSoBeIt_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMSoBeIt.Default__DMSoBeIt_C.SessionData.Lines(0).Lines
 msgctxt ",350B5B304D18A9FD50E44AA8A979877B"
 msgid "Ahhh... so be it!"
-msgstr ""
+msgstr "噢，就这样吧！"
 
 #. Key:	3526724A47197988348500AADC4A0504
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_RL.Default__RomyDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
 #: /Game/Dialogue/Romy/Default/RomyDefault01_RL.Default__RomyDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
 msgctxt ",3526724A47197988348500AADC4A0504"
 msgid "So, you bathe all day?"
-msgstr "那么，你整天洗澡吗？"
+msgstr "那么，你整天都在洗香香吗？"
 
 #. Key:	354DB41C4CBE7109F318B1B3C5D66984
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchHaveKeystone.Default__MonarchHaveKeystone_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Monarch/Default/MonarchHaveKeystone.Default__MonarchHaveKeystone_C.SessionData.Lines(4).Lines
 msgctxt ",354DB41C4CBE7109F318B1B3C5D66984"
 msgid "Usually, they have their way with me before I can finish."
-msgstr ""
+msgstr "通常，他们会用他们特有的方式让我停不下来。"
 
 #. Key:	354E29D445D2F28CFD2E2782082F8D11
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_StartSnatchT.Default__MirruDefault01_StartSnatchT_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_StartSnatchT.Default__MirruDefault01_StartSnatchT_C.SessionData.Lines(0).Lines
 msgctxt ",354E29D445D2F28CFD2E2782082F8D11"
 msgid "Ahhh... come here human!"
-msgstr "啊哈……人类，到这儿来！"
+msgstr "啊哈……来这边儿，人类！"
 
 #. Key:	3587D87D4538714F62271FBFA1D17FFF
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03_R01.Default__FernDefault03_R01_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03_R01.Default__FernDefault03_R01_C.SessionData.Lines(2).Lines
 msgctxt ",3587D87D4538714F62271FBFA1D17FFF"
 msgid "If I have to spend the rest of eternity in one spot, I wouldn't want it to be with anyone else..."
-msgstr "如果我非得在一个地方度过余生，我只求与您相伴"
+msgstr "如果我非得在一个地方度过余生，我只求与您相随"
 
 #. Key:	35908AA04644610D46AB42B909BDD768
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleTittyPony_T.Default__KybeleTittyPony_T_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/Kybele/Default/KybeleTittyPony_T.Default__KybeleTittyPony_T_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",35908AA04644610D46AB42B909BDD768"
 msgid "That's it human, you have annoyed me long enough. Bend over and prepare to be stuffed with my fat spear!"
-msgstr ""
+msgstr "够了人类，你烦我够久了，弯下腰，准备被我的肥硕的长矛填满吧！"
 
 #. Key:	35B0312145CDC987463545B35DBCF219
 #. SourceLocation:	/Game/Dialogue/Mirru/SexScenes/MirruSnatchT.Default__MirruSnatchT_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Mirru/SexScenes/MirruSnatchT.Default__MirruSnatchT_C.SessionData.Lines(0).Lines
 msgctxt ",35B0312145CDC987463545B35DBCF219"
 msgid "Submit human... I cannot control my desires!"
-msgstr "向人类臣服……我克制不住自己的欲望了！"
+msgstr "服从，人类……我克制不住自己的欲望了！"
 
 #. Key:	35BF63974E330C75B3359E8E1E99F0CB
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(11).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(11).Lines
 msgctxt ",35BF63974E330C75B3359E8E1E99F0CB"
 msgid "However the demons grew weary of being governed by archangels, and decided to revolt."
-msgstr ""
+msgstr "然而，恶魔们厌倦了大天使的统治，决定反抗回去。"
 
 #. Key:	35CF617940B0723BA4795CA4E3D0FA22
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_StartLoveMakingT.Default__LeylannaDefault01_StartLoveMakingT_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Leylanna/Default/LeylannaDefault01_StartLoveMakingT.Default__LeylannaDefault01_StartLoveMakingT_C.SessionData.Lines(0).Lines
 msgctxt ",35CF617940B0723BA4795CA4E3D0FA22"
 msgid "Come to my embrace."
-msgstr "投入我的怀抱吧。"
+msgstr "投入我的温柔乡吧。"
 
 #. Key:	35E72C7041E32B269ECDA081BF9906C0
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(15).LinesToFemale
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(15).LinesToFemale
 msgctxt ",35E72C7041E32B269ECDA081BF9906C0"
 msgid "I'm getting wetter by the second..."
-msgstr "哦~我现在已经湿了..."
+msgstr "哦~我一秒就湿透了…"
 
 #. Key:	360772034C5CFEB38121F884358A5F7C
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowHadSex01.Default__WidowHadSex01_C.SessionData.LinesGrungy(1).LinesGrungy
 #: /Game/Dialogue/Widow/Default/WidowHadSex01.Default__WidowHadSex01_C.SessionData.LinesGrungy(1).LinesGrungy
 msgctxt ",360772034C5CFEB38121F884358A5F7C"
 msgid "You need a bath. Come now, place your body between my breasts and let's get you clean."
-msgstr ""
+msgstr "你需要洗个澡。来吧。现在，把你的身体放在我的乳房之间，让她们把你弄干净。"
 
 #. Key:	364811A44C2FE9E58EA99A89A91D330A
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcGoneWorse.Default__OrcGoneWorse_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcGoneWorse.Default__OrcGoneWorse_C.SessionData.Lines(0).Lines
 msgctxt ",364811A44C2FE9E58EA99A89A91D330A"
 msgid "Grrrrrrr!!!!!!!!"
-msgstr ""
+msgstr "咕噜噜噜！！！！"
 
 #. Key:	3688842F4859D54E5DEE7C9284F1966A
 #. SourceLocation:	/Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToFuta(8).LinesToFuta
 #: /Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToFuta(8).LinesToFuta
 msgctxt ",3688842F4859D54E5DEE7C9284F1966A"
 msgid "Sweet delicious human seed, let it all go! Ahhh..."
-msgstr "多么甜美可口的的人类种子，都射给我！啊……"
+msgstr "多么甜美可口的的人类种子，全流出来，都射给我！啊……"
 
 #. Key:	3688E2EC4574EAE7A8F242B913F48060
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeAboutBees.Default__BeeAboutBees_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/QueenBee/Default/BeeAboutBees.Default__BeeAboutBees_C.SessionData.Lines(0).Lines
 msgctxt ",3688E2EC4574EAE7A8F242B913F48060"
 msgid "There isn't much to say. We stake out a claim of land with plentiful flowers, and use the nectar."
-msgstr ""
+msgstr "没什么太多要说的。我们划定了一块有丰富花朵的土地，以此采集花蜜。"
 
 #. Key:	36E3E99D4C836714C7292D93FA860BA5
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R03.Default__FaleneDefault01_R03_C.SessionData.Lines(9).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R03.Default__FaleneDefault01_R03_C.SessionData.Lines(9).Lines
 msgctxt ",36E3E99D4C836714C7292D93FA860BA5"
 msgid "One or more will certainly take interest and follow you."
-msgstr "肯定会有一个甚至更多对你感性趣并且开始跟随着你。"
+msgstr "肯定会有一个甚至更多魔弗灵对你感性趣并且开始跟随着你。"
 
 #. Key:	36FB659142F59E57CE11B996BF838787
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeHadSex01.Default__MegaSlimeHadSex01_C.SessionData.LinesToFuta(0).LinesToFuta
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeHadSex01.Default__MegaSlimeHadSex01_C.SessionData.LinesToFuta(0).LinesToFuta
 msgctxt ",36FB659142F59E57CE11B996BF838787"
 msgid "Wow that felt so good!"
-msgstr ""
+msgstr "哇哦，那棒极了！"
 
 #. Key:	3713C92543DDBF9AF3C3209EE018350C
 #. SourceLocation:	/Game/Dialogue/Emissary/SexScenes/EmissaryAngelGroinLove.Default__EmissaryAngelGroinLove_C.SessionData.LinesToFuta(2).LinesToFuta
@@ -2902,14 +2902,14 @@ msgstr "我爱亮晶晶的东西！！！"
 #: /Game/Dialogue/Cassie/Default/CassieDefault01.Default__CassieDefault01_C.SessionData.Lines(4).Lines
 msgctxt ",372744754A7F7B2F4F1D72B3F739DBDC"
 msgid "Oh! The human!"
-msgstr "噢！是你啊人类！"
+msgstr "噢！是人类！"
 
 #. Key:	3771E4E540E0BDDF6C468691EF623F85
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowKeystone.Default__WidowKeystone_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Widow/Default/WidowKeystone.Default__WidowKeystone_C.SessionData.Lines(3).Lines
 msgctxt ",3771E4E540E0BDDF6C468691EF623F85"
 msgid "Perhaps a trade is in order..."
-msgstr ""
+msgstr "也许可以促成一笔交易呢……"
 
 #. Key:	37933117464CBF3120925D83C7A81935
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToFemale(4).LinesToFemale
@@ -2923,7 +2923,7 @@ msgstr "想象一下，你的性器在我的触手中会感觉多么爽……我
 #: /Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToMale(4).LinesToMale
 msgctxt ",37BE82A749B75C694B68B3856342C2A7"
 msgid "Mmmm... so hard! Ohhh... ahhh!"
-msgstr "嗯... 好深! 哦... 啊!"
+msgstr "嗯... 好重……好深! 哦... 啊!"
 
 #. Key:	37E6B83D46955FAADDF215966CCB5A8B
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R03.Default__CamillaDefault01_R03_C.SessionData.Lines(1).Lines
@@ -2937,49 +2937,49 @@ msgstr "你知道变得很小在这个世界上是什么感觉吗?"
 #: /Game/Dialogue/DragonMatriarch/Default/DMTaskFulfilled.Default__DMTaskFulfilled_C.SessionData.Lines(1).Lines
 msgctxt ",3815589C483262ECB1EA19B8C0F8DABA"
 msgid "You gave me so much milk, and I consumed all of it!"
-msgstr ""
+msgstr "你给了我那么多牛奶，我都喝光了！"
 
 #. Key:	382D95F84EE60493751368AE5D1FFE56
 #. SourceLocation:	/Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToFuta(6).LinesToFuta
 #: /Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToFuta(6).LinesToFuta
 msgctxt ",382D95F84EE60493751368AE5D1FFE56"
 msgid "Yes! I can feel you're about to cum... I want it all. Mmmm..."
-msgstr "对！我感受到你要去了.....我要你的全部。嗯......."
+msgstr "对！我感受到你要去了.....我要你全部射出来。嗯......."
 
 #. Key:	3834BEFA49DCF9700CF52A8776CAE288
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowKeystone.Default__WidowKeystone_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Widow/Default/WidowKeystone.Default__WidowKeystone_C.SessionData.Lines(5).Lines
 msgctxt ",3834BEFA49DCF9700CF52A8776CAE288"
 msgid "Oh the thought of my own adorable elf is making me wet... and hungry."
-msgstr ""
+msgstr "哦，一想到属于自己的可爱的精灵，我就又湿透了……还饿了。"
 
 #. Key:	38365E644649BD12B20E879BB823AAC7
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaHadSex02.Default__CamillaHadSex02_C.SessionData.LinesToMale(1).LinesToMale
 #: /Game/Dialogue/Camilla/Default/CamillaHadSex02.Default__CamillaHadSex02_C.SessionData.LinesToMale(1).LinesToMale
 msgctxt ",38365E644649BD12B20E879BB823AAC7"
 msgid "Your cock was so big, I didn't think I could take all of it."
-msgstr ""
+msgstr "你的生殖器太大了，我不认为我能全部'吃'的下去。"
 
 #. Key:	383F99384A9AA2EB709D22BFAE55B72F
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleGreeting01.Default__KybeleGreeting01_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Kybele/Default/KybeleGreeting01.Default__KybeleGreeting01_C.SessionData.Lines(3).Lines
 msgctxt ",383F99384A9AA2EB709D22BFAE55B72F"
 msgid "You will have to go through me!"
-msgstr ""
+msgstr "你先得过我这一关！"
 
 #. Key:	386696884552AA79E38A38B6CD4C33BA
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiTaskFulfilled.Default__FesssiTaskFulfilled_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiTaskFulfilled.Default__FesssiTaskFulfilled_C.SessionData.Lines(0).Lines
 msgctxt ",386696884552AA79E38A38B6CD4C33BA"
 msgid "Freedom! The fresh air feels sssso good. The titan you bred me was so strong, it had no trouble lifting my heavy body. It even smashed a few surrounding rocks too!"
-msgstr ""
+msgstr "自由！新鲜空气感觉很好。你帮我培育的泰坦是如此的强壮，它毫不费力地举起了我沉重的身体，甚至还打碎了周围的一些岩石！"
 
 #. Key:	3888188240872C25EF9A03B26842C93D
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraTaskFulfilled.Default__PetraTaskFulfilled_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Petra/Default/PetraTaskFulfilled.Default__PetraTaskFulfilled_C.SessionData.Lines(0).Lines
 msgctxt ",3888188240872C25EF9A03B26842C93D"
 msgid "Now I understand! Pawsmaati's wisdom knows no bounds."
-msgstr ""
+msgstr "现在我明白了！帕丝玛媞的懂得太多了。"
 
 #. Key:	38A804064868E5E8FF3BE5A81144D82A
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01.Default__FernDefault01_C.SessionData.Lines(1).Lines
@@ -2993,21 +2993,21 @@ msgstr "..."
 #: /Game/Dialogue/Autumn/Default/DryadBossomCherries.Default__DryadBossomCherries_C.SessionData.Lines(9).Lines
 msgctxt ",38BCD1174242BC7366EC2D967B472DE1"
 msgid "You can tell how hard I came by the size of the fruit. The larger ones were oh so fun to make."
-msgstr ""
+msgstr "你可以从水果的大小看出我有多努力。大一点的太有趣了"
 
 #. Key:	38CC526548FEE9E798647C9C32B75ECE
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadAboutDryads.Default__DryadAboutDryads_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Autumn/Default/DryadAboutDryads.Default__DryadAboutDryads_C.SessionData.Lines(4).Lines
 msgctxt ",38CC526548FEE9E798647C9C32B75ECE"
 msgid "I decided to use my dryad power to produce fruit for them, and they love it."
-msgstr ""
+msgstr "我决定用我的树妖的力量为他们生产水果，他们爱上了我的水果。"
 
 #. Key:	38F493C44D198004851E1399B9B3A835
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleTittyPony.Default__KybeleTittyPony_C.SessionData.LinesToMale(1).LinesToMale
 #: /Game/Dialogue/Kybele/Default/KybeleTittyPony.Default__KybeleTittyPony_C.SessionData.LinesToMale(1).LinesToMale
 msgctxt ",38F493C44D198004851E1399B9B3A835"
 msgid "It's been sometime since I have been mouted, so I might get rough!"
-msgstr ""
+msgstr "我已经有一段时间没活动活动了，所以我可能会变得粗暴的哟！"
 
 #. Key:	391607BA4B3A996D1551BC9B7E71F385
 #. SourceLocation:	/Game/Characters/Procedural/Variants/Harpy/Harvest/HarpyHarvest.Default__HarpyHarvest_C.Harvest.RaceName
@@ -3035,7 +3035,7 @@ msgstr "我看到了一个欲求不满的人来到了我面前"
 #: /Game/Dialogue/AmberMae/Default/AmberMaeDefault01_RL.Default__AmberMaeDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
 msgctxt ",397B4EDC415499258BF65B825D968230"
 msgid "What do you know about the old temple?"
-msgstr ""
+msgstr "你对这座古代圣殿了解多少？"
 
 #. Key:	39BB76F04901D85036C696B74CA537B3
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeDefault01_Accent.Default__AmberMaeDefault01_Accent_C.SessionData.Lines(2).Lines
@@ -3049,7 +3049,8 @@ msgstr "那里的天气有时候会变得好冷，如果尼要去那里，尼最
 #: /Game/UI/TaskDescriptions.TaskDescriptions.TextEntries(2).TextEntries
 msgctxt ",39E4B8C74F24A77B88CFA89F73E896C7"
 msgid "Meow! Yes, I write that as often as I blurt it out. Hmmmm... I want... um... meow! Gimme something cute I can put my butter stick in. The less noise it makes the better I guess, meow. Maybe make it extra warm and soft... you can control that right? Meow, this paper looks tasty. Just a few nibbles wouldn't hurt.  -Cassie"
-msgstr ""
+msgstr "
+喵呜！是的，我想说什么就会写下来。嗯……我要……嗯……喵！给我一些可爱的东西，我可以把我的黄油棒放进去。噪音越小越好，喵呜。也许能让它能更温暖也更柔软。。。你能控制的对吧？喵呜，这张纸看起来很好吃。只要小小的咬伤几口就好了。——凯茜"
 
 #. Key:	39E5F4F34604E8D146FCCBA395551EFA
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.MutHut.ManageActionMessage
@@ -3070,35 +3071,35 @@ msgstr "那就是交配！"
 #: /Game/Dialogue/Cassie/Default/CassieHadSex01.Default__CassieHadSex01_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",3A445E064F00F058EEF964928975B1F0"
 msgid "Meow! That felt so good..."
-msgstr ""
+msgstr "喵呜！感觉爽极了……"
 
 #. Key:	3A46F38444516EB07B8D84BC38A2B77C
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadHaveKeystone.Default__DryadHaveKeystone_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Autumn/Default/DryadHaveKeystone.Default__DryadHaveKeystone_C.SessionData.Lines(2).Lines
 msgctxt ",3A46F38444516EB07B8D84BC38A2B77C"
 msgid "Sure we made a giant fruit, but you lack the lust I require to feed these cows."
-msgstr ""
+msgstr "我们的确结出了巨大的果实，但你没有我喂这些牛的欲望"
 
 #. Key:	3A5C7D5342118BA87B8C6595C9B5D200
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R01.Default__CamillaDefault01_R01_C.SessionData.Lines(7).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R01.Default__CamillaDefault01_R01_C.SessionData.Lines(7).Lines
 msgctxt ",3A5C7D5342118BA87B8C6595C9B5D200"
 msgid "The massive set of tits called Amber sells milk. You can find Amber across the way, but be warned: the only thing thicker than her accent is her body. Good luck with that."
-msgstr "那个巨乳娘安布尔是卖奶的。你可以在街对面找到，不过你要当心：比她的口音重的就是她的身体。祝你好运咯。"
+msgstr "那个巨乳安布尔是卖奶的。你可以在街对面找到，不过你要当心：比她的口音重的就是她的身体。祝你好运咯。"
 
 #. Key:	3A8C32C44AAB9702B680029FE2C6DAD8
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchStartShySex.Default__MonarchStartShySex_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/Monarch/Default/MonarchStartShySex.Default__MonarchStartShySex_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",3A8C32C44AAB9702B680029FE2C6DAD8"
 msgid "*Extreme blushing*"
-msgstr ""
+msgstr "*脸红透了*"
 
 #. Key:	3AB82ACD4DE402E534B94C83E44F5A2C
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaGreeting01.Default__NeelaGreeting01_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Neela/Default/NeelaGreeting01.Default__NeelaGreeting01_C.SessionData.Lines(2).Lines
 msgctxt ",3AB82ACD4DE402E534B94C83E44F5A2C"
 msgid "Neela, warden of the Void, keybearer of pussy portals, at your service."
-msgstr "我，霓拉，虚空的守望者，蜜穴之门的看门人，为您效劳。"
+msgstr "我，妮拉，虚空的守望者，蜜穴之门的看门人，为您效劳。"
 
 #. Key:	3AD149F249D46CC8CCB146B464F0C53D
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_TastyHuman.Default__NeelaDefault01_TastyHuman_C.SessionData.Lines(0).Lines
@@ -3119,7 +3120,7 @@ msgstr "而你所要抓的魔弗灵却并非像我这样受到神佑！"
 #: /Game/Dialogue/Petra/Default/PetraTaskFulfilled.Default__PetraTaskFulfilled_C.SessionData.Lines(1).Lines
 msgctxt ",3AEC10F04A7A17CC79668DBE56DADBEA"
 msgid "The succubus you provided me is... magical."
-msgstr ""
+msgstr "你给我的那个魅魔……太厉害了。"
 
 #. Key:	3B3FB5184F1E276BF9EE46AB7835441D
 #. SourceLocation:	/Game/Characters/Procedural/Variants/Starfallen/Harvest/StarfallenHarvest.Default__StarfallenHarvest_C.Harvest.Description
@@ -3133,28 +3134,28 @@ msgstr "星陨人体液"
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03_R02.Default__FernDefault03_R02_C.SessionData.Lines(4).Lines
 msgctxt ",3B447AD04300826ECFC550A03A3AA0BC"
 msgid "My lower body is filled with nectar just waiting to surround your body as you cum again... and again."
-msgstr "我的下体已经充满了花蜜。我已经忍不住想象你在我身体里一次又一次地射精"
+msgstr "我的下体已经充满了花蜜。我已经忍不住想象您在我身体里一次又一次地射精了。"
 
 #. Key:	3B686C7E477142920CF64F8119EC7E6F
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_FloatRhyme.Default__ParvatiDefault01_FloatRhyme_C.SessionData.Lines(6).Lines
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_FloatRhyme.Default__ParvatiDefault01_FloatRhyme_C.SessionData.Lines(6).Lines
 msgctxt ",3B686C7E477142920CF64F8119EC7E6F"
 msgid "Give into your desires, it will not render you weak."
-msgstr "把你全身心交给我，我们将会在喜悦中融为一体"
+msgstr "屈服于你的欲望吧，它不会使你软弱的。"
 
 #. Key:	3B6C0A634B200C954436A296F4A9EFEE
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_HowToSpiritForm.Default__LeylannaDefault01_HowToSpiritForm_C.SessionData.LinesToMale(2).LinesToMale
 #: /Game/Dialogue/Leylanna/Default/LeylannaDefault01_HowToSpiritForm.Default__LeylannaDefault01_HowToSpiritForm_C.SessionData.LinesToMale(2).LinesToMale
 msgctxt ",3B6C0A634B200C954436A296F4A9EFEE"
 msgid "Catch a male Vulwarg if you have not done so, and then return to me. We will then make love and form a covenant."
-msgstr "如果你还没有抓过雄性狼灵，去抓一只。然后回来找我，我们会颠鸾倒凤一场并以此为你的魂灵形态定下盟约。"
+msgstr "如果你还没有抓过雄性狼灵，去抓一只。然后回来找我，我们会颠鸾倒凤一场并以此为你的魂灵形态定下契约。"
 
 #. Key:	3B7564A547A46D41C60CB999DCC9B845
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiHowLong.Default__FesssiHowLong_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiHowLong.Default__FesssiHowLong_C.SessionData.Lines(4).Lines
 msgctxt ",3B7564A547A46D41C60CB999DCC9B845"
 msgid "But by far the best surprises came from behind... or they did before that confounded Cockblock Gate sealed itself a few days ago."
-msgstr ""
+msgstr "但到目前为止最好的惊喜都是来自于背后……或者是在几天前那扇令人困惑的大门自动关闭之前"
 
 #. Key:	3B79840D47C6CCB278E40AB26C3546E7
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_StartMIssionary.Default__ParvatiDefault01_StartMIssionary_C.SessionData.Lines(0).Lines
@@ -3168,21 +3169,21 @@ msgstr "..."
 #: /Game/Dialogue/Widow/Default/WidowGreeting01.Default__WidowGreeting01_C.SessionData.Lines(0).Lines
 msgctxt ",3B83735E49E0C65B9C47E19DEE0B3417"
 msgid "*Strange moans and squishy noises can be heard within.*"
-msgstr ""
+msgstr "*里面可以听到奇怪的呻吟声和黏糊糊的声音*"
 
 #. Key:	3B85C4B1437679C67EE00DB4AEA10E96
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcBrashDumb.Default__OrcBrashDumb_C.SessionData.Lines(7).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcBrashDumb.Default__OrcBrashDumb_C.SessionData.Lines(7).Lines
 msgctxt ",3B85C4B1437679C67EE00DB4AEA10E96"
 msgid "Me chieftain because I use my dick the most, so watch out!"
-msgstr ""
+msgstr "我 酋长，因为我用我的老二最多，所以小心点！"
 
 #. Key:	3C151FC94376B799967B11AAA342949E
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDungeon_RL.Default__LeylannaDungeon_RL_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/Leylanna/Default/LeylannaDungeon_RL.Default__LeylannaDungeon_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",3C151FC94376B799967B11AAA342949E"
 msgid "You're the high priestess!!!!"
-msgstr ""
+msgstr "你是高级女祭司！！！"
 
 #. Key:	3C197E81483FDB92C0B7DE83C29374D3
 #. SourceLocation:	/Game/Ranch/Upgrades/ThriaeHive.Default__ThriaeHive_C.Upgrade.DisplayName
@@ -3196,14 +3197,14 @@ msgstr "蜂巢"
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePearl.Default__MegaSlimePearl_C.SessionData.Message
 msgctxt ",3C6678BF441FA4DC09CD16B12864C86C"
 msgid "Beautiful Pearl was given away."
-msgstr ""
+msgstr "交出了美丽的珍珠"
 
 #. Key:	3C6949B84E9BE02327C5408DC7F1D673
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadDefault01_RL.Default__DryadDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
 #: /Game/Dialogue/Autumn/Default/DryadDefault01_RL.Default__DryadDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
 msgctxt ",3C6949B84E9BE02327C5408DC7F1D673"
 msgid "I can help you make a cherry!"
-msgstr ""
+msgstr "我可以帮你做一个樱桃！"
 
 #. Key:	3C944B624D25292479528987C3078CBF
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryGreeting01.Default__EmissaryGreeting01_C.SessionData.Lines(7).Lines
@@ -3217,7 +3218,7 @@ msgstr "万物规则即是从祂处诞生，流经祂后终而回归于祂怀抱
 #: /Game/Dialogue/Widow/Default/WidowDefault01_RL.Default__WidowDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",3C9BA6E04AC95F2B27A50B89FF127DCA"
 msgid "Tell me about spiders."
-msgstr ""
+msgstr "跟我讲讲蜘蛛的事情。"
 
 #. Key:	3CA687014A0A2E686C1525BCF1F25CAE
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(30 - Value).TraitIcons.HelpText
@@ -3231,14 +3232,14 @@ msgstr "花哨打扮：继承了一个不同寻常的配色方案"
 #: /Game/Dialogue/Autumn/Default/DryadFatAssLamia.Default__DryadFatAssLamia_C.SessionData.Lines(7).Lines
 msgctxt ",3CAE764B43C77D2CB4504791345E729C"
 msgid "It's been awhile, maybe I should go check on her."
-msgstr ""
+msgstr "好久没见了，也许我该去看看她。"
 
 #. Key:	3CD8374646422958F67B3F8F2C11622C
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleTittyPony.Default__KybeleTittyPony_C.SessionData.LinesToFemale(2).LinesToFemale
 #: /Game/Dialogue/Kybele/Default/KybeleTittyPony.Default__KybeleTittyPony_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",3CD8374646422958F67B3F8F2C11622C"
 msgid "That should teach you to cross this titty po--I mean mighty centaur warmaiden, again!"
-msgstr ""
+msgstr "这再一次教会你如何深入这个大奶驹……——我是说！强大的半人马女战士！"
 
 #. Key:	3D4441784AF4D03AE277679928164F4E
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(21 - Value).TraitIcons.DisplayName
@@ -3252,98 +3253,98 @@ msgstr "坚挺"
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03_RL_F.Default__FernDefault03_RL_F_C.ResponseData(4).ResponseData.BreederPrompt
 msgctxt ",3D80ACD9492E522E22EE0EAAD298E834"
 msgid "I'm climbing in your flower."
-msgstr "我想要钻进你的花瓣里"
+msgstr "我想要钻进你的花瓣里。"
 
 #. Key:	3D8EEBEC4ED68B55EF4D03AE26C8037C
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeDefault01_RL.Default__MegaSlimeDefault01_RL_C.ResponseData(4).ResponseData.BreederPrompt
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeDefault01_RL.Default__MegaSlimeDefault01_RL_C.ResponseData(4).ResponseData.BreederPrompt
 msgctxt ",3D8EEBEC4ED68B55EF4D03AE26C8037C"
 msgid "I want to play in your slime!"
-msgstr ""
+msgstr "我想要在你的史莱姆里玩！"
 
 #. Key:	3DB538F149AC7F6C7364009E1811D1CF
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault02.Default__EmissaryDefault02_C.SessionData.Lines(6).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault02.Default__EmissaryDefault02_C.SessionData.Lines(6).Lines
 msgctxt ",3DB538F149AC7F6C7364009E1811D1CF"
 msgid "Or, hath desire brought you abreast my holy golden bosom?"
-msgstr ""
+msgstr "或者，是欲望使你与我神圣的金色胸怀并驾齐驱吗？"
 
 #. Key:	3DDC87214109BEB2D2A970A966C08449
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchStartShySex.Default__MonarchStartShySex_C.SessionData.LinesToFemale(2).LinesToFemale
 #: /Game/Dialogue/Monarch/Default/MonarchStartShySex.Default__MonarchStartShySex_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",3DDC87214109BEB2D2A970A966C08449"
 msgid "May I... use my toy on you?"
-msgstr ""
+msgstr "我可以……在你身上用我的小玩具吗？"
 
 #. Key:	3DE7C5E5483FE8321224F9A0BE1EE1E2
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeLikesPresent.Default__MegaSlimeLikesPresent_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeLikesPresent.Default__MegaSlimeLikesPresent_C.SessionData.Lines(1).Lines
 msgctxt ",3DE7C5E5483FE8321224F9A0BE1EE1E2"
 msgid "I will keep it forever as a token of our friendship!"
-msgstr ""
+msgstr "我将永远保留它作为我们友谊的象征！"
 
 #. Key:	3E483C5F491D4BAE82E56082A61D1FA0
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleTaskFulfilled.Default__KybeleTaskFulfilled_C.SessionData.LinesToFemale(5).LinesToFemale
 #: /Game/Dialogue/Kybele/Default/KybeleTaskFulfilled.Default__KybeleTaskFulfilled_C.SessionData.LinesToFemale(5).LinesToFemale
 msgctxt ",3E483C5F491D4BAE82E56082A61D1FA0"
 msgid "Ahhh! She's the perfect toy for such a boring task. You have my thanks."
-msgstr ""
+msgstr "啊哈哈！她是做这种无聊工作的最佳人选。谢谢你！"
 
 #. Key:	3E509CE6430904677DC8DBB0A19336D8
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMDefault_RL.Default__DMDefault_RL_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/DragonMatriarch/Default/DMDefault_RL.Default__DMDefault_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",3E509CE6430904677DC8DBB0A19336D8"
 msgid "Can't you nap somewhere else?"
-msgstr ""
+msgstr "你不能在别的地方小睡吗？"
 
 #. Key:	3E5797444DCB450E19730E9C8CB6A4FB
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleTittyPony.Default__KybeleTittyPony_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/Kybele/Default/KybeleTittyPony.Default__KybeleTittyPony_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",3E5797444DCB450E19730E9C8CB6A4FB"
 msgid "That's it human, you have annoyed me long enough. Bend over and prepare to be stuffed with my fat spear!"
-msgstr ""
+msgstr "够了，人类，你吵我够久了。弯下腰准备被我的肥矛塞满吧！"
 
 #. Key:	3E5B1CA94E6EB9CC180AE3A6F9EC5439
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryCockblockGates.Default__EmissaryCockblockGates_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryCockblockGates.Default__EmissaryCockblockGates_C.SessionData.Lines(2).Lines
 msgctxt ",3E5B1CA94E6EB9CC180AE3A6F9EC5439"
 msgid "Seek the keystones hidden throughout the world, for one is required per gate."
-msgstr ""
+msgstr "寻找隐藏在世界各地的钥石，因为每个大门都需要一个。"
 
 #. Key:	3EAFC53348C0B793D4BF32A6B78F4E3F
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_Forgot_RL.Default__ParvatiDefault01_Forgot_RL_C.ResponseData(4).ResponseData.BreederPrompt
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_Forgot_RL.Default__ParvatiDefault01_Forgot_RL_C.ResponseData(4).ResponseData.BreederPrompt
 msgctxt ",3EAFC53348C0B793D4BF32A6B78F4E3F"
 msgid "Lifted!"
-msgstr ""
+msgstr "抬起来了"
 
 #. Key:	3EB71DED4BE3050E6199E7B8D96DD53B
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiStuck.Default__FesssiStuck_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiStuck.Default__FesssiStuck_C.SessionData.Lines(5).Lines
 msgctxt ",3EB71DED4BE3050E6199E7B8D96DD53B"
 msgid "Hiss! Perhaps it's finally time I did something about thisss, so that I might share my ass with the world."
-msgstr ""
+msgstr "嘶！也许我终于该做点什么了，这样我就可以和全世界分享我的屁股了"
 
 #. Key:	3ECED49B42C93D52237EFFBEAB033F9A
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeDefault01.Default__BeeDefault01_C.SessionData.LinesToMale(1).LinesToMale
 #: /Game/Dialogue/QueenBee/Default/BeeDefault01.Default__BeeDefault01_C.SessionData.LinesToMale(1).LinesToMale
 msgctxt ",3ECED49B42C93D52237EFFBEAB033F9A"
 msgid "Soon my nectar collection will be complete, and I can return to the Hivelands."
-msgstr ""
+msgstr "很快我的花蜜收集工作就要完成了，我就可以回到蜂巢大地了"
 
 #. Key:	3EDC6D7644348135F915AD8CFA2438CE
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_RL_F.Default__FernDefault02_RL_F_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02_RL_F.Default__FernDefault02_RL_F_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",3EDC6D7644348135F915AD8CFA2438CE"
 msgid "Why did you call me master?"
-msgstr "你为什么称我为主人"
+msgstr "你为什么称我为主人？"
 
 #. Key:	3EDC810646DEEE7CC8706393F4141D13
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimePlay.Default__MegaSlimePlay_C.SessionData.LinesToMale(0).LinesToMale
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePlay.Default__MegaSlimePlay_C.SessionData.LinesToMale(0).LinesToMale
 msgctxt ",3EDC810646DEEE7CC8706393F4141D13"
 msgid "Really?! These truly are the best days of my life!"
-msgstr ""
+msgstr "真的吗，这真的是我一生中最棒的日子了"
 
 #. Key:	3EEDCB0B41A901791EE10990EB7EBF6A
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_AboutMusic.Default__RomyDefault01_AboutMusic_C.SessionData.Lines(6).Lines
@@ -3357,21 +3358,21 @@ msgstr "不过总有一些喜欢在泥里打滚。"
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R02.Default__CamillaDefault01_R02_C.SessionData.Lines(6).Lines
 msgctxt ",3EF462824AF0C626F44930B3EB3D1614"
 msgid "Demons prefer the lava flows of Moaning Crag."
-msgstr "魔女喜欢呻吟峭壁的岩浆热流。"
+msgstr "恶魔们喜欢娇喘峭壁下的滚滚岩浆。"
 
 #. Key:	3EF6E0F646189B89DDE495A5A01F7FC3
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(32 - Value).TraitIcons.DisplayName
 #: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(32 - Value).TraitIcons.DisplayName
 msgctxt ",3EF6E0F646189B89DDE495A5A01F7FC3"
 msgid "Abomination"
-msgstr "令人反感"
+msgstr "真让人讨厌"
 
 #. Key:	3EFC55C841DE04F93E1162B03860B502
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFuta(0).LinesToFuta
 #: /Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFuta(0).LinesToFuta
 msgctxt ",3EFC55C841DE04F93E1162B03860B502"
 msgid "Ohhh @BREEDER_NAME@... you were amazing."
-msgstr ""
+msgstr "噢……@BREEDER_NAME@……你棒呆了。"
 
 #. Key:	3F053255484259108C0E28AFBD627175
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToMale(1).LinesToMale
@@ -3385,21 +3386,21 @@ msgstr "你不知道，有多少束缚，在这一刻被我统统抛之脑后了
 #: /Game/Dialogue/Leylanna/Default/LeylannaOldTempleDungeon.Default__LeylannaOldTempleDungeon_C.SessionData.Lines(2).Lines
 msgctxt ",3F42819C4BE489F79C959596626E0A60"
 msgid "Oh..."
-msgstr ""
+msgstr "喔……"
 
 #. Key:	3FA017C943E38117C9C5C1B911067136
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadCherryHelp_RL.Default__DryadCherryHelp_RL_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/Autumn/Default/DryadCherryHelp_RL.Default__DryadCherryHelp_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",3FA017C943E38117C9C5C1B911067136"
 msgid "Let's make a fruit!"
-msgstr ""
+msgstr "让我们一起做水果吧！"
 
 #. Key:	3FF7BD1544456D7735C2D2AA0DCBAA1A
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaHadSex01.Default__CamillaHadSex01_C.SessionData.LinesToFuta(1).LinesToFuta
 #: /Game/Dialogue/Camilla/Default/CamillaHadSex01.Default__CamillaHadSex01_C.SessionData.LinesToFuta(1).LinesToFuta
 msgctxt ",3FF7BD1544456D7735C2D2AA0DCBAA1A"
 msgid "Your cock was so big, I didn't think I could take all of it."
-msgstr ""
+msgstr "你的生殖器太大了，我感觉我并不能接受得了"
 
 #. Key:	40100E704D14DC5D1B113F84C1BCE936
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(10).LinesToMale
@@ -3434,42 +3435,42 @@ msgstr "如果你不在状态，你也可以通过在他们身上涂抹魔弗灵
 #: /Game/Dialogue/Monarch/Default/MonarchDefault01_RL.Default__MonarchDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",402496A44933EE13233F8E8A45D06E47"
 msgid "The queen?"
-msgstr ""
+msgstr "皇后？"
 
 #. Key:	4052D6DF434789A177EAA1A32665DC40
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_RL_T.Default__FernDefault02_RL_T_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02_RL_T.Default__FernDefault02_RL_T_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",4052D6DF434789A177EAA1A32665DC40"
 msgid "Why did you call me master?"
-msgstr "你为什么称我为主人"
+msgstr "你为什么称我为主人？"
 
 #. Key:	408D0D424145C7FC8A4A419C5F15FC5E
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleAnyMeans.Default__KybeleAnyMeans_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/Kybele/Default/KybeleAnyMeans.Default__KybeleAnyMeans_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",408D0D424145C7FC8A4A419C5F15FC5E"
 msgid "Yes. By any means necessary!"
-msgstr ""
+msgstr "对。不管用什么方法！"
 
 #. Key:	409211234F50BB3CC5987D94FC8463AA
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraDefault01_RL.Default__PetraDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/Petra/Default/PetraDefault01_RL.Default__PetraDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",409211234F50BB3CC5987D94FC8463AA"
 msgid "Can you help me get that keystone?"
-msgstr ""
+msgstr "你能帮我拿到那个钥石吗？"
 
 #. Key:	40FFE44B48699F620EAC16A81249A058
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeHadSex01.Default__MegaSlimeHadSex01_C.SessionData.LinesToFuta(3).LinesToFuta
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeHadSex01.Default__MegaSlimeHadSex01_C.SessionData.LinesToFuta(3).LinesToFuta
 msgctxt ",40FFE44B48699F620EAC16A81249A058"
 msgid "You should stay down here and give me more! We can be friends forever."
-msgstr ""
+msgstr "你应该待在这里多给我点！我们可以永远做朋友。"
 
 #. Key:	410012DF43FE2AB2B4B74FA7EE1CB85E
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeDefault01.Default__AmberMaeDefault01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeDefault01.Default__AmberMaeDefault01_C.SessionData.Lines(1).Lines
 msgctxt ",410012DF43FE2AB2B4B74FA7EE1CB85E"
 msgid "Come 'an put yerself betwixt them--I don't mind none!"
-msgstr "快来，快把自己埋进来——俺真是等不及了~"
+msgstr "快过来，把自己埋到中间————俺真的是等不及了~！"
 
 #. Key:	41480BAC414E8393545F14A5AF5C1CBD
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernGreeting01.Default__FernGreeting01_C.SessionData.Lines(3).Lines
@@ -3490,21 +3491,21 @@ msgstr "不像其他大多海妖是双性，她是非常罕见的纯正女性。
 #: /Game/Dialogue/DragonMatriarch/Default/DMMuchEnergy.Default__DMMuchEnergy_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",415BAAD3485DF4862A1042A34A209E90"
 msgid "Perhaps a quick flight up to Climax Peak is in order, there's bound to be a dumb Titan lumbering about."
-msgstr ""
+msgstr "也许我们应该飞到极乐之巅，那里肯定会有个笨笨巨人在四处游荡"
 
 #. Key:	4163AB5147C585FA2B2677AB39C31FC2
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcAkabekoCheck.Default__OrcAkabekoCheck_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcAkabekoCheck.Default__OrcAkabekoCheck_C.SessionData.Lines(1).Lines
 msgctxt ",4163AB5147C585FA2B2677AB39C31FC2"
 msgid "Human did good, chieftain already dumped loads in her."
-msgstr ""
+msgstr "人类做得很好，酋长已经在她身上倾倒了很多子弹了"
 
 #. Key:	417606634FB97A6E74DED7A87503CED0
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcDefault01.Default__OrcDefault01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcDefault01.Default__OrcDefault01_C.SessionData.Lines(0).Lines
 msgctxt ",417606634FB97A6E74DED7A87503CED0"
 msgid "Human! My tribe sisters want to breed."
-msgstr ""
+msgstr "人类！我的部落姐妹们想要繁衍后代。"
 
 #. Key:	4190CA08434458A4DA0C58AFFD9BDDC9
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R04.Default__FaleneDefault01_R04_C.SessionData.Lines(2).Lines
@@ -3518,28 +3519,28 @@ msgstr "根据我的推论，我估计魔弗灵比我们认为的人类要饥渴
 #: /Game/Dialogue/QueenBee/Default/BeeDefault01.Default__BeeDefault01_C.SessionData.LinesToMale(2).LinesToMale
 msgctxt ",41B56BDE47DBF26EB76387BAB182E0D2"
 msgid "Is t-t-there something... you want human?"
-msgstr ""
+msgstr "有…有…什么你想要的吗，人类？"
 
 #. Key:	41CE38AC413D8EA31A17AAA16825D852
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimePlay.Default__MegaSlimePlay_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePlay.Default__MegaSlimePlay_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",41CE38AC413D8EA31A17AAA16825D852"
 msgid "You will feel so good as I flood your womb with my slime..."
-msgstr ""
+msgstr "我用我的粘液灌满你的子宫，你会爽的直翻白眼的"
 
 #. Key:	41D4E33A4F278EEAC8E03DBD1A9618E5
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeSuckJugs_Start.Default__AmberMaeSuckJugs_Start_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeSuckJugs_Start.Default__AmberMaeSuckJugs_Start_C.SessionData.Lines(1).Lines
 msgctxt ",41D4E33A4F278EEAC8E03DBD1A9618E5"
 msgid "I'm get'n wet, milk me 'lil human! Drink it all!"
-msgstr "俺好湿，快狠狠吸俺的奶，人类！全部喝掉！"
+msgstr "俺好湿，快狠狠吸俺的奶，人类！全部喝掉吧！"
 
 #. Key:	42094BD145964827266556B272FD2005
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernGreeting03.Default__FernGreeting03_C.SessionData.LinesToMale(4).LinesToMale
 #: /Game/Dialogue/Fern/DefaultP3/FernGreeting03.Default__FernGreeting03_C.SessionData.LinesToMale(4).LinesToMale
 msgctxt ",42094BD145964827266556B272FD2005"
 msgid "Slide yourself in here with me, my body is silky and filled with sweet nectar. I will make you feel so good..."
-msgstr ""
+msgstr "滑入我充满了花蜜，犹如丝绸般柔软的身体吧，我会让您好好享受的..."
 
 #. Key:	4216C26A4EE0EF8A17937686F1FBEC4A
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01_RL_F.Default__FernDefault01_RL_F_C.ResponseData(2).ResponseData.BreederPrompt
@@ -3560,7 +3561,7 @@ msgstr "而你所要抓的魔弗灵却并非像我这样受到神佑！"
 #: /Game/Dialogue/Yasmine/Default/YasminePearls.Default__YasminePearls_C.SessionData.Lines(1).Lines
 msgctxt ",4225207741108002DA6A24AE7B076E55"
 msgid "They are fun to make, and can sell for a decent chunk of orgasium."
-msgstr ""
+msgstr "它们制作起来很有趣，而且可以卖个好价钱。"
 
 #. Key:	424BF25644C67138FF6800BD56A2F0CF
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(9).LinesToMale
@@ -3581,56 +3582,56 @@ msgstr "啊啊不要停~~尼这人类~~俺的~浓厚绵密的奶…啊~"
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R06.Default__FaleneDefault01_R06_C.SessionData.Lines(7).Lines
 msgctxt ",42E4526948669BCD5AFBD29DC9583D3C"
 msgid "Meh, I am an alchemist... I don't believe in this stuff! Go talk to high priestess Leylanna or that creepy Seraphim if you want to learn more about this myth!"
-msgstr "嘛，我是个炼金术师……我一点也不信这种鬼话！如果你想了解这段秘辛，去找最高女祭司Leylana或者那个令人毛骨悚然的六翼天使！"
+msgstr "我是炼精术士……我不相信这些东西！如果你想进一步了解这个神话，去和高级女祭司蕾莱娜或那个令人毛骨悚然的六翼天使谈谈吧！"
 
 #. Key:	431393014FD2AE0F14B10994F1A6E951
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(5).Lines
 msgctxt ",431393014FD2AE0F14B10994F1A6E951"
 msgid "A force was needed to contrast the light, and so the Goddess gave into Her most lustful desires and birthed the darkness."
-msgstr ""
+msgstr "需要一种力量来衬托光明，因此女神将她最淫欲的欲望投入其中，因此诞生了黑暗。"
 
 #. Key:	432AB6154EB0FCBABFD45A9F48D948F8
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcFixOwnGate.Default__OrcFixOwnGate_C.SessionData.LinesToFemale(3).LinesToFemale
 #: /Game/Dialogue/OrcChief/Default/OrcFixOwnGate.Default__OrcFixOwnGate_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",432AB6154EB0FCBABFD45A9F48D948F8"
 msgid "Human fix gate now, or get cock stuffed down gullet!"
-msgstr ""
+msgstr "人类修好大门现在！不然就把生殖器塞进你的下水道！"
 
 #. Key:	433691C34A0864415618B78808993A0E
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMNapSomewhereElse.Default__DMNapSomewhereElse_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMNapSomewhereElse.Default__DMNapSomewhereElse_C.SessionData.Lines(1).Lines
 msgctxt ",433691C34A0864415618B78808993A0E"
 msgid "For hundreds of years I have come to this rock to rest, it's quite comfortable."
-msgstr ""
+msgstr "几百年来，我一直在这块岩石上休息，它很舒服"
 
 #. Key:	434F3EDD4D71E19F342B9FB4B2780A63
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaHadSex01.Default__NeelaHadSex01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Neela/Default/NeelaHadSex01.Default__NeelaHadSex01_C.SessionData.Lines(0).Lines
 msgctxt ",434F3EDD4D71E19F342B9FB4B2780A63"
 msgid "Oh yes, that was incredible."
-msgstr ""
+msgstr "哦，是的，太不可思议了"
 
 #. Key:	434FF9C34E180AC6724D628D8E2EB07A
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDungeon2.Default__CassieDungeon2_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Cassie/Default/CassieDungeon2.Default__CassieDungeon2_C.SessionData.Lines(4).Lines
 msgctxt ",434FF9C34E180AC6724D628D8E2EB07A"
 msgid "*Purr* You made me feel so good... so Cassie fixed it for you!"
-msgstr ""
+msgstr "*猫呼噜声*你让我感觉舒服极了……所以凯茜帮你修好了！"
 
 #. Key:	4360D9A3483F76A70B34C59BF0B5B019
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiAreYouOk.Default__FesssiAreYouOk_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiAreYouOk.Default__FesssiAreYouOk_C.SessionData.Lines(0).Lines
 msgctxt ",4360D9A3483F76A70B34C59BF0B5B019"
 msgid "Your concern is making me wet... hissss... come closer."
-msgstr ""
+msgstr "靠近点，嘶嘶嘶，你的关心让我湿了。"
 
 #. Key:	436AE5954AEC637113E3E1A30DFDE1C5
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMNapSomewhereElse.Default__DMNapSomewhereElse_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMNapSomewhereElse.Default__DMNapSomewhereElse_C.SessionData.Lines(0).Lines
 msgctxt ",436AE5954AEC637113E3E1A30DFDE1C5"
 msgid "Nah."
-msgstr ""
+msgstr "不不不"
 
 #. Key:	437DBE7940749A6838FDA39FD90FF637
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryRaiseTraitLvl_RL.Default__EmissaryRaiseTraitLvl_RL_C.ResponseData(0).ResponseData.BreederPrompt
@@ -3644,7 +3645,7 @@ msgstr "接受"
 #: /Game/Dialogue/Camilla/Default/CamillaHadSex01.Default__CamillaHadSex01_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",43B91A4A43D78CA88ED80E9B8E857EB2"
 msgid "If you... uh... ever get desperate again, you know where to find me!"
-msgstr ""
+msgstr "但是如果你…呃…如果你又很渴望的话，你知道哪里能找到我！"
 
 #. Key:	43D16A4C487E8E717D3AF2A72A1F2C56
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_MultipleHearts.Default__MirruDefault01_MultipleHearts_C.SessionData.Lines(1).Lines
@@ -3658,49 +3659,49 @@ msgstr "人类，你好扫兴诶。"
 #: /Game/Dialogue/Neela/SexScenes/NeelaSnakeCuddleT.Default__NeelaSnakeCuddleT_C.SessionData.Lines(3).Lines
 msgctxt ",43D6E7FC4718254A804FD5AF3D1C8186"
 msgid "Does my Lamia body please you?"
-msgstr "我Lamia族的身体是不是很好操？"
+msgstr "你喜欢我的拉米娅一族的身体吗？"
 
 #. Key:	43D79A3F4EFECC071827CCAC96ED865A
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R06.Default__FaleneDefault01_R06_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R06.Default__FaleneDefault01_R06_C.SessionData.Lines(5).Lines
 msgctxt ",43D79A3F4EFECC071827CCAC96ED865A"
 msgid "She birthed offspring in their image and made them immortal. Those who believe call this the Great Conception."
-msgstr ""
+msgstr "他们以祂的形象生育后代，使他们长生不老。那些相信的人称之为伟大的受孕"
 
 #. Key:	43F7A9D34F081E2EA25537A60B42DBA3
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R07.Default__CamillaDefault01_R07_C.SessionData.LinesToFuta(0).LinesToFuta
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R07.Default__CamillaDefault01_R07_C.SessionData.LinesToFuta(0).LinesToFuta
 msgctxt ",43F7A9D34F081E2EA25537A60B42DBA3"
 msgid "Don't waste your delicious body fluid on me. Just wait for Falene to come back, or go suck on Amber's tits."
-msgstr "不要把你的美味精液浪费在我身上。等着法琳娜回来，或者去吸安布尔的奶子。"
+msgstr "不要把你的美味精液浪费在我身上。等着法莲娜回来，或者去吸安布尔的奶子。"
 
 #. Key:	44000BD74D084D5F4F4AD99708071613
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieHadSex01.Default__CassieHadSex01_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/Cassie/Default/CassieHadSex01.Default__CassieHadSex01_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",44000BD74D084D5F4F4AD99708071613"
 msgid "*Purr*"
-msgstr ""
+msgstr "*猫呼噜声*"
 
 #. Key:	442AA41044275C5F5330F99CF2ECE542
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_StartLifted.Default__ParvatiDefault01_StartLifted_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_StartLifted.Default__ParvatiDefault01_StartLifted_C.SessionData.Lines(0).Lines
 msgctxt ",442AA41044275C5F5330F99CF2ECE542"
 msgid "..."
-msgstr "。。。"
+msgstr "……"
 
 #. Key:	44A109FA42CB5758C411968173BA0B7F
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiStuck.Default__FesssiStuck_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiStuck.Default__FesssiStuck_C.SessionData.Lines(1).Lines
 msgctxt ",44A109FA42CB5758C411968173BA0B7F"
 msgid "My giant, but delicious ass, has been stuck in this cave for a long time. Hiss!"
-msgstr ""
+msgstr "我的巨大而且美味的屁股，已经被困在这个洞里很长时间了。嘶！"
 
 #. Key:	44ABED7740DE9FD12170D8B548E87A78
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(8).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(8).Lines
 msgctxt ",44ABED7740DE9FD12170D8B548E87A78"
 msgid "She assigned each world a special Seraphim, an archangel, to guide the evolution of life."
-msgstr ""
+msgstr "祂给每个世界分配了一个特殊的六翼天使，一个大天使，来引导生命的进化。"
 
 #. Key:	44BC09AE4BDFA439FBFD8BAABD7A96D0
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(25 - Value).TraitIcons.DisplayName
@@ -3742,7 +3743,7 @@ msgstr "你的翘臀饱满紧实，酥胸如此丰满…还有…噢~还有一�
 #: /Game/Dialogue/Fesssi/Default/FesssiHadSex01.Default__FesssiHadSex01_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",45593BFD42216BAC5309AAAB9A612E59"
 msgid "Bring that human pussy back to me soon."
-msgstr ""
+msgstr "尽快把那个人类的阴道带过来。"
 
 #. Key:	45B1E6E34C7DA1B37BDE04B204DC4C4B
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_RL.Default__MirruDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
@@ -3756,14 +3757,14 @@ msgstr "你是一名公主啊……"
 #: /Game/World/Overworld.Overworld:PersistentLevel.NekoCondo_1.ManageActionMessage
 msgctxt ",45DEB2444826198BC72D2197A3F25B05"
 msgid "Manage your Nekos"
-msgstr "管理你的猫猫人"
+msgstr "管理你的猫娘们"
 
 #. Key:	46018B7B49E8F91F3AB3B5A9002485B1
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleCentaur.Default__KybeleCentaur_C.SessionData.Lines(6).Lines
 #: /Game/Dialogue/Kybele/Default/KybeleCentaur.Default__KybeleCentaur_C.SessionData.Lines(6).Lines
 msgctxt ",46018B7B49E8F91F3AB3B5A9002485B1"
 msgid "External \"help\" is required, and you are looking tasty at the moment."
-msgstr ""
+msgstr "需要外部“帮助”，而且您现在看起来很美味。"
 
 #. Key:	464B0F3B450345A0F3EA8E98C67A5248
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(6).LinesToMale
@@ -3784,21 +3785,21 @@ msgstr "我母亲是一名可敬可爱的海妖，一名美丽而丰腴的海中
 #: /Game/Dialogue/Autumn/Default/DryadHadSex01.Default__DryadHadSex01_C.SessionData.Lines(0).Lines
 msgctxt ",46745F5D451EF7EB89BFE58F57B364E3"
 msgid "Look at the size of it!"
-msgstr ""
+msgstr "看看它的大小！"
 
 #. Key:	46C09FA14157EC1F3D6608BB30F25A60
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon2.Default__AmberMaeLockedDungeon2_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon2.Default__AmberMaeLockedDungeon2_C.SessionData.Lines(3).Lines
 msgctxt ",46C09FA14157EC1F3D6608BB30F25A60"
 msgid "Them townsfolk loved playing with 'mai soft body... *sigh*"
-msgstr ""
+msgstr "老乡他们都喜欢玩俺柔软的身体*叹息*"
 
 #. Key:	46D776EB4F6C6F71D802088F7C493A82
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToFuta(6).LinesToFuta
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToFuta(6).LinesToFuta
 msgctxt ",46D776EB4F6C6F71D802088F7C493A82"
 msgid "If that doesn't suit you, how about you feed me some of your delicious cum?"
-msgstr ""
+msgstr "如果这不和你意，不如你射给我吃点你的美味好嘛？"
 
 #. Key:	46DF2A6B40E2BC05DF3CD5879A17D834
 #. SourceLocation:	/Game/Characters/Procedural/Variants/Sylvan/Harvest/SylvanHarvest.Default__SylvanHarvest_C.Harvest.Description
@@ -3812,7 +3813,7 @@ msgstr "森之妖精体液"
 #: /Game/Dialogue/Fesssi/Default/FesssiIdiots.Default__FesssiIdiots_C.SessionData.Lines(4).Lines
 msgctxt ",46E1708442BF3BDBC5C555BB87A184A4"
 msgid "Maybe a team of vulwarg males... no they would just want blow jobs and then run away."
-msgstr ""
+msgstr "一队雄性狼人怎么样……不，他们只想要口交，满足后一溜烟就跑了"
 
 #. Key:	4713FDFD44B74E42186DE9AD0CAAEBC6
 #. SourceLocation:	/Game/Dialogue/Neela/SexScenes/NeelaSnakeCuddleF.Default__NeelaSnakeCuddleF_C.SessionData.Lines(3).Lines
@@ -3826,14 +3827,14 @@ msgstr "*舔舐*"
 #: /Game/Dialogue/Kybele/Default/KybeleDefault01_RL.Default__KybeleDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",473797F44055F2EA1A6BA1B748146FFF"
 msgid "Wow a centaur!"
-msgstr ""
+msgstr "哇！半人马！"
 
 #. Key:	47464D7B43F2BD56B082E8AB7F91F25E
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiHowLong.Default__FesssiHowLong_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiHowLong.Default__FesssiHowLong_C.SessionData.Lines(5).Lines
 msgctxt ",47464D7B43F2BD56B082E8AB7F91F25E"
 msgid "Damn those Cockblock Gates... we never asked for those. Imagine if the ancient builders of the world made something useful, like a spell to give futas a scrotum."
-msgstr ""
+msgstr "那些该死的鸡巴锁大门。。。我们从来不想要它们。想象一下，如果世界上的古代建设者设计建造了一些有用的东西，比如咒语赋予扶她蛋蛋。"
 
 #. Key:	47621D134EBA27E9FF0A6888F1D9CF3D
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernGreeting03.Default__FernGreeting03_C.SessionData.LinesToFemale(2).LinesToFemale
@@ -3854,7 +3855,7 @@ msgstr "给我看看你能建造什么"
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02_RL_F.Default__FernDefault02_RL_F_C.ResponseData(3).ResponseData.BreederPrompt
 msgctxt ",47C226CD43D2A9B28FA62BB961FB0FAE"
 msgid "You may have my breast milk!"
-msgstr "你可以喝我的牛奶！"
+msgstr "你可以用我的乳汁来灌溉自己了！"
 
 #. Key:	47D73C824ADC81BC6CCF3D92213FA9A5
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(29 - Value).TraitIcons.DisplayName
@@ -3875,7 +3876,7 @@ msgstr "哦，等等，我还没学到任何东西！"
 #: /Game/Dialogue/OrcChief/Default/OrcFixOwnGate.Default__OrcFixOwnGate_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",47F7DAF04C7F69F373B132BD8B955A76"
 msgid "*Snarl*"
-msgstr ""
+msgstr "*咆哮*"
 
 #. Key:	47FF727144E602154C40FFB1396CB921
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_RL.Default__FaleneDefault01_RL_C.ResponseData(5).ResponseData.BreederPrompt
@@ -3910,7 +3911,7 @@ msgstr "我们在交配过程中感受到的快感是……非常强烈的。强
 #: /Game/World/Overworld.Overworld:PersistentLevel.EM_HedonDungeonSwitch.BlockMessage
 msgctxt ",486FA5BE4745240DE60186BE36444829"
 msgid "The switch does not move."
-msgstr ""
+msgstr "开关没有任何动作"
 
 #. Key:	48A773D34A077935AE7A2FAD14F4A978
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryGreeting01.Default__EmissaryGreeting01_C.SessionData.Lines(6).Lines
@@ -3938,7 +3939,7 @@ msgstr "@BREEDER_NAME@. 吾已在此等候了汝许久。"
 #: /Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFemale(9).LinesToFemale
 msgctxt ",48EDBF874DED77CEE66F469303F265EB"
 msgid "I won't go near that temple, they will probably try and convert me, or make me inhale blue smoke."
-msgstr ""
+msgstr "我不会靠近那座寺庙，他们可能会试图让我皈依，或者让我吸入那些蓝烟。"
 
 #. Key:	48F333E347A7091F18F946AADDC3C69D
 #. SourceLocation:	/Game/Dialogue/Mirru/SexScenes/MirruKrakVag.Default__MirruKrakVag_C.SessionData.Lines(6).Lines
@@ -3959,14 +3960,14 @@ msgstr "而我也是其中之一！准确的来说我是一名收到至高女神
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_Teach.Default__ParvatiDefault01_Teach_C.SessionData.Lines(0).Lines
 msgctxt ",4954D9E748572866289FA785934950B8"
 msgid "Remove your garments, for you must be nude."
-msgstr ""
+msgstr "脱掉你的衣服，因为你必须赤忱相见。"
 
 #. Key:	49C2D0C2412EFE81B451C98459CA6027
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraGetKeystone.Default__PetraGetKeystone_C.SessionData.Lines(7).Lines
 #: /Game/Dialogue/Petra/Default/PetraGetKeystone.Default__PetraGetKeystone_C.SessionData.Lines(7).Lines
 msgctxt ",49C2D0C2412EFE81B451C98459CA6027"
 msgid "But then out of nowhere, a human shows up instead!"
-msgstr ""
+msgstr "但不知道从哪里钻出了一个人类！"
 
 #. Key:	49C9E46943998C63648E12A033938266
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(9 - Value).TraitIcons.DisplayName
@@ -3987,14 +3988,14 @@ msgstr "..."
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeHadSex01.Default__MegaSlimeHadSex01_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",4A37F933461F6E0CC65A6D82757FB764"
 msgid "Wow that felt so good!"
-msgstr ""
+msgstr "哇哦，那简直爽毙了！"
 
 #. Key:	4A730CFD4FE7937D823362B706A236A2
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_EnlightenedOne.Default__NeelaDefault01_EnlightenedOne_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_EnlightenedOne.Default__NeelaDefault01_EnlightenedOne_C.SessionData.Lines(1).Lines
 msgctxt ",4A730CFD4FE7937D823362B706A236A2"
 msgid "Her name is Pawsmaati, a blessed Neko in Sultry Plateau."
-msgstr ""
+msgstr "她的名字叫帕斯玛媞，是潮热高原上一位受祝福的猫娘"
 
 #. Key:	4A786E0642F65E2541EAB4BB64AD2628
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_RL_M.Default__FernDefault02_RL_M_C.ResponseData(1).ResponseData.BreederPrompt
@@ -4008,7 +4009,7 @@ msgstr "你不一样了！"
 #: /Game/World/Overworld.Overworld:PersistentLevel.CBGate_Crag.BlockMessage
 msgctxt ",4A8B6F014E313E51F87D8C8706BE28E3"
 msgid "Webs block this gate."
-msgstr ""
+msgstr "蛛网把这个大门封住了。"
 
 #. Key:	4A8BADCE4B9CDED5FAF83F9E2C212E8C
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToMale(0).LinesToMale
@@ -4022,7 +4023,7 @@ msgstr "唔，我可以考虑赐予你进入的权限……但我需要一点儿
 #: /Game/Dialogue/Mirru/SexScenes/MirruSnatchT.Default__MirruSnatchT_C.SessionData.Lines(4).Lines
 msgctxt ",4AA8E4C347C6877955982195612DC01D"
 msgid "This pleases me greatly... ahhhh."
-msgstr "这实在太令我愉悦了……啊呀……"
+msgstr "这实在太令我愉悦了……哎~呀……"
 
 #. Key:	4AD3767B435A26CAE69202B605CB1776
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03_RL_F.Default__FernDefault03_RL_F_C.ResponseData(2).ResponseData.BreederPrompt
@@ -4043,7 +4044,7 @@ msgstr "欲望正如流水，变动不居"
 #: /Game/Dialogue/Camilla/Default/CamillaFaleneWeek.Default__CamillaFaleneWeek_C.SessionData.Lines(1).Lines
 msgctxt ",4AF4F6C44BC706495A6BC1910F5EB035"
 msgid "Which is nothing more than an excuse to have sex with everything in sight while I do all the work!!"
-msgstr ""
+msgstr "这只不过是一个借口，在我做所有工作的时候，我可以和眼前的一切做爱!!"
 
 #. Key:	4AF6D7774E005B4FEFEFBD91CE5F5322
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01_RL_T.Default__FernDefault01_RL_T_C.ResponseData(4).ResponseData.BreederPrompt
@@ -4057,7 +4058,7 @@ msgstr "你可以用我的乳汁滋润自己了！"
 #: /Game/Dialogue/Petra/Default/PetraGetKeystone.Default__PetraGetKeystone_C.SessionData.Lines(9).Lines
 msgctxt ",4B400F8545DB288AE092E39BA2CD24BF"
 msgid "If you can find me a succubus, I will get that keystone for you."
-msgstr ""
+msgstr "如果你帮我找到一只魅魔，我会帮你拿到那个钥石的。"
 
 #. Key:	4B96D56447562EBC8748929A5D3B51FD
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernGreeting02.Default__FernGreeting02_C.SessionData.LinesToFuta(3).LinesToFuta
@@ -4085,49 +4086,49 @@ msgstr "你可真是个性感的紫色尤物！"
 #: /Game/Dialogue/QueenBee/Default/BeeUhNo.Default__BeeUhNo_C.SessionData.Lines(1).Lines
 msgctxt ",4BCD2C0947A04AB07ED274984B39E519"
 msgid "I ought to punish you, but... ohhh! As you can see, I'm busy."
-msgstr ""
+msgstr "我应该给你点颜色看看，但是……哦！如你所见，我太忙了。"
 
 #. Key:	4BEA745E46427D48E9DB48A470FF3A40
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadFatAssLamia.Default__DryadFatAssLamia_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Autumn/Default/DryadFatAssLamia.Default__DryadFatAssLamia_C.SessionData.Lines(4).Lines
 msgctxt ",4BEA745E46427D48E9DB48A470FF3A40"
 msgid "From that moment on I was fixed on her... I wanted to please her in ways I never before considered."
-msgstr ""
+msgstr "从那一刻起我就盯着她……我想以我从未想过的方式取悦她。"
 
 #. Key:	4C00C7F544226DAA1CBB4781B0CEB82F
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(3).Lines
 msgctxt ",4C00C7F544226DAA1CBB4781B0CEB82F"
 msgid "Aye, 'mai specialty is all things milk, and a quare good pair on me front. Bless me, hav'n jugs like these can really hurt 'mai back!"
-msgstr "害，俺的专长是研究各种奶，和俺身上顶着的这对怪玩意儿。保佑俺吧，有这样的大咪咪真的很伤俺的背！"
+msgstr "是呀，俺的特长是研究各种奶，和俺身上顶着的这对大酒桶。保佑俺吧，有这样的大咪咪真的很伤俺的背！"
 
 #. Key:	4C1E56854BDDE954FC7ACA99874AB4C3
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaHadSex02.Default__CamillaHadSex02_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/Camilla/Default/CamillaHadSex02.Default__CamillaHadSex02_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",4C1E56854BDDE954FC7ACA99874AB4C3"
 msgid "This little body experienced a lot of pleasure..."
-msgstr ""
+msgstr "这具小小的身体经历了很多愉悦……"
 
 #. Key:	4C58896E4C9EC24AD95FD9B3C5846453
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiDefault02_RL.Default__FesssiDefault02_RL_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/Fesssi/Default/FesssiDefault02_RL.Default__FesssiDefault02_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",4C58896E4C9EC24AD95FD9B3C5846453"
 msgid "But... you're stuck."
-msgstr ""
+msgstr "但是……你卡住了"
 
 #. Key:	4CC5D673471A3B46D285D681BCAEC1A8
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraPracticeMe.Default__PetraPracticeMe_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Petra/Default/PetraPracticeMe.Default__PetraPracticeMe_C.SessionData.Lines(2).Lines
 msgctxt ",4CC5D673471A3B46D285D681BCAEC1A8"
 msgid "Ahhh... yes! Well what are you waiting for?"
-msgstr ""
+msgstr "啊……没错！好吧，那你还在等什么？"
 
 #. Key:	4CEEC1684CDAEA938B302F89B5DCC6FD
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiCave.Default__FesssiCave_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiCave.Default__FesssiCave_C.SessionData.Lines(2).Lines
 msgctxt ",4CEEC1684CDAEA938B302F89B5DCC6FD"
 msgid "You won't find seraphim and elves down there... no. Goblins, bats, and spiders are more likely."
-msgstr ""
+msgstr "你在下面找不到六翼天使和精灵们的……不。更可能是哥布林、蝙蝠和蜘蛛吧。”"
 
 #. Key:	4D0B9DAB42EF8CA84E014A8298104E74
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_UpHere.Default__RomyDefault01_UpHere_C.SessionData.Lines(4).Lines
@@ -4141,7 +4142,7 @@ msgstr "这一切只有至高女神能给你答案。可惜啊，我不能去听
 #: /Game/Dialogue/Kybele/Default/KybeleCentaur.Default__KybeleCentaur_C.SessionData.Lines(1).Lines
 msgctxt ",4D14F6284D4722E3384EB5A50BDD7ACC"
 msgid "You would do well to turn around and leave the dragons alone."
-msgstr ""
+msgstr "你最好转过身去，别去惹那些龙。"
 
 #. Key:	4DA62EBE4FE5CCF8694322AA22E38C1D
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R04.Default__FaleneDefault01_R04_C.SessionData.Lines(12).Lines
@@ -4155,7 +4156,7 @@ msgstr "我们喜欢创造新的魔弗灵，这样他们就也能体验到这个
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R07_RL.Default__CamillaDefault01_R07_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",4DE4EDAD457F0C2715629B82E07D5D91"
 msgid "Oh come here you lovable shortstack!"
-msgstr "哦，过来，你这个可爱的嫩草!"
+msgstr "哦，过来，你这个可爱的小丫头!"
 
 #. Key:	4E12D93143928EAE2221E7A3621657C0
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R01.Default__FaleneDefault01_R01_C.SessionData.Lines(8).Lines
@@ -4169,14 +4170,14 @@ msgstr "我的假说是，当魔弗灵精子与卵子结合，它们破坏了时
 #: /Game/Dialogue/AmberMae/Default/AmberMaeDefault01_RL.Default__AmberMaeDefault01_RL_C.ResponseData(3).ResponseData.BreederPrompt
 msgctxt ",4E27E33747B868644B436C9F77707525"
 msgid "May I suck on your jugs?"
-msgstr "我可以吸你的咪咪么？"
+msgstr "我可以吸你的'大酒桶'么？"
 
 #. Key:	4E36B8A545FB7E25EE044C834B5EFC4D
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernHadSex02.Default__FernHadSex02_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Fern/DefaultP2/FernHadSex02.Default__FernHadSex02_C.SessionData.Lines(0).Lines
 msgctxt ",4E36B8A545FB7E25EE044C834B5EFC4D"
 msgid "Mmmm... mastah tasty!"
-msgstr ""
+msgstr "恩，主银，好喝！"
 
 #. Key:	4E498E254A8B38B0C2BC51A386589A62
 #. SourceLocation:	/Game/Dialogue/Leylanna/SexScenes/LeylannaLeyCov.Default__LeylannaLeyCov_C.SessionData.LinesToFemale(0).LinesToFemale
@@ -4190,14 +4191,14 @@ msgstr "你就乖乖躺好然后放松吧@BREEDER_NAME@..."
 #: /Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToMale(8).LinesToMale
 msgctxt ",4E52974540DE6960CB56CDB713C76A05"
 msgid "That must have been you, perhaps you should go and talk to her."
-msgstr ""
+msgstr "那一定是你，也许你应该去和她好好谈谈。"
 
 #. Key:	4E5BBE2D466F692CEB63ACA293C411A8
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruHadSex01.Default__MirruHadSex01_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/Mirru/Default/MirruHadSex01.Default__MirruHadSex01_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",4E5BBE2D466F692CEB63ACA293C411A8"
 msgid "You have satisfied a kraken princess, and allowed me to release my lust."
-msgstr ""
+msgstr "你居然满足了一个海怪公主，让我释放了我的欲望。"
 
 #. Key:	4E7910C949370E1A22F20886B7F19689
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryBlessedInquiry01_RL.Default__EmissaryBlessedInquiry01_RL_C.ResponseData(0).ResponseData.BreederPrompt
@@ -4218,7 +4219,7 @@ msgstr "他们让我清洗他们身体的每一个角落，我很享受……非
 #: /Game/Dialogue/Fesssi/Default/FesssiDefault03_RL_F.Default__FesssiDefault03_RL_F_C.ResponseData(3).ResponseData.BreederPrompt
 msgctxt ",4E7C9B4743337D054AE863AB4EAF155F"
 msgid "You can stick that tongue in me..."
-msgstr ""
+msgstr "你可以把舌头伸进来……"
 
 #. Key:	4E899A5D4E84988C4EA22C94596B1177
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_YourMusic.Default__RomyDefault01_YourMusic_C.SessionData.LinesToFemale(2).LinesToFemale
@@ -4239,7 +4240,7 @@ msgstr "你能为我做什么?"
 #: /Game/Dialogue/Autumn/Default/DryadBossomCherries.Default__DryadBossomCherries_C.SessionData.Lines(2).Lines
 msgctxt ",4EBD4351412C922E0D1B4DAE8A11ABC7"
 msgid "It's not uncommon for a single Ayrshire to eat ten bosom cherries in a single day."
-msgstr ""
+msgstr "一个埃尔郡人一天吃十颗乳房樱桃是很平常的事。"
 
 #. Key:	4F17407F4C735CA48643138A59606A3C
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01.Default__FernDefault01_C.SessionData.Lines(2).Lines
@@ -4260,14 +4261,14 @@ msgstr "*吮吸，舔*"
 #: /Game/Dialogue/Autumn/Default/DryadGreeting01.Default__DryadGreeting01_C.SessionData.Lines(1).Lines
 msgctxt ",4F3471C54B27DDD9BC7D5F8A12D1E871"
 msgid "Soft and plump, with many a bump."
-msgstr ""
+msgstr "柔软丰满，有许多激凸"
 
 #. Key:	4F37D08C43E11EDF706D07998D86692F
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyHadSex01.Default__RomyHadSex01_C.SessionData.LinesGrungy(0).LinesGrungy
 #: /Game/Dialogue/Romy/Default/RomyHadSex01.Default__RomyHadSex01_C.SessionData.LinesGrungy(0).LinesGrungy
 msgctxt ",4F37D08C43E11EDF706D07998D86692F"
 msgid "Oh you dirty dirty human... what have you done to yourself?"
-msgstr ""
+msgstr "哦，你这个脏兮兮的人类。。。你对自己做了些什么？"
 
 #. Key:	4F601DAA48F980A712CFA1A4888DDCBC
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToFuta(2).LinesToFuta
@@ -4281,7 +4282,7 @@ msgstr "我几乎见识过了所有魔弗灵引以为傲的家伙们。"
 #: /Game/Dialogue/QueenBee/Default/BeeDefault01.Default__BeeDefault01_C.SessionData.LinesToFuta(0).LinesToFuta
 msgctxt ",4F85128C485261E5971763A5F3E5C2A7"
 msgid "This corner is n-n-nice and safe!"
-msgstr ""
+msgstr "这个角落又安全又……又……棒！"
 
 #. Key:	4F926E9345E810F3C912438E56312AC9
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaGreeting01.Default__LeylannaGreeting01_C.SessionData.Lines(2).Lines
@@ -4295,7 +4296,7 @@ msgstr "是了……你的名字是@BREEDER_NAME@。魂灵向我传达着这一�
 #: /Game/Dialogue/Widow/Default/WidowSpiders.Default__WidowSpiders_C.SessionData.Lines(1).Lines
 msgctxt ",4FA58F3643C40D88119D81857F7F6815"
 msgid "We are reclusive cavern dwellers, and once a home is found it's not uncommon for us to stay there for many years."
-msgstr ""
+msgstr "我们是隐居的穴居者，一旦找到一个家，我们就会在那里待上很多年。"
 
 #. Key:	4FC454FA455E4284639DF9A235A1B888
 #. SourceLocation:	/Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToFuta(4).LinesToFuta
@@ -4323,21 +4324,21 @@ msgstr "咕……呵呵呵……我得控制一下自己！"
 #: /Game/Dialogue/QueenBee/Default/BeeDefault01.Default__BeeDefault01_C.SessionData.LinesToFuta(1).LinesToFuta
 msgctxt ",502599044F833B4F276595B3EAD343C5"
 msgid "Soon my nectar collection will be complete, and I can return to the Hivelands."
-msgstr ""
+msgstr "很快我的花蜜收集工作就要完成了，我可以回到蜂巢大地了。"
 
 #. Key:	5045176546DDF08434B08ABE881B84B8
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraAboutPawsmaati.Default__PetraAboutPawsmaati_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Petra/Default/PetraAboutPawsmaati.Default__PetraAboutPawsmaati_C.SessionData.Lines(4).Lines
 msgctxt ",5045176546DDF08434B08ABE881B84B8"
 msgid "For me, Pawsmaati decided to manifest a large cock. It felt so good as she thrust it deep inside me..."
-msgstr ""
+msgstr "对我来说，帕丝玛媞决定变出了一个大鸡巴。当她把它插进我的身体时，简直爽哭了……"
 
 #. Key:	5075655C40C6B014FB7A99AE08709576
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_RL.Default__MirruDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_RL.Default__MirruDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",5075655C40C6B014FB7A99AE08709576"
 msgid "Tell me about Krakens."
-msgstr "给我介绍下海妖族吧。"
+msgstr "跟我说说克拉肯一族吧。"
 
 #. Key:	5091F30244DD52A6CED9788A1B9B6A79
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_Princess.Default__MirruDefault01_Princess_C.SessionData.Lines(6).Lines
@@ -4365,7 +4366,7 @@ msgstr "光滑的"
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",50E84BD14AFF02C2DD65798A8386C0FE"
 msgid "When enough semen accumulates, usually in water, there is a chance for it to turn into a slime."
-msgstr ""
+msgstr "当精液积累到一定数量(通常是在水中)时，它就有可能变成黏液。"
 
 #. Key:	51444A264763D03D8B5051AEDAB55B5F
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(32 - Value).TraitIcons.HelpText
@@ -4379,14 +4380,14 @@ msgstr "令人反感：该个体是近亲繁殖的产物"
 #: /Game/Dialogue/Monarch/Default/MonarchQueen.Default__MonarchQueen_C.SessionData.Lines(0).Lines
 msgctxt ",51891BB34DD1356F61B02FB5FE4F3636"
 msgid "Yes, t-t-the magestic queen bee of Hivelands. All insect @MONSTER_RACE@ serve her."
-msgstr ""
+msgstr "是的，蜂…蜂…蜂巢大地有魔力的蜂后。所有的昆虫都为她服务"
 
 #. Key:	51B5762D4545FEE2F7E8D895B66B031B
 #. SourceLocation:	/Game/Ranch/Upgrades/BovaurShed.Default__BovaurShed_C.Upgrade.Description
 #: /Game/Ranch/Upgrades/BovaurShed.Default__BovaurShed_C.Upgrade.Description
 msgctxt ",51B5762D4545FEE2F7E8D895B66B031B"
 msgid "This allows you to catch and store all variants of Bovaur."
-msgstr "这将允许你捕获以及储存所有的奶牛人"
+msgstr "这将允许你捕获以及储存所有的奶牛族人"
 
 #. Key:	51CEBDA94681ACB09279C2A598681796
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_YourMusic_ToneDeaf.Default__RomyDefault01_YourMusic_ToneDeaf_C.SessionData.Lines(1).Lines
@@ -4400,7 +4401,7 @@ msgstr "如果你想好了记得回来找我"
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R07.Default__CamillaDefault01_R07_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",51E33E8544C5A1055CF34EA764D9E53C"
 msgid "Amber's tits are bigger than me! Why is this world so cruel..."
-msgstr "安布尔的胸部比我大!为什么这个世界如此残酷……"
+msgstr "为什么安布尔的胸部比我大!这个世界太残酷了……"
 
 #. Key:	51FAB478484E006C8F04E28F37E5D4D3
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_StartRCowgirl.Default__ParvatiDefault01_StartRCowgirl_C.SessionData.Lines(0).Lines
@@ -4442,7 +4443,7 @@ msgstr "*吮吸 吮吸*"
 #: /Game/Dialogue/Widow/Default/WidowTaskFullfilled2.Default__WidowTaskFullfilled2_C.SessionData.Lines(3).Lines
 msgctxt ",52FA782943DCF1904C31D0AD39452FE2"
 msgid "Please take the glowing rock on your way out. I feel the hunger creeping up, and my elf is looking full and ready."
-msgstr ""
+msgstr "出去的时候请带上那块发光的石头。我感到饥渴在疯涨，我的精灵看起来已经准备好了。"
 
 #. Key:	53133AE5461CD4363425BC8B9E8327F4
 #. SourceLocation:	/Game/Dialogue/Emissary/SexScenes/EmissaryAngelGroinLove.Default__EmissaryAngelGroinLove_C.SessionData.LinesToFemale(0).LinesToFemale
@@ -4456,7 +4457,7 @@ msgstr "纵享这一切吧，因为吾侍服于汝。"
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_RL.Default__CamillaDefault01_RL_C.ResponseData(6).ResponseData.BreederPrompt
 msgctxt ",535696214ED031B7F34A458925D0CEA8"
 msgid "Falene brings you stuff?"
-msgstr ""
+msgstr "法莲娜捎给你什么东西了？"
 
 #. Key:	537B245D4CBB8BD28882D3AB47480EA4
 #. SourceLocation:	/Game/Dialogue/Fern/SexScenes/FernCum_01.Default__FernCum_01_C.SessionData.Lines(1).Lines
@@ -4470,7 +4471,7 @@ msgstr "*吮吸 吮吸*"
 #: /Game/Dialogue/Fern/DefaultP3/FernHadSex03.Default__FernHadSex03_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",53B2E09F4A5C770431651A9B727EA17D"
 msgid "Ahhh... I have never felt so good!"
-msgstr ""
+msgstr "噢……我从没感觉那么爽过！"
 
 #. Key:	53D49D34442BE0C5E4A971957D2298CD
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_StartLapDance.Default__ParvatiDefault01_StartLapDance_C.SessionData.Lines(0).Lines
@@ -4498,21 +4499,21 @@ msgstr "小蕨希望主人被小蕨侍弄的非常舒服嘶~"
 #: /Game/Dialogue/AmberMae/Default/AmberMaeSuckJugs_Cancel.Default__AmberMaeSuckJugs_Cancel_C.SessionData.Lines(0).Lines
 msgctxt ",5477799C4F9B5398BECB918C51B6CC44"
 msgid "Forgive me if I was com'n on too strong! I hope I didn't offend ye..."
-msgstr "如果俺太冲撞尼一定要原谅俺！希望俺没有冒犯到尼…"
+msgstr "如果俺太粗鲁了尼一定要原谅俺！希望俺没有冒犯到尼…"
 
 #. Key:	5487409C445EEB5B2C699C8A5253DD30
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFemale(2).LinesToFemale
 #: /Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",5487409C445EEB5B2C699C8A5253DD30"
 msgid "Perhaps you would like a taste of my sparkly elf pussy?"
-msgstr ""
+msgstr "也许你想尝尝我闪亮精灵的阴部?"
 
 #. Key:	5499C216450B8D38D1D5E48EAB4EAE1A
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeGreeting01.Default__MegaSlimeGreeting01_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeGreeting01.Default__MegaSlimeGreeting01_C.SessionData.Lines(3).Lines
 msgctxt ",5499C216450B8D38D1D5E48EAB4EAE1A"
 msgid "Do you want to meet my best friend?"
-msgstr ""
+msgstr "你想要认识一下我最好的朋友吗？"
 
 #. Key:	54A656CF43AE3DD98B149D8CB0E836B1
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R02.Default__FaleneDefault01_R02_C.SessionData.Lines(4).Lines
@@ -4526,21 +4527,21 @@ msgstr "这很令人沮丧，我甚至想不起来我是如何来到这里的，
 #: /Game/Dialogue/OrcChief/Default/OrcFixOwnGate.Default__OrcFixOwnGate_C.SessionData.LinesToFuta(3).LinesToFuta
 msgctxt ",54C74A434002CAD60426198FDDCF4B82"
 msgid "Human fix gate now, or your cock is mine!"
-msgstr ""
+msgstr "人类 修理门现在，不然你的鸡巴就是我的了！"
 
 #. Key:	550D874045EED9CAB4096BB51CD7C32A
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowSpiders.Default__WidowSpiders_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Widow/Default/WidowSpiders.Default__WidowSpiders_C.SessionData.Lines(2).Lines
 msgctxt ",550D874045EED9CAB4096BB51CD7C32A"
 msgid "Patiently we will wait for our mates to come to us... this world is full of lumbering morons oozing with delicious fluids."
-msgstr ""
+msgstr "我们会耐心地等待我们的同伴来找我们……这世界上到处都是浑身都是美味的液体却笨手笨脚的小笨蛋们。"
 
 #. Key:	554D996445578E57126935A57AEBB8F3
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_R03.Default__FernDefault02_R03_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02_R03.Default__FernDefault02_R03_C.SessionData.Lines(0).Lines
 msgctxt ",554D996445578E57126935A57AEBB8F3"
 msgid "Oh Master... you are too good to me."
-msgstr "oh，主人...你对我太好了。"
+msgstr "oh，主人...您对我太好了。"
 
 #. Key:	554F10F14C2C753407F470A787D584FB
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(16).LinesToMale
@@ -4561,7 +4562,7 @@ msgstr "狼人"
 #: /Game/Dialogue/QueenBee/Default/BeeHaveKeystone.Default__BeeHaveKeystone_C.SessionData.Lines(6).Lines
 msgctxt ",558508384A3AD98E8ACC849F53F551A9"
 msgid "Everyone wanted \"personal time\" with me, and it was glorious."
-msgstr ""
+msgstr "每个人都想和我有'私人时间'，这真是太棒了。"
 
 #. Key:	55894A674E5C647D1DC14EB1951CE50D
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(20 - Value).TraitIcons.HelpText
@@ -4575,7 +4576,7 @@ msgstr "虐待狂：降低配种对象的忠诚度，自身获得双倍经验"
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePlay.Default__MegaSlimePlay_C.SessionData.LinesToFuta(1).LinesToFuta
 msgctxt ",55BACC2142DFD6EE2C302A860E4A23FF"
 msgid "You will feel so good as I milk your cock for all of its delicious semen..."
-msgstr ""
+msgstr "你会感觉很好，因为我为你的大鸡鸡挤出了所有美味的精液…"
 
 #. Key:	55DE769C4C259F81CB55299E36998DA3
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyGreeting01.Default__RomyGreeting01_C.SessionData.LinesGrungy(4).LinesGrungy
@@ -4589,14 +4590,14 @@ msgstr "褪去你的衣服，然后让我来把你洗干净"
 #: /Game/Dialogue/Petra/Default/PetraHadSex01.Default__PetraHadSex01_C.SessionData.Lines(1).Lines
 msgctxt ",55F0F60A4D567468043EF687B0A22338"
 msgid "You made me feel so good human. We should \"practice\" again sometime!"
-msgstr ""
+msgstr "你让我爽翻了，人类！我们应该什么时候再'练习一下'！"
 
 #. Key:	560A29014AB558719DDBF6ABAA67FA3F
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeHadSex01.Default__MegaSlimeHadSex01_C.SessionData.LinesToFemale(5).LinesToFemale
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeHadSex01.Default__MegaSlimeHadSex01_C.SessionData.LinesToFemale(5).LinesToFemale
 msgctxt ",560A29014AB558719DDBF6ABAA67FA3F"
 msgid "*Yawn*"
-msgstr ""
+msgstr "打哈欠"
 
 #. Key:	560FCF68432946FE1C6D7BA2F8088AB6
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TravelShrines(0 - Value).TravelShrines.ShrineName
@@ -4610,35 +4611,35 @@ msgstr "落红断崖"
 #: /Game/Dialogue/Fesssi/Default/FesssiWantTongue.Default__FesssiWantTongue_C.SessionData.Lines(1).Lines
 msgctxt ",56130E5B431626086919BFB37E7FA460"
 msgid "I would never pass up a chance to taste the depths of human pussy."
-msgstr ""
+msgstr "我绝不会错过品尝人类阴道深处的机会。"
 
 #. Key:	5624D94B49EF02787D13EDAFB71F472A
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToFemale(5).LinesToFemale
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToFemale(5).LinesToFemale
 msgctxt ",5624D94B49EF02787D13EDAFB71F472A"
 msgid "Ohhh... would you please this old warden? It is a lonely life..."
-msgstr "噢，你就满足我这个可怜的老守卫吧……我的命途真是太过漫长而孤独了……"
+msgstr "噢，你就满足我这个可怜的老守卫吧……我的命途真是太过漫长而寂寞了……"
 
 #. Key:	562919BA4DDFB552659A82ABD2D238A1
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_AboutLamias.Default__NeelaDefault01_AboutLamias_C.SessionData.Lines(6).Lines
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_AboutLamias.Default__NeelaDefault01_AboutLamias_C.SessionData.Lines(6).Lines
 msgctxt ",562919BA4DDFB552659A82ABD2D238A1"
 msgid "Her name is Apopha Fesssi. Come to think of it... I haven't seen her in years."
-msgstr ""
+msgstr "她的名字叫阿波法·菲希。我想想……我好多年没见过她了。"
 
 #. Key:	5629D6AE4A1B8ABE39599596DC46FC1C
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(16).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(16).Lines
 msgctxt ",5629D6AE4A1B8ABE39599596DC46FC1C"
 msgid "She took pity on their creations and made love with them, an event that would come to be known as the Great Conception."
-msgstr ""
+msgstr "祂同情他们的创作，和他们做爱，这一事件后来被称为“伟大受孕”。"
 
 #. Key:	566D4E2B458FC3277E49CB91D5CAB649
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_Daze.Default__EmissaryDefault01_Daze_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_Daze.Default__EmissaryDefault01_Daze_C.SessionData.Lines(2).Lines
 msgctxt ",566D4E2B458FC3277E49CB91D5CAB649"
 msgid "Then, the dark reaper of the daze will bring back to that body your awareness."
-msgstr ""
+msgstr "然后，发呆的黑暗死神将把你的意识带回你的身体。"
 
 #. Key:	567F4EF7487947546DDFE3B0195DFDEB
 #. SourceLocation:	/Game/Dialogue/Neela/SexScenes/NeelaSnakeCuddleF.Default__NeelaSnakeCuddleF_C.SessionData.Lines(0).Lines
@@ -4652,14 +4653,14 @@ msgstr "真是美味的人类小穴……噢……"
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault02.Default__EmissaryDefault02_C.SessionData.Lines(3).Lines
 msgctxt ",569794004A0E468573BC3689623AE387"
 msgid "Why the Goddess felt the need to create such worthless lifeforms puzzles me."
-msgstr ""
+msgstr "为什么女神觉得有必要创造这种毫无价值的生命形式令我困惑。"
 
 #. Key:	577526BD4B68AFD89F753E8F9023A937
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMHadSex01.Default__DMHadSex01_C.SessionData.LinesToFuta(1).LinesToFuta
 #: /Game/Dialogue/DragonMatriarch/Default/DMHadSex01.Default__DMHadSex01_C.SessionData.LinesToFuta(1).LinesToFuta
 msgctxt ",577526BD4B68AFD89F753E8F9023A937"
 msgid "Somehow your little cock made me feel amazing."
-msgstr ""
+msgstr "不知怎么的，你的小弟弟让我感觉很棒。"
 
 #. Key:	57759F684D98A4E1D01E469878BF79D9
 #. SourceLocation:	/Game/Dialogue/Neela/SexScenes/NeelaSnakeCuddleT.Default__NeelaSnakeCuddleT_C.SessionData.Lines(2).Lines
@@ -4673,21 +4674,21 @@ msgstr "*满足的呻吟*"
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeHowLong.Default__MegaSlimeHowLong_C.SessionData.Lines(1).Lines
 msgctxt ",57C253374563B35B8FD5A2A79361E4CA"
 msgid "Once they built the new temple above, people stopped coming here to play with me."
-msgstr ""
+msgstr "自从他们在上面建了新的圣殿，人们就不再来这里和我玩了。"
 
 #. Key:	586C9720448CC48985AE2E8FA3546D05
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchHaveKeystone2.Default__MonarchHaveKeystone2_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Monarch/Default/MonarchHaveKeystone2.Default__MonarchHaveKeystone2_C.SessionData.Lines(1).Lines
 msgctxt ",586C9720448CC48985AE2E8FA3546D05"
 msgid "I will remove the h-h-honeycomb from the Hivelands gate."
-msgstr ""
+msgstr "我要把蜂…蜂……蜂巢从蜂巢大地的大门上拆下来。"
 
 #. Key:	5881DC0E4C70AE1F56EE70A7C1A4A78A
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon.Default__AmberMaeLockedDungeon_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon.Default__AmberMaeLockedDungeon_C.SessionData.Lines(5).Lines
 msgctxt ",5881DC0E4C70AE1F56EE70A7C1A4A78A"
 msgid "Yer ask'n the wrong lass though, I'm just a simple milkmaid."
-msgstr ""
+msgstr "尼问错人了，俺只是个普通的挤奶女工。"
 
 #. Key:	589C39424192EF623DC606AE1E6D2D75
 #. SourceLocation:	/Game/Ranch/Upgrades/DemonPool.Default__DemonPool_C.Upgrade.DisplayName
@@ -4701,21 +4702,21 @@ msgstr "恶魔池"
 #: /Game/Dialogue/Fern/Default/FernBeeFlowers.Default__FernBeeFlowers_C.SessionData.Lines(1).Lines
 msgctxt ",58A8C4EA402471CFC5C6DF9121D86086"
 msgid "..."
-msgstr ""
+msgstr "……"
 
 #. Key:	58BD8EB444FFAA62E1DB458F4B2C10DC
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadFatAssLamia.Default__DryadFatAssLamia_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Autumn/Default/DryadFatAssLamia.Default__DryadFatAssLamia_C.SessionData.Lines(0).Lines
 msgctxt ",58BD8EB444FFAA62E1DB458F4B2C10DC"
 msgid "Oh Fesssi! She's so cute."
-msgstr ""
+msgstr "哦，菲希！她超漂亮的！"
 
 #. Key:	58D1FC2449F60C6958E9A78371E3450A
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimePlay1.Default__MegaSlimePlay1_C.SessionData.LinesToFuta(4).LinesToFuta
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePlay1.Default__MegaSlimePlay1_C.SessionData.LinesToFuta(4).LinesToFuta
 msgctxt ",58D1FC2449F60C6958E9A78371E3450A"
 msgid "I'm going to eat all of it and make lots of new slime..."
-msgstr ""
+msgstr "我要把它们全部吞下，然后制造很多新的黏液……"
 
 #. Key:	58E0621949B1FDAFBD7C18B246C16918
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeSuckJugs_RL.Default__AmberMaeSuckJugs_RL_C.ResponseData(0).ResponseData.BreederPrompt
@@ -4736,14 +4737,14 @@ msgstr "你想呀人类，扶她不需要它们。"
 #: /Game/Dialogue/OrcChief/Default/OrcFixOwnGate.Default__OrcFixOwnGate_C.SessionData.LinesToFemale(4).LinesToFemale
 msgctxt ",5948418C46289A7006EC59860F4A1739"
 msgid "You get giant load of cum until chieftain satisfied!"
-msgstr ""
+msgstr "你会得到大量的精液直到酋长满意为止!"
 
 #. Key:	59A830904A9DC04A6B7B1CB5E274E11A
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleAnyMeans_RL.Default__KybeleAnyMeans_RL_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/Kybele/Default/KybeleAnyMeans_RL.Default__KybeleAnyMeans_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",59A830904A9DC04A6B7B1CB5E274E11A"
 msgid "I will be leaving now..."
-msgstr ""
+msgstr "我要走了……"
 
 #. Key:	59AE8221430C7DB9A85B7BB2B4663795
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01.Default__EmissaryDefault01_C.SessionData.Lines(0).Lines
@@ -4771,7 +4772,7 @@ msgstr "与圣殿天使的盟誓是什么？"
 #: /Game/Dialogue/Neela/SexScenes/NeelaSnakeCuddleF.Default__NeelaSnakeCuddleF_C.SessionData.Lines(2).Lines
 msgctxt ",59EF8E454FA9D93BA790BF92B0EE3873"
 msgid "Ahh... my Lamia tongue will make you feel so good..."
-msgstr "我的舌头会让你爽到翻白眼的！"
+msgstr "我拉米娅的舌头会让你爽到翻白眼的！"
 
 #. Key:	5A3E7C5348B9CE872B1AC68AF9AEF76B
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(27 - Value).TraitIcons.HelpText
@@ -4792,7 +4793,7 @@ msgstr "*啧吮 舔舐*"
 #: /Game/Dialogue/Cassie/Default/CassieHadSex01.Default__CassieHadSex01_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",5A9731DD46A8ADC8650FC7A682C0D08C"
 msgid "You're going to have lots of cute kittens with how much love butter I gave you!!!"
-msgstr ""
+msgstr "有了我给你的爱黄油，你会拥有很多可爱的小猫咪的!!！"
 
 #. Key:	5AA0883E43DAD4AAE0EF269EA3233B0A
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_RL.Default__ParvatiDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
@@ -4806,7 +4807,7 @@ msgstr "请教导我新的体位！"
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(6).Lines
 msgctxt ",5AA8E62541EFA61D3ED30CAD3E1D0946"
 msgid "Demons crawled out of the darkness, and immediately started having sex with the Seraphim."
-msgstr ""
+msgstr "恶魔们从黑暗中爬出来，立刻开始和六翼天使做爱"
 
 #. Key:	5ACEB47B4DC474437836D1BE5DF53CC7
 #. SourceLocation:	/Game/Dialogue/Blossom/Default/BlossomDefault01_RL_F.Default__BlossomDefault01_RL_F_C.ResponseData(1).ResponseData.BreederPrompt
@@ -4820,35 +4821,35 @@ msgstr "小蕨！你的花说话了！！"
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToFuta(7).LinesToFuta
 msgctxt ",5AEA5C7F4EB5E13F37FC0C9552530212"
 msgid "I want to feel warm human cum course through me!"
-msgstr "我十分渴望人类的精液灌进我的身体里！"
+msgstr "我十分渴望人类的温暖精液灌进我的身体里！"
 
 #. Key:	5B354C0D4D37B6FD0F25BCA917BD6BE1
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeAboutOrb.Default__MegaSlimeAboutOrb_C.SessionData.Lines(6).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeAboutOrb.Default__MegaSlimeAboutOrb_C.SessionData.Lines(6).Lines
 msgctxt ",5B354C0D4D37B6FD0F25BCA917BD6BE1"
 msgid "*Sigh* How I dream of what it would be like to roll around so freely."
-msgstr ""
+msgstr "*叹气*我梦想着自由地滚来滚去的感觉。"
 
 #. Key:	5B50ECD6460E78702D62488307BE2A0A
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_RL.Default__FaleneDefault01_RL_C.ResponseData(7).ResponseData.BreederPrompt
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_RL.Default__FaleneDefault01_RL_C.ResponseData(7).ResponseData.BreederPrompt
 msgctxt ",5B50ECD6460E78702D62488307BE2A0A"
 msgid "Why don't futas have balls?"
-msgstr "为什么扶她没有蛋蛋？"
+msgstr "为什么扶她没有蛋蛋呢？"
 
 #. Key:	5B8BBC574B6A3FC58C5769B04B8923FE
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_RL.Default__RomyDefault01_RL_C.ResponseData(5).ResponseData.BreederPrompt
 #: /Game/Dialogue/Romy/Default/RomyDefault01_RL.Default__RomyDefault01_RL_C.ResponseData(5).ResponseData.BreederPrompt
 msgctxt ",5B8BBC574B6A3FC58C5769B04B8923FE"
 msgid "What is with the locked dungeon?"
-msgstr ""
+msgstr "那个锁着的地牢是怎么回事？"
 
 #. Key:	5BCD2C4F491787616684ECAD40FE34C6
 #. SourceLocation:	/Game/Dialogue/Reaper/Default/ReaperDefault01_RL.Default__ReaperDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/Reaper/Default/ReaperDefault01_RL.Default__ReaperDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",5BCD2C4F491787616684ECAD40FE34C6"
 msgid "Hello?"
-msgstr ""
+msgstr "你好？"
 
 #. Key:	5C17953A4E43CD3EE715BC8BE3D80889
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R02.Default__CamillaDefault01_R02_C.SessionData.Lines(8).Lines
@@ -4869,7 +4870,7 @@ msgstr "你可以做什么？"
 #: /Game/Dialogue/Cassie/Default/CassieDungeon.Default__CassieDungeon_C.SessionData.Lines(7).Lines
 msgctxt ",5C38779E4968CAF3F455C68BDBEDADF9"
 msgid "There! Promise me if you open it... we will have kinky sex in the old temple! Meow!"
-msgstr ""
+msgstr "好了!答应我，如果你打开它…我们会在古庙里疯狂地做爱!喵呜!"
 
 #. Key:	5C55705949989D3944ACDD8DE6CAEB1E
 #. SourceLocation:	/Game/Dialogue/Fern/SexScenes/FernMilk_01.Default__FernMilk_01_C.SessionData.Lines(2).Lines
@@ -4890,35 +4891,35 @@ msgstr "魔弗灵的起源不仅古老且未知，但是我们比其他生灵都
 #: /Game/Dialogue/AmberMae/Default/AmberMaeDungeon_RL.Default__AmberMaeDungeon_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",5C98DE6F491C2551F3E059B7839548B4"
 msgid "You couldn't fit in the dungeon?!"
-msgstr ""
+msgstr "你进不了地牢?！"
 
 #. Key:	5D1189D248873A7E95BA20AA8EADCF1C
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_Daze.Default__EmissaryDefault01_Daze_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_Daze.Default__EmissaryDefault01_Daze_C.SessionData.Lines(0).Lines
 msgctxt ",5D1189D248873A7E95BA20AA8EADCF1C"
 msgid "When the Goddess saw that Her creations indulged heavily in the pleasures of breeding that they neglected life, She devised a solution."
-msgstr ""
+msgstr "当女神看到她的创造物沉迷于生育的乐趣而忽视了生命时，她想出了一个解决办法。"
 
 #. Key:	5D244F6542342816F374B582D37B9B98
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(18).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(18).Lines
 msgctxt ",5D244F6542342816F374B582D37B9B98"
 msgid "Swearing to return again one day, the Goddess departed and faded from sight."
-msgstr ""
+msgstr "女神发誓有一天会再回来，祂离开了，消失在人们的视线中。"
 
 #. Key:	5D28B49D4DE445D9A31C4FA2B4501737
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.CBGate_Sands.PlaceMessage
 #: /Game/World/Overworld.Overworld:PersistentLevel.CBGate_Sands.PlaceMessage
 msgctxt ",5D28B49D4DE445D9A31C4FA2B4501737"
 msgid "Lewd Desert is now accessible."
-msgstr ""
+msgstr "现在可以访问淫荡沙漠了"
 
 #. Key:	5DBBC25548CE64C57F539B87D36558A9
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiIdiots.Default__FesssiIdiots_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiIdiots.Default__FesssiIdiots_C.SessionData.Lines(1).Lines
 msgctxt ",5DBBC25548CE64C57F539B87D36558A9"
 msgid "Now human, we are going to need a mighty creature in order to free my girthy hindquarters."
-msgstr ""
+msgstr "现在人类，我们需要一个强大的生物来解放我的后躯"
 
 #. Key:	5E27E8A74A30D389BBB939B5142249BB
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiGreeting01.Default__ParvatiGreeting01_C.SessionData.LinesToFuta(7).LinesToFuta
@@ -4932,7 +4933,7 @@ msgstr "我迫切渴求着你硕大的阴茎"
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(8).LinesToFemale
 msgctxt ",5E335B804845931D253C9186CD06C403"
 msgid "To breed!"
-msgstr "那就是交配！"
+msgstr "为了交配！"
 
 #. Key:	5E3B309B4D79B4A31F6B1786E8B3AB2D
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToMale(7).LinesToMale
@@ -4946,14 +4947,14 @@ msgstr "我十分渴望人类的精液灌进我的身体里！"
 #: /Game/Dialogue/Fern/DefaultP3/FernHadSex03.Default__FernHadSex03_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",5E79231E46C65B7ABB930CBB9EE87267"
 msgid "You released soooo much cum in here, I love it."
-msgstr ""
+msgstr "您在这里释放了太多的精液，我太爱这种感觉了。"
 
 #. Key:	5E8F33C74DE660C4911FD98A332F6BDE
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeKneel.Default__BeeKneel_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/QueenBee/Default/BeeKneel.Default__BeeKneel_C.SessionData.Lines(0).Lines
 msgctxt ",5E8F33C74DE660C4911FD98A332F6BDE"
 msgid "Ahhh yes... place your mouth upon my teat, for it is custom for all subjects to taste of my honey."
-msgstr ""
+msgstr "啊~是的…求你把你的嘴放在我的乳头上，因为品尝我的蜂蜜是众人的习惯。"
 
 #. Key:	5F41B5A04451E1F4E959DA86D6846CB4
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R04.Default__FaleneDefault01_R04_C.SessionData.Lines(6).Lines
@@ -4967,7 +4968,7 @@ msgstr "不像人类女性，女性魔弗灵的乳房总是在产乳……很多
 #: /Game/Dialogue/Autumn/Default/DryadCherryHelp.Default__DryadCherryHelp_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",5F4FDDD7441D663752F3D78544042EEA"
 msgid "I'm getting wet just thinking about your thick cock seeding me."
-msgstr ""
+msgstr "一想到你的大鸡巴在我身上播种，我就湿透了"
 
 #. Key:	5F71A084478332FD553228BF6DB08550
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(2 - Value).TraitIcons.DisplayName
@@ -5002,14 +5003,14 @@ msgstr "唔，我可以考虑赐予你进入的权限……但我需要一点儿
 #: /Game/Dialogue/Emissary/Default/EmissaryHadSex01.Default__EmissaryHadSex01_C.SessionData.LinesToFuta(3).LinesToFuta
 msgctxt ",604FA2154312C173E208F3949C0C0A75"
 msgid "Judging by the mess on the temple floor, quite good."
-msgstr ""
+msgstr "从神殿地板上的脏乱程度来看，还不错。"
 
 #. Key:	60635C454CEF8341039602B6529EEE22
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowSpiders.Default__WidowSpiders_C.SessionData.Lines(6).Lines
 #: /Game/Dialogue/Widow/Default/WidowSpiders.Default__WidowSpiders_C.SessionData.Lines(6).Lines
 msgctxt ",60635C454CEF8341039602B6529EEE22"
 msgid "Since humans are, or were, a myth, spiders crave the next best thing: elves."
-msgstr ""
+msgstr "人类是个神话，或者说曾经是个达不到的神话，所以蜘蛛就渴求仅次于人类的东西:精灵。"
 
 #. Key:	609D904E4D1F23007D88028804202202
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_HowToSpiritForm_RL_F.Default__LeylannaDefault01_HowToSpiritForm_RL_F_C.ResponseData(0).ResponseData.BreederPrompt
@@ -5030,7 +5031,7 @@ msgstr "这种本能会驱使他们去向被称为\"女神之身\"的祭坛雕�
 #: /Game/Dialogue/Leylanna/Default/LeylannaHadSex01.Default__LeylannaHadSex01_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",60F7E0894814D89ADDD7CDBD0B8BDFA5"
 msgid "Bring those soft breasts to me... I want to feel them."
-msgstr ""
+msgstr "把那对柔软的乳房带给我…我想感受它们"
 
 #. Key:	610937E54B5168894FBCF992E5728C73
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01.Default__MirruDefault01_C.SessionData.Lines(0).Lines
@@ -5044,42 +5045,42 @@ msgstr "旱地上的人类回来了呢。"
 #: /Game/Dialogue/Leylanna/Default/LeylannaDefault01_SpiritForm.Default__LeylannaDefault01_SpiritForm_C.SessionData.Lines(2).Lines
 msgctxt ",611DA9BB4817A59AE6891B9EEF129C59"
 msgid "Some adore you so greatly, they are willing to bind themselves to your physical body, allowing you to take on their form."
-msgstr "有些魔弗灵对你非常钦慕，它们愿意将自己的肉体借给你，以至于你能使用他们的形态。"
+msgstr "有些人非常崇拜你，他们愿意把自己束缚在你的肉体上，让你呈现出他们的形态"
 
 #. Key:	611DEEEA4F0BEB84BE76FDAD70AB9B96
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeTaskFulfilled.Default__BeeTaskFulfilled_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/QueenBee/Default/BeeTaskFulfilled.Default__BeeTaskFulfilled_C.SessionData.Lines(2).Lines
 msgctxt ",611DEEEA4F0BEB84BE76FDAD70AB9B96"
 msgid "You came through for us human, and for that you have my thanks."
-msgstr ""
+msgstr "你为了我们而来，人类。为此我十分感谢你。"
 
 #. Key:	61341EBA4A04883698FF08BF81A229FB
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_RL.Default__EmissaryDefault01_RL_C.ResponseData(5).ResponseData.BreederPrompt
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_RL.Default__EmissaryDefault01_RL_C.ResponseData(5).ResponseData.BreederPrompt
 msgctxt ",61341EBA4A04883698FF08BF81A229FB"
 msgid "What is the Great Conception?"
-msgstr ""
+msgstr "什么是伟大的受孕?"
 
 #. Key:	613E368A449069B472AC11842731C6AB
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMTaskFulfilled.Default__DMTaskFulfilled_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMTaskFulfilled.Default__DMTaskFulfilled_C.SessionData.Lines(0).Lines
 msgctxt ",613E368A449069B472AC11842731C6AB"
 msgid "Ahhh so sweet and creamy! I haven't felt this good in decades."
-msgstr ""
+msgstr "啊，又甜又滑!我几十年没这么爽过了"
 
 #. Key:	61A8146D43CCAA9D468CCC9D2CB22F42
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon.Default__AmberMaeLockedDungeon_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon.Default__AmberMaeLockedDungeon_C.SessionData.Lines(4).Lines
 msgctxt ",61A8146D43CCAA9D468CCC9D2CB22F42"
 msgid "If I recall... they rigged up some switch 'an pulley system."
-msgstr ""
+msgstr "如果俺没记错的话……他们应该有装配一些开关和滑轮系统。"
 
 #. Key:	61C3C47B425E2ACFE03921A38EDBD93D
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.CBGate_Glade.PlaceMessage
 #: /Game/World/Overworld.Overworld:PersistentLevel.CBGate_Glade.PlaceMessage
 msgctxt ",61C3C47B425E2ACFE03921A38EDBD93D"
 msgid "Esoteric Glade is now accessible."
-msgstr ""
+msgstr "现在可以拜访密荫之地了。"
 
 #. Key:	61DD0F8342D2EFAE9232248215EADFB4
 #. SourceLocation:	/Game/Ranch/Upgrades/NekoCondo.Default__NekoCondo_C.Upgrade.Description
@@ -5100,7 +5101,7 @@ msgstr "跟我讲讲如何繁殖魔弗灵."
 #: /Game/Dialogue/Petra/Default/PetraAboutPawsmaati.Default__PetraAboutPawsmaati_C.SessionData.Lines(3).Lines
 msgctxt ",6200B02D4EBCCEB4A3E6E2A95F82F6FA"
 msgid "She has the unique ability to change her body, both in size and... \"features\"."
-msgstr ""
+msgstr "她有一种独特的能力来改变自己的身体，无论是在体型上还是…\”特性\”"
 
 #. Key:	620C1C684C2E93329AEAD78099B4E620
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R01.Default__FaleneDefault01_R01_C.SessionData.Lines(9).Lines
@@ -5114,14 +5115,14 @@ msgstr "两者都进入了孕育的另一个维度，对魔弗灵后代来说是
 #: /Game/Dialogue/OrcChief/Default/OrcBrashDumb.Default__OrcBrashDumb_C.SessionData.Lines(8).Lines
 msgctxt ",6229EDF2456AA517D405ACBDBBD6D488"
 msgid "Sometimes a tribe sister comes up here to challenge me. She will leave with her pussy and mouth full of my seed!"
-msgstr ""
+msgstr "有时部落的姐妹会来挑战我。她会带着她满嘴和满蜜穴我的种子灰溜溜的离开!”"
 
 #. Key:	623951124677DCB7B08E31B3C53CABCC
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadFlowers.Default__DryadFlowers_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Autumn/Default/DryadFlowers.Default__DryadFlowers_C.SessionData.Lines(0).Lines
 msgctxt ",623951124677DCB7B08E31B3C53CABCC"
 msgid "Hmm... I believe I can."
-msgstr ""
+msgstr "哼……我感觉我可以。"
 
 #. Key:	6266DCAA4BE349E65FF6D89994B5E9C6
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03_RL_F.Default__FernDefault03_RL_F_C.ResponseData(0).ResponseData.BreederPrompt
@@ -5135,42 +5136,42 @@ msgstr "为什么叫我主人？"
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(13).Lines
 msgctxt ",627219374671317BBA6148B048EA7B8F"
 msgid "Such creations roamed in weak forms purely by instinct, what you call animals."
-msgstr ""
+msgstr "这些创造物纯粹出于本能，也就是你们所说的动物，以微弱的形式漫游。"
 
 #. Key:	62B5CF3C40893752840CAEBF4C8159C3
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault02.Default__EmissaryDefault02_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault02.Default__EmissaryDefault02_C.SessionData.Lines(4).Lines
 msgctxt ",62B5CF3C40893752840CAEBF4C8159C3"
 msgid "It did not deserve the pleasures you granted it, and I would advise never speaking with it again."
-msgstr ""
+msgstr "它不配得到你所赋予的欢乐，我劝你永远不要再同它说话。"
 
 #. Key:	62DABAA04453893D6FCD5390D28CB19A
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_R02.Default__FernDefault02_R02_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02_R02.Default__FernDefault02_R02_C.SessionData.Lines(2).Lines
 msgctxt ",62DABAA04453893D6FCD5390D28CB19A"
 msgid "Soon, I will fully bloom and not be able to move. We can have a lot of fun with my flower body!"
-msgstr "很快，我就会开花了但之后便无法移动。我的身体在之后可以带给我们很多乐趣！"
+msgstr "很快，我就会开花了但之后便无法移动了。我的身体在之后可以带给我们很多乐趣！"
 
 #. Key:	62FF5D604699246B05ECEDA19F98F1BA
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",62FF5D604699246B05ECEDA19F98F1BA"
 msgid "You have no idea how much restraint I am putting forth at this moment..."
-msgstr "你不知道，有多少束缚，在这一刻被我统统抛之脑后了……"
+msgstr "你不知道我在这一刻有多么克制自己……"
 
 #. Key:	630D79B54CCF1CADC252DB970D8C7327
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleTittyPony_T.Default__KybeleTittyPony_T_C.SessionData.LinesToMale(2).LinesToMale
 #: /Game/Dialogue/Kybele/Default/KybeleTittyPony_T.Default__KybeleTittyPony_T_C.SessionData.LinesToMale(2).LinesToMale
 msgctxt ",630D79B54CCF1CADC252DB970D8C7327"
 msgid "That should teach you to cross this titty po--I mean mighty centaur warmaiden, again!"
-msgstr ""
+msgstr "这再一次给你一个教训，让你越过这个奶驹———我说的是强大的半人马战女!"
 
 #. Key:	63185F8D44DB00B8514792BA4971889F
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_SexPositions.Default__FaleneDefault01_SexPositions_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_SexPositions.Default__FaleneDefault01_SexPositions_C.SessionData.Lines(4).Lines
 msgctxt ",63185F8D44DB00B8514792BA4971889F"
 msgid "She will probably know more, she sleeps... I mean gets... around."
-msgstr ""
+msgstr "她可能会知道更多，她睡着了……我的意思是被……包围"
 
 #. Key:	6340E0A045F87C6E35C3348C97609B67
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01.Default__ParvatiDefault01_C.SessionData.Lines(1).Lines
@@ -5184,14 +5185,14 @@ msgstr "我发誓，我真的想要和你做爱"
 #: /Game/Dialogue/QueenBee/Default/BeeMasturbate.Default__BeeMasturbate_C.SessionData.Lines(2).Lines
 msgctxt ",639BDE8A40D4ABAD77555A89D2C8E86B"
 msgid "Or being your sex toy. Don't think I haven't noticed you defiling their adorable fuzzy bodies."
-msgstr ""
+msgstr "或者成为你的性玩具。别以为我没注意到你玷污了他们可爱的毛茸茸的身体"
 
 #. Key:	63A38D02485080C06D6E03A71640D251
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01_RL_T.Default__FernDefault01_RL_T_C.ResponseData(5).ResponseData.BreederPrompt
 #: /Game/Dialogue/Fern/Default/FernDefault01_RL_T.Default__FernDefault01_RL_T_C.ResponseData(5).ResponseData.BreederPrompt
 msgctxt ",63A38D02485080C06D6E03A71640D251"
 msgid "The Queen Bee demands flowers."
-msgstr ""
+msgstr "蜂后渴求鲜花的簇拥"
 
 #. Key:	63A5E9734DC0420DD97A739128DEEF85
 #. SourceLocation:	/Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToFuta(3).LinesToFuta
@@ -5205,14 +5206,14 @@ msgstr "*舔，啧啧水声*"
 #: /Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon.Default__AmberMaeLockedDungeon_C.SessionData.Lines(0).Lines
 msgctxt ",63ACAC1E4A5D5DFE164A168EAFEE76BC"
 msgid "Aye, 'tis been countless years since anyone's been down there!"
-msgstr ""
+msgstr "是啊，已经好多年没人下去过了!"
 
 #. Key:	63B540744119014025598C8555237076
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMHadSex01.Default__DMHadSex01_C.SessionData.LinesToFemale(2).LinesToFemale
 #: /Game/Dialogue/DragonMatriarch/Default/DMHadSex01.Default__DMHadSex01_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",63B540744119014025598C8555237076"
 msgid "Humans... I can understand why the world is obsessed with you now."
-msgstr ""
+msgstr "人类……我现在明白为什么全世界都对你着迷了。"
 
 #. Key:	63B6296840BB64E725E7219F715EEAB1
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToFuta(4).LinesToFuta
@@ -5226,7 +5227,7 @@ msgstr "一些神圣的……一些禁忌的……一些人类的东西！"
 #: /Game/Dialogue/Autumn/Default/DryadFatAssLamia.Default__DryadFatAssLamia_C.SessionData.Lines(2).Lines
 msgctxt ",63C3A400466ECFE75FCDA58BBC7954C9"
 msgid "She was... eh... doing interesting things with a massive spider!"
-msgstr ""
+msgstr "她是…呃……做有趣的事情的巨大的蜘蛛!”"
 
 #. Key:	63F3737B48B4C916545D1D8159EB762C
 #. SourceLocation:	/Game/Breeding/Positions/Cowgirl.Default__Cowgirl_C.SessionData.PositionName
@@ -5240,14 +5241,14 @@ msgstr "骑乘位"
 #: /Game/Dialogue/Leylanna/Default/LeylannaDefault01_BlueSmoke.Default__LeylannaDefault01_BlueSmoke_C.SessionData.Lines(1).Lines
 msgctxt ",642A06E64C62D0AA35E17FB7181BDBD8"
 msgid "By inhaling it all day it grants me visions into worlds beyond."
-msgstr ""
+msgstr "整天吸入它，它赋予我获得了跳脱世界的视觉"
 
 #. Key:	643311E64814ADA6B66E4AB03B31A666
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraAboutPawsmaati.Default__PetraAboutPawsmaati_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Petra/Default/PetraAboutPawsmaati.Default__PetraAboutPawsmaati_C.SessionData.Lines(2).Lines
 msgctxt ",643311E64814ADA6B66E4AB03B31A666"
 msgid "In her long years, she has mastered the magical arts of flesh transmogrify and sexual pleasure."
-msgstr ""
+msgstr "在她漫长的岁月里，她已经掌握了肉体变形和性快感的神奇艺术。"
 
 #. Key:	644065F84B0F2E772BE21695810A2F0F
 #. SourceLocation:	/Game/Characters/Procedural/Variants/Bovaur/Harvest/BovaurHarvest.Default__BovaurHarvest_C.Harvest.Description
@@ -5261,7 +5262,7 @@ msgstr "奶牛人体液"
 #: /Game/World/Events/EM_Pearl.Default__EM_Pearl_C.ActivateMessage
 msgctxt ",6447F38E4E2E302612E297856123386E"
 msgid "Take Pearl"
-msgstr ""
+msgstr "抬走珍珠。"
 
 #. Key:	646A76464079BB23F12A50A6B8512B75
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(27).LinesToFemale
@@ -5303,14 +5304,14 @@ msgstr "你这副胴体简直是绝佳的性爱玩具。"
 #: /Game/Dialogue/QueenBee/Default/BeeMasturbate.Default__BeeMasturbate_C.SessionData.Lines(1).Lines
 msgctxt ",64CC71FD416D9657B85C8B867FC921DE"
 msgid "As queen, I am entitled to constant pleasure. Yet, my daughters are busy collecting nectar."
-msgstr ""
+msgstr "作为女王，我有权享受永恒的快乐。然而，我的女儿们正忙着采集花蜜呢。"
 
 #. Key:	64D03AEC41B764C9BCFB0CAAED5A58DD
 #. SourceLocation:	/Game/Dialogue/Yasmine/Default/YasmineDefault01.Default__YasmineDefault01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Yasmine/Default/YasmineDefault01.Default__YasmineDefault01_C.SessionData.Lines(0).Lines
 msgctxt ",64D03AEC41B764C9BCFB0CAAED5A58DD"
 msgid "*Strange moans and squishy noises can be heard within.*"
-msgstr ""
+msgstr "*里面可以听到奇怪的呻吟声和黏糊糊的声音*"
 
 #. Key:	64DDB04B426866024F9EFC98D34E99E5
 #. SourceLocation:	/Game/Dialogue/Blossom/Default/BlossomDefault01_RL_F.Default__BlossomDefault01_RL_F_C.ResponseData(0).ResponseData.BreederPrompt
@@ -5338,21 +5339,21 @@ msgstr "当我满身沾着怪物的精液从@WORLD_NAME@回来时, 她笑了好�
 #: /Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFuta(6).LinesToFuta
 msgctxt ",653BCE96424AE552DCA4D7853B50BC39"
 msgid "Actually, fat ass reminds me of something!"
-msgstr ""
+msgstr "事实上，大肥屁股让我想起了什么!"
 
 #. Key:	657B8CAA4F7FC96AAD9188A418E914E3
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchPrettyButterfly.Default__MonarchPrettyButterfly_C.SessionData.Lines(6).Lines
 #: /Game/Dialogue/Monarch/Default/MonarchPrettyButterfly.Default__MonarchPrettyButterfly_C.SessionData.Lines(6).Lines
 msgctxt ",657B8CAA4F7FC96AAD9188A418E914E3"
 msgid "To start s-s-sex and... control it."
-msgstr ""
+msgstr "开始做…做……做爱…然后……控制它。"
 
 #. Key:	659F65A5454F216DBCA2DE943F3D816D
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_R04.Default__FernDefault02_R04_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02_R04.Default__FernDefault02_R04_C.SessionData.Lines(0).Lines
 msgctxt ",659F65A5454F216DBCA2DE943F3D816D"
 msgid "Oh Master... you are too good to me."
-msgstr "oh，主人...你对我太好了"
+msgstr "oh，主人...您对我太好了"
 
 #. Key:	65F2B1384977D80660A4E4A91389BC9D
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(12 - Value).TraitIcons.DisplayName
@@ -5366,7 +5367,7 @@ msgstr "脏乱不堪"
 #: /Game/Dialogue/DragonMatriarch/Default/DMClimaxPeak.Default__DMClimaxPeak_C.SessionData.Lines(4).Lines
 msgctxt ",660193204E5DEA727DEC1C858BA2467E"
 msgid "Legends say, when a blessed dragon consumes the milk she will be granted new vigor."
-msgstr ""
+msgstr "传说，当一条受祝福的龙喝了奶，她将被赋予新的智力。"
 
 #. Key:	664C0BE948989DEEE1185793CB1EEE77
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiGreeting01.Default__ParvatiGreeting01_C.SessionData.LinesToFemale(5).LinesToFemale
@@ -5380,7 +5381,7 @@ msgstr "我的教导可不是为了那些想要保守童贞的人"
 #: /Game/Dialogue/Fern/Default/FernDefault01_RL_T.Default__FernDefault01_RL_T_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",6658580C407404A28C6BD1875A2920D2"
 msgid "What a lovely talking fern..."
-msgstr "真是个可爱的小蕨。"
+msgstr "真是个可爱又会说话的小蕨。"
 
 #. Key:	668D13F146AB0A33AF196F814E2CAA98
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_RL.Default__RomyDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
@@ -5394,21 +5395,21 @@ msgstr "沐浴."
 #: /Game/Dialogue/Fesssi/Default/FesssiIdiots.Default__FesssiIdiots_C.SessionData.Lines(7).Lines
 msgctxt ",6692103B4B53269229DB388B380B520F"
 msgid "Do hurry human, I am very horny and ready to mate with the world... starting with you."
-msgstr ""
+msgstr "快点人类，我很饥渴，准备和这个世界交配…从你开始!
 
 #. Key:	66E2EA9044A750BB60AD308B87FE3071
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadHaveKeystone.Default__DryadHaveKeystone_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Autumn/Default/DryadHaveKeystone.Default__DryadHaveKeystone_C.SessionData.Lines(3).Lines
 msgctxt ",66E2EA9044A750BB60AD308B87FE3071"
 msgid "They eat the bossom cherries faster than I can make them."
-msgstr ""
+msgstr "它们吃乳房樱桃的速度比我生产的速度还快。"
 
 #. Key:	66E8E5AB4E2D126AFBE3A7858C3E70EF
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_PussyPortals.Default__NeelaDefault01_PussyPortals_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_PussyPortals.Default__NeelaDefault01_PussyPortals_C.SessionData.Lines(0).Lines
 msgctxt ",66E8E5AB4E2D126AFBE3A7858C3E70EF"
 msgid "Can you think of a better name? Just look at the damn things."
-msgstr "你想得出来更好的名字吗？"
+msgstr "“你能想到一个更好的名字吗?”看看这些该死的东西。"
 
 #. Key:	66F6289345C29C0CE3AFC2A1AB411CEE
 #. SourceLocation:	/Game/Dialogue/Cassie/SexScenes/CassieButterButtF.Default__CassieButterButtF_C.SessionData.Lines(5).Lines
@@ -5422,21 +5423,21 @@ msgstr "噢爽...喵呜...啊哈..."
 #: /Game/Dialogue/Falene/Default/FaleneDefault02.Default__FaleneDefault02_C.SessionData.Lines(4).Lines
 msgctxt ",66FF732B48A05F6D56007DA56AA83546"
 msgid "Hehehe... she is going to love what I brought her."
-msgstr ""
+msgstr "哈哈…她会喜欢我带给她的东西。"
 
 #. Key:	6704B8A54849F885661105A85287867D
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaFaleneWeek.Default__CamillaFaleneWeek_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaFaleneWeek.Default__CamillaFaleneWeek_C.SessionData.Lines(3).Lines
 msgctxt ",6704B8A54849F885661105A85287867D"
 msgid "First, I have to be naked."
-msgstr ""
+msgstr "首先，我得一丝不挂"
 
 #. Key:	6779B6F54EA9811CDA01BB899D8E10A4
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(2).Lines
 msgctxt ",6779B6F54EA9811CDA01BB899D8E10A4"
 msgid "I'm Amber-Mae, yer Bovaur dairy lass!"
-msgstr "俺叫安铂，尼的奶工！"
+msgstr "俺叫安布尔-梅，尼的每日鲜奶小姐！"
 
 #. Key:	679174774B8AE81A6C98AE933C6D1BF3
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_Formuria.Default__MirruDefault01_Formuria_C.SessionData.Lines(5).Lines
@@ -5457,21 +5458,21 @@ msgstr "真可惜，明明我们可以一起唱出美妙动人的歌声的"
 #: /Game/Dialogue/Fesssi/Default/FesssiHowLong.Default__FesssiHowLong_C.SessionData.Lines(8).Lines
 msgctxt ",67B0B0EE4398E581F4E9B6AF9761BCCE"
 msgid "Captivated by my buxom behind, they would worship it or stick their fat cocks deep inside. I took more loads in my ass than any other @MONSTER_RACE@. Hiss!"
-msgstr ""
+msgstr "被我丰满的臀部所吸引，他们会崇拜它，或者把他们的肥屌深深地插进里面。我屁股里的子弹比谁都要多得多，嘶！"
 
 #. Key:	67B51FA5454DB188B081BFACCC583F71
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_RL_F.Default__FernDefault02_RL_F_C.ResponseData(4).ResponseData.BreederPrompt
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02_RL_F.Default__FernDefault02_RL_F_C.ResponseData(4).ResponseData.BreederPrompt
 msgctxt ",67B51FA5454DB188B081BFACCC583F71"
 msgid "The Queen Bee demands flowers."
-msgstr ""
+msgstr "蜂后渴望被鲜花簇拥"
 
 #. Key:	67E8752E482B4F96EC745D8BB55B5F68
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_StartCowgirl.Default__ParvatiDefault01_StartCowgirl_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_StartCowgirl.Default__ParvatiDefault01_StartCowgirl_C.SessionData.Lines(0).Lines
 msgctxt ",67E8752E482B4F96EC745D8BB55B5F68"
 msgid "..."
-msgstr ""
+msgstr "……"
 
 #. Key:	67EB3E22466BD62D9BC182899350E3AF
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDefault01_Meow.Default__CassieDefault01_Meow_C.SessionData.LinesToFemale(1).LinesToFemale
@@ -5485,14 +5486,14 @@ msgstr "*咕噜咕噜声*"
 #: /Game/Dialogue/Monarch/Default/MonarchStartShySex.Default__MonarchStartShySex_C.SessionData.LinesToFuta(3).LinesToFuta
 msgctxt ",6829983E4E26EA5122F484ADF8FB4FD0"
 msgid "So I can, y-y-you know... feel your cock deep inside me."
-msgstr ""
+msgstr "所以我想，你懂的。。。让你的大鸡鸡深入我的身体。"
 
 #. Key:	6850165B47861B4D0E47B1AFBC409B6A
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToFemale(5).LinesToFemale
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToFemale(5).LinesToFemale
 msgctxt ",6850165B47861B4D0E47B1AFBC409B6A"
 msgid "It's a nutritious aphrodisiac, a very powerful one so be careful!"
-msgstr ""
+msgstr "这是一种营养丰富的壮阳药，非常强效，所以要万分小心！"
 
 #. Key:	688E1D934E2D63E60F30488E807E8643
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_AboutKrakens.Default__MirruDefault01_AboutKrakens_C.SessionData.Lines(5).Lines
@@ -5506,7 +5507,7 @@ msgstr "我们从未有意伤害谁，可欲望总得满足，无论代价如何
 #: /Game/Dialogue/Monarch/Default/MonarchDefault01.Default__MonarchDefault01_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",68A15FB749BF4A36B88C4C82CBC3166E"
 msgid "Soon my nectar collection will be complete, and I can return to the Hivelands."
-msgstr ""
+msgstr "很快我的花蜜收集就完成了，我就可以回到蜂巢大地了。"
 
 #. Key:	68CDC1534D4397A3A7211A8ED7C2F578
 #. SourceLocation:	/Game/Dialogue/Cassie/SexScenes/CassieSplintersT.Default__CassieSplintersT_C.SessionData.Lines(5).Lines
@@ -5534,7 +5535,7 @@ msgstr "测试3"
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeAboutOrb.Default__MegaSlimeAboutOrb_C.SessionData.Lines(4).Lines
 msgctxt ",694BFC904B3397B73FEBEF836CD65954"
 msgid "We have been best friends ever since, even though she won't tell me her name."
-msgstr ""
+msgstr "从那以后我们一直是最好的朋友，尽管她不肯告诉我她的名字"
 
 #. Key:	695409264F52725B30031E8F0FB4052C
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_RL_F.Default__FernDefault02_RL_F_C.ResponseData(2).ResponseData.BreederPrompt
@@ -5548,7 +5549,7 @@ msgstr "你能干嘛？"
 #: /Game/Dialogue/Autumn/Default/DryadBossomCherries.Default__DryadBossomCherries_C.SessionData.Lines(6).Lines
 msgctxt ",69736B6847FFEF0E503D5B911CB4FE32"
 msgid "I may or may not take advantage of cute sleeping cows..."
-msgstr ""
+msgstr "我可能会也可能不会利用可爱的睡着的牛们…"
 
 #. Key:	697AC02A4A47BBBD70150ABE216F79E9
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_StartForgotten.Default__ParvatiDefault01_StartForgotten_C.SessionData.Lines(1).Lines
@@ -5562,14 +5563,14 @@ msgstr "在我做些润滑的时候，汝可以冥思一会"
 #: /Game/Dialogue/Kybele/Default/KybeleDefault01_RL.Default__KybeleDefault01_RL_C.ResponseData(4).ResponseData.BreederPrompt
 msgctxt ",698288A146113C1492125B891EA3456D"
 msgid "Can I have that keystone?"
-msgstr ""
+msgstr "我可以拿那个钥石了吗？"
 
 #. Key:	6993DD7B4964C190B75F98AABA008FAA
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieGreeting01.Default__CassieGreeting01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Cassie/Default/CassieGreeting01.Default__CassieGreeting01_C.SessionData.Lines(0).Lines
 msgctxt ",6993DD7B4964C190B75F98AABA008FAA"
 msgid "Well butter my butt and slap me with a biscuit. A human!"
-msgstr "诶我要用黄油涂满我的小屁股，还要用香香甜的饼干铺满身。啊呀！一个人类！"
+msgstr "好吧，给我屁股涂上黄油，再拿饼干拍我屁股。人类!"
 
 #. Key:	69F9118A434154DE440203AEBAD52F22
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_AboutKrakens.Default__MirruDefault01_AboutKrakens_C.SessionData.Lines(6).Lines
@@ -5583,7 +5584,7 @@ msgstr "如果这意味着我们要翻云覆雨个把小时，同时从彼此身
 #: /Game/Ranch/Upgrades/HarpyAviary.Default__HarpyAviary_C.Upgrade.TypeDisplay
 msgctxt ",6A26D99744982C7F05898A800D9AB807"
 msgid "Nephelym Barn"
-msgstr "魔弗灵谷仓"
+msgstr "魔弗灵牧场"
 
 #. Key:	6A4F7C15487175679D62FFA469639D1A
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDefault01_Meow_RL_F.Default__CassieDefault01_Meow_RL_F_C.ResponseData(1).ResponseData.BreederPrompt
@@ -5597,14 +5598,14 @@ msgstr "黄油棒？你认真的？"
 #: /Game/Dialogue/Cassie/SexScenes/CassieSplintersT.Default__CassieSplintersT_C.SessionData.Lines(0).Lines
 msgctxt ",6AAA8DC54239107FC4E476B1F67AD574"
 msgid "Ohhh... big human dick feels amazing!"
-msgstr "哦...人类的肉棒感觉棒极了"
+msgstr "哦...人类的肉棒太赞了！"
 
 #. Key:	6AADAD5D41D98C207B7FEB993604434A
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.EM_Keystone_QueenBee.FailMessage
 #: /Game/World/Overworld.Overworld:PersistentLevel.EM_Keystone_QueenBee.FailMessage
 msgctxt ",6AADAD5D41D98C207B7FEB993604434A"
 msgid "It will not move."
-msgstr ""
+msgstr "它一动不动"
 
 #. Key:	6AD76D124EA5FF55B998D39AD1070F08
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeSuckJugs_Start.Default__AmberMaeSuckJugs_Start_C.SessionData.Lines(0).Lines
@@ -5618,7 +5619,7 @@ msgstr "噢俺的天啊！噢噢噢！"
 #: /Game/Dialogue/Monarch/Default/MonarchShySexT_RL.Default__MonarchShySexT_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",6AFADD1A416223C71B86159050C16A67"
 msgid "My body is ready."
-msgstr ""
+msgstr "我欲火焚身.
 
 #. Key:	6B00C5C74D9E87523316E2827BCF76F6
 #. SourceLocation:	/Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToFuta(1).LinesToFuta
@@ -5632,28 +5633,28 @@ msgstr "*吮吸* *吮吸*"
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_Princess.Default__MirruDefault01_Princess_C.SessionData.Lines(4).Lines
 msgctxt ",6B7696AA4F7FC59BCCFABC996AED1F8B"
 msgid "I envy my lesser siblings in a way, they are not required to embark on a 30 year pilgrimage like me."
-msgstr "我倒是挺嫉妒我的弟弟妹妹，我得花30年去朝圣，他们不用。"
+msgstr "有时我挺羡慕我的小兄弟姐妹，他们不需要像我一样踏上30年的朝圣之旅。"
 
 #. Key:	6BC585A94AB919791876E989ABC6AFC2
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon.Default__AmberMaeLockedDungeon_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon.Default__AmberMaeLockedDungeon_C.SessionData.Lines(2).Lines
 msgctxt ",6BC585A94AB919791876E989ABC6AFC2"
 msgid "Didn't get very far though, me jugs 'an buxom hips said no!"
-msgstr ""
+msgstr "不过还没走多远，俺那大大的屁股就在抗议了！"
 
 #. Key:	6BD3487945B18914AE271E871E682D15
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiTaskFulfilled.Default__FesssiTaskFulfilled_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiTaskFulfilled.Default__FesssiTaskFulfilled_C.SessionData.Lines(3).Lines
 msgctxt ",6BD3487945B18914AE271E871E682D15"
 msgid "Now... come closer, for I wish to mate with you."
-msgstr ""
+msgstr "现在…靠近点，我想和你做爱。"
 
 #. Key:	6BD4BB9B462B18C1771C5C8CE331DDAC
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchPrettyButterfly.Default__MonarchPrettyButterfly_C.SessionData.Lines(7).Lines
 #: /Game/Dialogue/Monarch/Default/MonarchPrettyButterfly.Default__MonarchPrettyButterfly_C.SessionData.Lines(7).Lines
 msgctxt ",6BD4BB9B462B18C1771C5C8CE331DDAC"
 msgid "I'm too shy... so I just collect nectar for our queen."
-msgstr ""
+msgstr "我太害羞了……所以我只是为女王采集花蜜"
 
 #. Key:	6C9735694D5FA2594461AF9E28110F5C
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(26).LinesToFemale
@@ -5667,28 +5668,28 @@ msgstr "当然了，他们于此还是很温柔的。到目前为止还没出现
 #: /Game/Dialogue/Kybele/Default/KybeleTittyPony.Default__KybeleTittyPony_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",6CE8D4CC4972C62CFCB7FE9919BBA235"
 msgid "That should teach you to cross this titty po--I mean mighty centaur warmaiden, again!"
-msgstr ""
+msgstr "这再一次教会你如何深入这个大奶驹……——我是说！强大的半人马女战士！"
 
 #. Key:	6CEBE4ED41B379988D725290EDC4FE95
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaHadSex01.Default__CamillaHadSex01_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/Camilla/Default/CamillaHadSex01.Default__CamillaHadSex01_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",6CEBE4ED41B379988D725290EDC4FE95"
 msgid "This little body experienced a lot of pleasure..."
-msgstr ""
+msgstr "这个小小的身体经历了很多快乐……"
 
 #. Key:	6D0C594D4C4F236FB6A4E28627184737
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R02.Default__CamillaDefault01_R02_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R02.Default__CamillaDefault01_R02_C.SessionData.Lines(1).Lines
 msgctxt ",6D0C594D4C4F236FB6A4E28627184737"
 msgid "Foxen and Vulwargs like the shade and trees of the Lustwood."
-msgstr "狐狸人和狼人喜欢欲望森林的阴凉和树木。"
+msgstr "狐人和狼人喜欢迷情之森的阴凉和树木。"
 
 #. Key:	6D1219CB453AA152B8E0548996E8123B
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiCave.Default__FesssiCave_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiCave.Default__FesssiCave_C.SessionData.Lines(3).Lines
 msgctxt ",6D1219CB453AA152B8E0548996E8123B"
 msgid "Apparently, if you go deep enough, you will find hell itself. Filled to the brim with lusty demons and dark magic."
-msgstr ""
+msgstr "显然，如果你走得够深，你会发现地狱本身。充满了充满活力的恶魔和暗魔法。"
 
 #. Key:	6D1431474F1C713E9D755F93772C653C
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(15 - Value).TraitIcons.HelpText
@@ -5702,14 +5703,14 @@ msgstr "多汁: 在收获时产生50%的体液"
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_Forgot_RL.Default__ParvatiDefault01_Forgot_RL_C.ResponseData(6).ResponseData.BreederPrompt
 msgctxt ",6D1721A840C5FB9C772FA0B710043ADC"
 msgid "Waterfall!"
-msgstr ""
+msgstr "瀑布式"
 
 #. Key:	6D1F8DD440DBF92518A5E6833EB831FA
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadHaveKeystone.Default__DryadHaveKeystone_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Autumn/Default/DryadHaveKeystone.Default__DryadHaveKeystone_C.SessionData.Lines(4).Lines
 msgctxt ",6D1F8DD440DBF92518A5E6833EB831FA"
 msgid "I've heard legends of the daughters of the queen bee in Hivelands."
-msgstr ""
+msgstr "我听传说蜂后的女儿们在蜂巢大地。"
 
 #. Key:	6D4E481742B09428791263B3A820281E
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeDefault01_SuckJugs.Default__AmberMaeDefault01_SuckJugs_C.SessionData.Lines(4).Lines
@@ -5723,28 +5724,28 @@ msgstr "哦天，俺…俺现在真的好为难，俺的欲望简直要冲出俺
 #: /Game/Dialogue/Fern/DefaultP2/FernBeeFlowers2.Default__FernBeeFlowers2_C.SessionData.Lines(0).Lines
 msgctxt ",6D4FCB5345397A3D9726C1AAA8B438D6"
 msgid "I am not powerful enough to control the plants in other lands."
-msgstr ""
+msgstr "我的力量还不足以控制其他地方的植物。"
 
 #. Key:	6D77CB43488C767A611292B40E89506D
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeGreeting01.Default__MegaSlimeGreeting01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeGreeting01.Default__MegaSlimeGreeting01_C.SessionData.Lines(1).Lines
 msgctxt ",6D77CB43488C767A611292B40E89506D"
 msgid "No one ever comes down here, let alone a human."
-msgstr ""
+msgstr "没人来过这里，更别说人类了。"
 
 #. Key:	6D839EC343F5CB6DF39F048E74C3A3F6
 #. SourceLocation:	/Game/Breeding/Positions/LapDance.Default__LapDance_C.SessionData.PositionName
 #: /Game/Breeding/Positions/LapDance.Default__LapDance_C.SessionData.PositionName
 msgctxt ",6D839EC343F5CB6DF39F048E74C3A3F6"
 msgid "Lap Dance"
-msgstr ""
+msgstr "膝上艳舞式"
 
 #. Key:	6DBA71B949F9F1ABB3D362AB777D197E
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleTittyPony_T.Default__KybeleTittyPony_T_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/Kybele/Default/KybeleTittyPony_T.Default__KybeleTittyPony_T_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",6DBA71B949F9F1ABB3D362AB777D197E"
 msgid "It's been sometime since I have released, so this is going to get messy."
-msgstr ""
+msgstr "我已经有一段时间没有释放了，所以我准备粗暴点哟"
 
 #. Key:	6DCC52994B8322D169A47299585B1FFA
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_SpiritForm.Default__LeylannaDefault01_SpiritForm_C.SessionData.Lines(3).Lines
@@ -5758,14 +5759,14 @@ msgstr "因为这种转变发生在虚空之中，所以鲜有限制。无论如
 #: /Game/Dialogue/Kybele/Default/KybeleAnyMeans.Default__KybeleAnyMeans_C.SessionData.LinesToFuta(4).LinesToFuta
 msgctxt ",6DD6D2E84735C26D7103ADA9DEA53E81"
 msgid "If you do not leave this place, you will mount me with that modest sized cock until I'm satisfied!"
-msgstr ""
+msgstr "如果你不离开这个地方，你就用那只中等大小的鸡巴骑我，直到我满意为止!"
 
 #. Key:	6DFA50D843F564F540771EAD2DCC848B
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleHaveKeystone.Default__KybeleHaveKeystone_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Kybele/Default/KybeleHaveKeystone.Default__KybeleHaveKeystone_C.SessionData.Lines(3).Lines
 msgctxt ",6DFA50D843F564F540771EAD2DCC848B"
 msgid "Just don't tell her if you see her! If you do, you will feel the wrath of my fat cock again!"
-msgstr ""
+msgstr "如果你看到她，千万别告诉她!如果你这么做，你会再次感受到我的大鸡巴的愤怒!"
 
 #. Key:	6DFC948B4585FAC19AED8692ED4B45F2
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_RechargeSpiritForm_RL_F.Default__LeylannaDefault01_RechargeSpiritForm_RL_F_C.ResponseData(1).ResponseData.BreederPrompt
@@ -5828,14 +5829,14 @@ msgstr "哦，等等， 我...嗯……"
 #: /Game/Dialogue/DragonMatriarch/Default/DMHadSex01.Default__DMHadSex01_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",6EB1D4054ABCE1E3818FC39FB5A8415A"
 msgid "Somehow you took a cock larger than you and still made it feel amazing."
-msgstr ""
+msgstr "不知怎么的，你拿了个比你大的鸡巴还让人感觉很棒。"
 
 #. Key:	6ED67799423B871587B12E8DEC3D1BE1
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(0).Lines
 msgctxt ",6ED67799423B871587B12E8DEC3D1BE1"
 msgid "Oh! A cute li'l human! Nary in all me puff did I expect te see such a thing!"
-msgstr "噢！一个可爱的小人类！俺真是没想到能碰上这样的事！"
+msgstr "噢！一个可爱的小伦类！俺真是没想到能碰上这样的事！"
 
 #. Key:	6F1214E04CFF55C4F15CF6B9593AE091
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToFuta(3).LinesToFuta
@@ -5856,7 +5857,7 @@ msgstr "现在你就是@WORLD_NAME@大陆最新的居民啦！"
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_SexPositions.Default__FaleneDefault01_SexPositions_C.SessionData.Lines(3).Lines
 msgctxt ",6F314EC947FA4FB92B59FFB3E0E4AC10"
 msgid "Talk to that super cute snake lady with the funny hat."
-msgstr ""
+msgstr "和那个戴着滑稽帽子的超级漂亮的拉米娅女士谈谈"
 
 #. Key:	6F4E36894BE6D32AB2BF92B2FB1F5697
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_RaiseTraitLvl.Default__EmissaryDefault01_RaiseTraitLvl_C.SessionData.Lines(1).Lines
@@ -5870,42 +5871,42 @@ msgstr "但首先。请先向至高女神表明汝之诚意。赞美归于至高
 #: /Game/Dialogue/AmberMae/SexScenes/AmberMilkyF.Default__AmberMilkyF_C.SessionData.Lines(0).Lines
 msgctxt ",6F5E6DAB49A4FDFA3CF6ADB4F98239E5"
 msgid "Ahhhh! Suck 'em hard, 'mai milk is all for you!"
-msgstr "啊啊…用力 再用力吸！俺的奶全都是尼的！"
+msgstr "啊啊…用力 再用力吸！俺的奶全都是给尼准备的！"
 
 #. Key:	6F8F41154136EFB2D479DCB4A853DC48
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcBrashDumb.Default__OrcBrashDumb_C.SessionData.Lines(9).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcBrashDumb.Default__OrcBrashDumb_C.SessionData.Lines(9).Lines
 msgctxt ",6F8F41154136EFB2D479DCB4A853DC48"
 msgid "Hahaha! *snarl*"
-msgstr ""
+msgstr "哈哈哈!*咆哮*"
 
 #. Key:	6FA3A5FA4FAB4D57D0E13D8815C6D5E7
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeGreeting01.Default__MegaSlimeGreeting01_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeGreeting01.Default__MegaSlimeGreeting01_C.SessionData.Lines(4).Lines
 msgctxt ",6FA3A5FA4FAB4D57D0E13D8815C6D5E7"
 msgid "My beloved orb!! It's so beautiful, I will cherish it always."
-msgstr ""
+msgstr "我亲爱的球球！！它是如此美丽，我会永远珍惜它。"
 
 #. Key:	6FB79F1B4245887D7C56A197959DA2A1
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03.Default__FernDefault03_C.SessionData.LinesToFuta(1).LinesToFuta
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03.Default__FernDefault03_C.SessionData.LinesToFuta(1).LinesToFuta
 msgctxt ",6FB79F1B4245887D7C56A197959DA2A1"
 msgid "Look at my beautiful flower, it bloomed! Oh my did it feel weird..."
-msgstr "看我美丽的身体，它开了！哦，感觉有点怪怪的...，"
+msgstr "快看看我美丽的花，它开放了!哦，我的天，是不是感觉怪怪的……"
 
 #. Key:	6FBC636D494A40330AAEBDBCD6886299
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMGrasslandsTrees.Default__DMGrasslandsTrees_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMGrasslandsTrees.Default__DMGrasslandsTrees_C.SessionData.Lines(0).Lines
 msgctxt ",6FBC636D494A40330AAEBDBCD6886299"
 msgid "What do you know human!"
-msgstr ""
+msgstr "你知道什么，人类！"
 
 #. Key:	6FD7E94044B57DA992A79BA4422CF69C
 #. SourceLocation:	/Game/Dialogue/Yasmine/Default/YasmineDefault01_RL.Default__YasmineDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/Yasmine/Default/YasmineDefault01_RL.Default__YasmineDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",6FD7E94044B57DA992A79BA4422CF69C"
 msgid "You make pearls?"
-msgstr ""
+msgstr "你产珍珠？"
 
 #. Key:	6FED048C4BF38E565F2ADC90DC3F4390
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(16 - Value).TraitIcons.DisplayName
@@ -5919,28 +5920,28 @@ msgstr "热心肠"
 #: /Game/Dialogue/Cassie/Default/CassieDefault01_RL.Default__CassieDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",6FF789054D56C91D6CC53C8148D8EFCD"
 msgid "What's with the dungeon by the temple?"
-msgstr ""
+msgstr "圣殿旁边的地牢是怎么回事?"
 
 #. Key:	703D9D7D4CD9D794DDE1929CCE0E5D1C
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMDefault_RL5_F.Default__DMDefault_RL5_F_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/DragonMatriarch/Default/DMDefault_RL5_F.Default__DMDefault_RL5_F_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",703D9D7D4CD9D794DDE1929CCE0E5D1C"
 msgid "Bring it on dragon."
-msgstr ""
+msgstr "放马过来吧，巨龙"
 
 #. Key:	703E8E554AE59D97908541A592216732
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcFixOwnGate.Default__OrcFixOwnGate_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/OrcChief/Default/OrcFixOwnGate.Default__OrcFixOwnGate_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",703E8E554AE59D97908541A592216732"
 msgid "Grrrrrrrr!!!"
-msgstr ""
+msgstr "咕噜咕噜"
 
 #. Key:	703FABE24E96D3592AA524833F23CA4D
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDefault01_RL.Default__CassieDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
 #: /Game/Dialogue/Cassie/Default/CassieDefault01_RL.Default__CassieDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
 msgctxt ",703FABE24E96D3592AA524833F23CA4D"
 msgid "Remind me about that dungeon under the temple."
-msgstr ""
+msgstr "你让我想起那个圣殿下的地牢。"
 
 #. Key:	705BCA1D4ACA54FF178C9DA094C9DBA1
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_R01.Default__FernDefault02_R01_C.SessionData.Lines(1).Lines
@@ -5954,35 +5955,35 @@ msgstr "我在您的土地上长大，很快它将成为我的永远的家！"
 #: /Game/Dialogue/Leylanna/SexScenes/LeylannaLeyCov.Default__LeylannaLeyCov_C.SessionData.LinesToFuta(1).LinesToFuta
 msgctxt ",7063E832426D1615683CF5A75DC53A4E"
 msgid "Yes, please me with your cock and the spirits shall grant you favor."
-msgstr "对…就是这样，用你的性器好好取悦我，我将授予你所求的魂灵形态。"
+msgstr "是的，用你的鸡巴取悦我，魂灵也会给你恩惠。"
 
 #. Key:	708DC59B48E375114559229ED41F492F
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToFemale(4).LinesToFemale
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToFemale(4).LinesToFemale
 msgctxt ",708DC59B48E375114559229ED41F492F"
 msgid "We convert semen that would go to waste into new life, you can even eat my slime!"
-msgstr ""
+msgstr "我们把会浪费掉的精液转化为新的生命，你甚至可以吃我的粘液!”"
 
 #. Key:	709579B446D8D4D2C2F3EE98857ED27A
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMDefault_RL5_T.Default__DMDefault_RL5_T_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/DragonMatriarch/Default/DMDefault_RL5_T.Default__DMDefault_RL5_T_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",709579B446D8D4D2C2F3EE98857ED27A"
 msgid "Bring it on dragon."
-msgstr ""
+msgstr "放马过来吧，巨龙"
 
 #. Key:	709C1A4748A9B0773A823DB8EB5B31E0
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeHadSex01.Default__BeeHadSex01_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/QueenBee/Default/BeeHadSex01.Default__BeeHadSex01_C.SessionData.Lines(2).Lines
 msgctxt ",709C1A4748A9B0773A823DB8EB5B31E0"
 msgid "What brings you before me?"
-msgstr ""
+msgstr "什么风把你吹来了?"
 
 #. Key:	70A96E9D4322ED35C13DF78AF12A5931
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_BlueSmoke.Default__LeylannaDefault01_BlueSmoke_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Leylanna/Default/LeylannaDefault01_BlueSmoke.Default__LeylannaDefault01_BlueSmoke_C.SessionData.Lines(0).Lines
 msgctxt ",70A96E9D4322ED35C13DF78AF12A5931"
 msgid "It allows me to commune with the spirits."
-msgstr ""
+msgstr "它能让我与灵魂交流"
 
 #. Key:	70B4299E404BAC657357D7AD12E3DF68
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFuta(16).LinesToFuta
@@ -5996,7 +5997,7 @@ msgstr "我想要感受你的酥胸……跟我的乳房紧紧交叠……啊啊
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_FutaBalls.Default__FaleneDefault01_FutaBalls_C.SessionData.Lines(3).Lines
 msgctxt ",70CF21944D42682E43C6EBB4A8757DB0"
 msgid "Like we say here in @WORLD_NAME@: SUGAR WALLS BEFORE BALLS!!"
-msgstr "就像我们在@WORLD_NAME@常说的：SUGAR WALLS BEFORE BALLS ！！"
+msgstr "就像我们在@WORLD_NAME@常说的：SUGAR WALLS BEFORE BALLS ！！（梗，阴茎如糖墙，在球的前面）"
 
 #. Key:	70D390BA48724A55513FB282118180B9
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R04.Default__CamillaDefault01_R04_C.SessionData.Lines(1).Lines
@@ -6010,14 +6011,14 @@ msgstr "法莲娜让我站在这的。她说这是为了增强我的自尊，弥
 #: /Game/Dialogue/Petra/Default/PetraGetKeystone.Default__PetraGetKeystone_C.SessionData.Lines(4).Lines
 msgctxt ",70DC582F462398013170BB8D6FFECADB"
 msgid "It's what every @MONSTER_RACE@ dreams of happening at night really."
-msgstr ""
+msgstr "这是每个魔弗灵所梦寐以求的事情"
 
 #. Key:	711B52C8486478B27C9236A70F6DABAC
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowSpiders.Default__WidowSpiders_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Widow/Default/WidowSpiders.Default__WidowSpiders_C.SessionData.Lines(3).Lines
 msgctxt ",711B52C8486478B27C9236A70F6DABAC"
 msgid "You have probably noticed that by now."
-msgstr ""
+msgstr "你现在可能已经注意到了。"
 
 #. Key:	715058EB4BEB5B309FE658A485A718AA
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R04.Default__FaleneDefault01_R04_C.SessionData.Lines(9).Lines
@@ -6038,14 +6039,14 @@ msgstr "撑好了！你这可爱的小野猫！"
 #: /Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFuta(7).LinesToFuta
 msgctxt ",717D6D564578FC099110B6899F65067E"
 msgid "That creepy golden seraphim, the one in the temple. She appeared only a few days ago, constantly asking to speak with \"the human\"."
-msgstr ""
+msgstr "那个可怕的金色六翼天使，圣殿里的那个。她几天前才出现，不断地要求和“人类”说话。"
 
 #. Key:	71914E004F66CB40BEDE07BF85D0FDC5
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcBrashDumb.Default__OrcBrashDumb_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcBrashDumb.Default__OrcBrashDumb_C.SessionData.Lines(0).Lines
 msgctxt ",71914E004F66CB40BEDE07BF85D0FDC5"
 msgid "Brash? Chieftain no understand fancy words!"
-msgstr ""
+msgstr "傲慢吗?酋长不懂花言巧语!”"
 
 #. Key:	71AEDBFC4C75BF861690DB96D8D3E7D4
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R01.Default__FaleneDefault01_R01_C.SessionData.Lines(2).Lines
@@ -6059,28 +6060,28 @@ msgstr "魔弗灵的生殖器功能跟人类的基本一样——即使功能更
 #: /Game/Dialogue/Fern/DefaultP2/FernBeeFlowers2.Default__FernBeeFlowers2_C.SessionData.Lines(1).Lines
 msgctxt ",72107B4B47CB1F5DE578558788562BE0"
 msgid "Only a dryad would have such an ability."
-msgstr ""
+msgstr "只有树妖才有这种能力。"
 
 #. Key:	7216159047B371957AA4BBB677FF8B34
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03_R04.Default__FernDefault03_R04_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03_R04.Default__FernDefault03_R04_C.SessionData.Lines(1).Lines
 msgctxt ",7216159047B371957AA4BBB677FF8B34"
 msgid "You will experience ecstasy as you cum inside my flower over and over."
-msgstr "当您在我的花瓣中一次又一次地射精时，您就能体验到真正的快乐"
+msgstr "当您在我的花瓣中一次又一次地射精时，您就能体验到真正的狂喜。"
 
 #. Key:	721BAB5440338ECB3CE2EB9A27D969B0
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiHadSex01.Default__ParvatiHadSex01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Parvati/Default/ParvatiHadSex01.Default__ParvatiHadSex01_C.SessionData.Lines(0).Lines
 msgctxt ",721BAB5440338ECB3CE2EB9A27D969B0"
 msgid "Returning to me with that familiar glint in your eye."
-msgstr ""
+msgstr "带着你眼中熟悉的光芒回到我身边。"
 
 #. Key:	722820CF485DAAEF312AD7B7C497D3AD
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03_R05.Default__FernDefault03_R05_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03_R05.Default__FernDefault03_R05_C.SessionData.Lines(0).Lines
 msgctxt ",722820CF485DAAEF312AD7B7C497D3AD"
 msgid "Isn't she beautiful?!"
-msgstr "她难道不美吗？"
+msgstr "难道她不美吗？"
 
 #. Key:	72570AA14FB2D285DAAB6584C841B08C
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_Forgot.Default__ParvatiDefault01_Forgot_C.SessionData.Lines(6).Lines
@@ -6094,14 +6095,14 @@ msgstr "你想要复习哪个体位？"
 #: /Game/Dialogue/Autumn/Default/DryadGreeting01.Default__DryadGreeting01_C.SessionData.Lines(2).Lines
 msgctxt ",725969164426D429929F949920B9A0BD"
 msgid "Delicious bosom cherries for all of my lovely dairies."
-msgstr ""
+msgstr "为我可爱的牧场准备了美味的乳房樱桃"
 
 #. Key:	72676A264244C7A242C2688B7B60F6A5
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01.Default__MirruDefault01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Mirru/Default/MirruDefault01.Default__MirruDefault01_C.SessionData.Lines(1).Lines
 msgctxt ",72676A264244C7A242C2688B7B60F6A5"
 msgid "Have you come to please this Kraken princess?"
-msgstr ""
+msgstr "你是来取悦这位克拉肯公主的吗?"
 
 #. Key:	729B81554E3D9EF979C07FB7C419E3C5
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R07.Default__FaleneDefault01_R07_C.SessionData.LinesToFuta(0).LinesToFuta
@@ -6122,21 +6123,21 @@ msgstr "既然如此，那我就要舐遍你蜜穴的每寸沟壑！"
 #: /Game/Dialogue/Fern/Default/FernHadSex01.Default__FernHadSex01_C.SessionData.Lines(1).Lines
 msgctxt ",72D1FC5F42F98687EDAE5AB4FD366E18"
 msgid "More! More!"
-msgstr ""
+msgstr "更多！我还要！"
 
 #. Key:	7329381C44D0F4921C47709DC7891BC4
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraDefault01_RL.Default__PetraDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
 #: /Game/Dialogue/Petra/Default/PetraDefault01_RL.Default__PetraDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
 msgctxt ",7329381C44D0F4921C47709DC7891BC4"
 msgid "You can practice with me!"
-msgstr ""
+msgstr "你可以和我一起练习做爱呀！"
 
 #. Key:	737ACFDE44717F24FCFA89B1A6780AA2
 #. SourceLocation:	/Game/Dialogue/Neela/SexScenes/NeelaSnakeCuddleT.Default__NeelaSnakeCuddleT_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Neela/SexScenes/NeelaSnakeCuddleT.Default__NeelaSnakeCuddleT_C.SessionData.Lines(4).Lines
 msgctxt ",737ACFDE44717F24FCFA89B1A6780AA2"
 msgid "Ahhh yes! Fill it with your human seed... ohhh."
-msgstr "啊啊啊~好爽！用你人类的种填满我的穴吧…啊~啊~"
+msgstr "啊啊啊~好爽！用你人类的种子填满我的蜜穴吧…噢~"
 
 #. Key:	73986546438B9C190B8B769537B05047
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TravelShrines(12 - Value).TravelShrines.ShrineName
@@ -6150,7 +6151,7 @@ msgstr "极乐之巅"
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(0).Lines
 msgctxt ",73B062844EF9F666A3FC88A79A97D47A"
 msgid "The Goddess in Her infinite wisdom became filled with desire after eons of loneliness."
-msgstr ""
+msgstr "在无尽的孤独之后，拥有无限智慧的女神充满了欲望。”"
 
 #. Key:	73B3AE3C43F892A09044CD8CAABBE3B3
 #. SourceLocation:	/Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToFuta(2).LinesToFuta
@@ -6164,49 +6165,49 @@ msgstr "当你的肉棒触到我的上颚时，感受我丝绒般的舌头抚摸
 #: /Game/Dialogue/Fern/DefaultP2/FernGreeting02.Default__FernGreeting02_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",73B59191487A1B6CCB6E58B4159D8060"
 msgid "Oh Master, you have fed me well."
-msgstr "噢，主人，你喂养的很好。"
+msgstr "噢，主人，您把我喂养的很好。"
 
 #. Key:	73C9D0AC49FFC3AEB6CFA59DB5E4FB92
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_RL.Default__LeylannaDefault01_RL_C.ResponseData(5).ResponseData.BreederPrompt
 #: /Game/Dialogue/Leylanna/Default/LeylannaDefault01_RL.Default__LeylannaDefault01_RL_C.ResponseData(5).ResponseData.BreederPrompt
 msgctxt ",73C9D0AC49FFC3AEB6CFA59DB5E4FB92"
 msgid "That blue smoke smells... nice..."
-msgstr ""
+msgstr "那个蓝色的烟雾，闻上去……棒极了"
 
 #. Key:	73F68F1D4C449AE1E1ECBCB61358B27E
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R02.Default__CamillaDefault01_R02_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R02.Default__CamillaDefault01_R02_C.SessionData.Lines(2).Lines
 msgctxt ",73F68F1D4C449AE1E1ECBCB61358B27E"
 msgid "Harpies prefer the hot sands of the Lewd Desert."
-msgstr ""
+msgstr "哈比们喜欢淫荡沙漠的热沙。"
 
 #. Key:	74017161472DC2AF18D66788ABE8AF78
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeDefault01.Default__BeeDefault01_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/QueenBee/Default/BeeDefault01.Default__BeeDefault01_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",74017161472DC2AF18D66788ABE8AF78"
 msgid "This corner is n-n-nice and safe!"
-msgstr ""
+msgstr "这个角落真的是-真-真的是又棒又安全"
 
 #. Key:	740E4D7D44C42EC222B32AAF3DB022F4
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R01.Default__FaleneDefault01_R01_C.SessionData.Lines(11).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R01.Default__FaleneDefault01_R01_C.SessionData.Lines(11).Lines
 msgctxt ",740E4D7D44C42EC222B32AAF3DB022F4"
 msgid "It's likely we have barely scratched the surface of what it's capable of, so my theory isn't that farfetched."
-msgstr "我们的假说很有可能触及到了一些真相，所以这个假说看起来并不那么牵强。"
+msgstr "很可能我们只是触及了它的能力的表面，所以我的理论并不牵强。"
 
 #. Key:	7413D71A4AAA4CA135368D8D6BD67DC1
 #. SourceLocation:	/Game/Dialogue/Mirru/SexScenes/MirruKrakVag.Default__MirruKrakVag_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Mirru/SexScenes/MirruKrakVag.Default__MirruKrakVag_C.SessionData.Lines(5).Lines
 msgctxt ",7413D71A4AAA4CA135368D8D6BD67DC1"
 msgid "I am going to cum... ahhh... it will be messy."
-msgstr "我要到了……哎呀……搞得一团糟……"
+msgstr "我要去了……哎呀……要搞得一团糟了……"
 
 #. Key:	744AC6EA4EF6E8F4298079829B209661
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimePlay1.Default__MegaSlimePlay1_C.SessionData.LinesToFuta(0).LinesToFuta
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePlay1.Default__MegaSlimePlay1_C.SessionData.LinesToFuta(0).LinesToFuta
 msgctxt ",744AC6EA4EF6E8F4298079829B209661"
 msgid "You are so kind! No one has ever been so nice to me!"
-msgstr ""
+msgstr "你真好!从来没有人对我这么好!"
 
 #. Key:	744F4E844CF281ADE05939B86FCE678E
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy_RL_T.Default__MirruDefault01_BodySexToy_RL_T_C.ResponseData(2).ResponseData.BreederPrompt
@@ -6220,21 +6221,21 @@ msgstr "你不止一个心脏？！"
 #: /Game/Dialogue/QueenBee/Default/BeeDefault03_RL.Default__BeeDefault03_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",7468ACB44E64BE348C44FFAF36EB756D"
 msgid "I will figure out how to make the flowers grow."
-msgstr ""
+msgstr "我会想办法让花长起来的。"
 
 #. Key:	748A7C25489A4B1CEC2B5D91B815FE8D
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimePearl.Default__MegaSlimePearl_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePearl.Default__MegaSlimePearl_C.SessionData.Lines(2).Lines
 msgctxt ",748A7C25489A4B1CEC2B5D91B815FE8D"
 msgid "I want to give you something in return."
-msgstr ""
+msgstr "我想给你点东西作为回报。"
 
 #. Key:	74AA1A6D401AC350EC36AA9E8E34202A
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeHadSex01.Default__MegaSlimeHadSex01_C.SessionData.LinesToFuta(1).LinesToFuta
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeHadSex01.Default__MegaSlimeHadSex01_C.SessionData.LinesToFuta(1).LinesToFuta
 msgctxt ",74AA1A6D401AC350EC36AA9E8E34202A"
 msgid "*Yawn*"
-msgstr ""
+msgstr "打哈欠"
 
 #. Key:	74E667E542A1B2DD54B1A4852E0B5BDE
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_RL_T.Default__FernDefault02_RL_T_C.ResponseData(1).ResponseData.BreederPrompt
@@ -6248,21 +6249,21 @@ msgstr "你变了！"
 #: /Game/World/Events/EM_Keystone.Default__EM_Keystone_C.FailMessage
 msgctxt ",750AE2DA411665A89B7126BAB42FC805"
 msgid "It's stuck in slime."
-msgstr ""
+msgstr "它卡在史莱姆里面了。"
 
 #. Key:	7519309946A12CD84883FC98FC964091
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.CBGate_Peak.PlaceMessage
 #: /Game/World/Overworld.Overworld:PersistentLevel.CBGate_Peak.PlaceMessage
 msgctxt ",7519309946A12CD84883FC98FC964091"
 msgid "Climax Peak is now accessible."
-msgstr ""
+msgstr "现在可以访问极乐之巅了"
 
 #. Key:	752BA5D9498A3D0A3B274BA6E3AFDDAE
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TravelShrines(11 - Value).TravelShrines.ShrineName
 #: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TravelShrines(11 - Value).TravelShrines.ShrineName
 msgctxt ",752BA5D9498A3D0A3B274BA6E3AFDDAE"
 msgid "Lewd Desert"
-msgstr ""
+msgstr "淫荡沙漠"
 
 #. Key:	7531D7CC4B4C50FC4972DB878B5DEDCA
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_RL.Default__LeylannaDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
@@ -6297,28 +6298,28 @@ msgstr "蜜穴之门……认真的吗？"
 #: /Game/Dialogue/Romy/Default/RomyDefault01.Default__RomyDefault01_C.SessionData.Lines(1).Lines
 msgctxt ",7618202D4A38C8CACBFF19A33C3F1E02"
 msgid "What can this humble mermaid do for you?"
-msgstr "区区人鱼，为您效劳。"
+msgstr "我这个卑微的美人鱼能为你做什么呢?"
 
 #. Key:	76389D804BFE8383064F778E692DD2D9
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault02.Default__FaleneDefault02_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault02.Default__FaleneDefault02_C.SessionData.Lines(1).Lines
 msgctxt ",76389D804BFE8383064F778E692DD2D9"
 msgid "The tiny little adorable nugget over there is my assistant Camilla."
-msgstr ""
+msgstr "那边那个可爱的小东西是我的助手卡米拉。"
 
 #. Key:	76894E414F0E86A40CDEB69862E1A67C
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R01.Default__FaleneDefault01_R01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R01.Default__FaleneDefault01_R01_C.SessionData.Lines(1).Lines
 msgctxt ",76894E414F0E86A40CDEB69862E1A67C"
 msgid "To be honest, we don't entirely understand how it works, but I have created the most widely accepted theory."
-msgstr "老实说，我们也不能完全理解它的工作原理，不过我创造了最被广泛接受的假说。"
+msgstr "说实话，我们还不完全了解它是如何运作的，但我创造了一个被最广泛接受的理论。"
 
 #. Key:	768DD9E6434228B7421D599AE774A24C
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeVerySad3.Default__MegaSlimeVerySad3_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeVerySad3.Default__MegaSlimeVerySad3_C.SessionData.Lines(0).Lines
 msgctxt ",768DD9E6434228B7421D599AE774A24C"
 msgid "*ENDLESS SOBBING*"
-msgstr ""
+msgstr "*无尽的哭泣*"
 
 #. Key:	76C3B8B24ADB1D21C1F205A4E3B35D2A
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(31 - Value).TraitIcons.HelpText
@@ -6332,7 +6333,7 @@ msgstr "反常体型：继承了不寻常的体型大小"
 #: /Game/Dialogue/Falene/Default/FaleneDefault02.Default__FaleneDefault02_C.SessionData.Lines(3).Lines
 msgctxt ",76DCFBB44EA9841F910FB9BE2CBD16B7"
 msgid "Of course we make love! What else are assistants for?"
-msgstr ""
+msgstr "我们当然会做爱!助理还能干什么?"
 
 #. Key:	76DD724248BA7178346EC59171F3BDF4
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyGreeting01.Default__RomyGreeting01_C.SessionData.LinesGrungy(5).LinesGrungy
@@ -6353,7 +6354,7 @@ msgstr "对…就是这样，用你的舌头好好取悦我，我将授予你所
 #: /Game/UI/TaskDescriptions.TaskDescriptions.TextEntries(7).TextEntries
 msgctxt ",774EB8DD4A26316F99CA678113DB2B19"
 msgid "Wet! I am wet and horny, only you can help. This time I want something to suck on, so breed me an adorable Nephelym with all sorts of suckables. Yes, suckables, you heard it here first.  -Falene"
-msgstr ""
+msgstr "又湿了!我又湿又欲火中烧，只有你能帮我。这次我想要一个可以吸吮的东西，所以给我养一个有各种吸吮物的可爱的魔弗灵。没错，可以吸吮的，你们是第一次在这里听到的。-法莲娜"
 
 #. Key:	77D22B994A5CAE9D14BE2DA1F7D43473
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R04.Default__FaleneDefault01_R04_C.SessionData.Lines(7).Lines
@@ -6402,7 +6403,7 @@ msgstr "光是看着你我就已经欲火焚身了... "
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_Leylanna.Default__EmissaryDefault01_Leylanna_C.SessionData.Lines(6).Lines
 msgctxt ",78C065C7473E103C41FCDA893D7F14FF"
 msgid "Frequently, she will wander over here naked with a glazed look in her eye."
-msgstr ""
+msgstr "她经常光着身子在这里走来走去，眼神呆滞。"
 
 #. Key:	78CE278740CEF8CBD44C7699C20FEA54
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_AboutLamias.Default__NeelaDefault01_AboutLamias_C.SessionData.Lines(1).Lines
@@ -6416,7 +6417,7 @@ msgstr "数千年作为虚空守护者的流浪日子让我离我的同伴更加
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeVerySad.Default__MegaSlimeVerySad_C.SessionData.Lines(1).Lines
 msgctxt ",79024D21459BC365A01399ABC4581F9B"
 msgid "It was so beautiful..."
-msgstr ""
+msgstr "回味无穷。"
 
 #. Key:	7921ED37459363625C14BEAA60B51F49
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_Pregnancy.Default__FaleneDefault01_Pregnancy_C.SessionData.Lines(4).Lines
@@ -6430,21 +6431,21 @@ msgstr "那不只是梦幻和可爱吗？ !!！"
 #: /Game/Dialogue/Kybele/Default/KybeleHadSex01.Default__KybeleHadSex01_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",7989199A4B0BA24F0B904493FCC965AC"
 msgid "Still... you took my fat horse cock well. That's amazing for one of your size!"
-msgstr ""
+msgstr "你仍然把我的大肥马屌照顾的很好。你的尺寸太棒了！"
 
 #. Key:	7A0924884575833B8154E88AE733B3E4
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.EM_Keystone_Kybele.FailMessage
 #: /Game/World/Overworld.Overworld:PersistentLevel.EM_Keystone_Kybele.FailMessage
 msgctxt ",7A0924884575833B8154E88AE733B3E4"
 msgid "Kybele fiercely guards this keystone."
-msgstr ""
+msgstr "凯布莉凶猛地守卫着这个钥石。"
 
 #. Key:	7A22D0874255FC1001174C8C01466911
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimePearl.Default__MegaSlimePearl_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePearl.Default__MegaSlimePearl_C.SessionData.Lines(3).Lines
 msgctxt ",7A22D0874255FC1001174C8C01466911"
 msgid "My beloved orb wishes to move on, and I want you to take it."
-msgstr ""
+msgstr "我亲爱的珍珠它希望继续前行，所以我希望你收下它。"
 
 #. Key:	7A37639548189268575986A48C480863
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_TheVoid.Default__NeelaDefault01_TheVoid_C.SessionData.Lines(2).Lines
@@ -6472,35 +6473,35 @@ msgstr "放松，让我来油润滑一下你的鸡巴。"
 #: /Game/Dialogue/Fesssi/Default/FesssiIdiots.Default__FesssiIdiots_C.SessionData.Lines(0).Lines
 msgctxt ",7A69F5FB4A97FC4EE925589FFD78142E"
 msgid "Indeed, sexy horny idiots. Hiss!"
-msgstr ""
+msgstr "的确，性感饥渴的笨蛋。嘶嘶"
 
 #. Key:	7A7EFCC44E743CC63CBCBB86D21C890C
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcBrashDumb.Default__OrcBrashDumb_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcBrashDumb.Default__OrcBrashDumb_C.SessionData.Lines(1).Lines
 msgctxt ",7A7EFCC44E743CC63CBCBB86D21C890C"
 msgid "Orcs are strong... maybe dumb, but strong."
-msgstr ""
+msgstr "兽人很强大…也许很傻，但很强大。"
 
 #. Key:	7AE87BF645B6A4B1D35071A966CCF13E
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_RL.Default__EmissaryDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_RL.Default__EmissaryDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",7AE87BF645B6A4B1D35071A966CCF13E"
 msgid "Raise the trait level."
-msgstr "提升特征/特质等级"
+msgstr "提高特质水平"
 
 #. Key:	7AF5BE374EF5FF228013EAB5CEA00E2E
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.EM_Keystone_DM.FailMessage
 #: /Game/World/Overworld.Overworld:PersistentLevel.EM_Keystone_DM.FailMessage
 msgctxt ",7AF5BE374EF5FF228013EAB5CEA00E2E"
 msgid "Don't touch this."
-msgstr ""
+msgstr "不准触碰。"
 
 #. Key:	7B46D37346081D01CB0C9B8C6CAEE2DF
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_RL.Default__NeelaDefault01_RL_C.ResponseData(4).ResponseData.BreederPrompt
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_RL.Default__NeelaDefault01_RL_C.ResponseData(4).ResponseData.BreederPrompt
 msgctxt ",7B46D37346081D01CB0C9B8C6CAEE2DF"
 msgid "I want to traverse your pussy... portal."
-msgstr "我迫不及待要进入……门了。"
+msgstr "我已经迫不及待要进入……门了。"
 
 #. Key:	7B5F72194EE494B66BEC5CAD05253722
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(15 - Value).TraitIcons.DisplayName
@@ -6514,49 +6515,49 @@ msgstr "多汁"
 #: /Game/Dialogue/Mirru/Default/MirruHadSex01.Default__MirruHadSex01_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",7BA3471A456AB33D0F6E1AB523E14EBC"
 msgid "Believe it or not, I held back and could have drenched you with more kraken cum."
-msgstr ""
+msgstr "信不信由你，我忍住了，本来可以用克拉肯精液浸湿你的。"
 
 #. Key:	7BA8039A45383C5B11EEA9AC428E3158
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToMale(0).LinesToMale
 #: /Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToMale(0).LinesToMale
 msgctxt ",7BA8039A45383C5B11EEA9AC428E3158"
 msgid "Ohhh @BREEDER_NAME@... you were amazing."
-msgstr ""
+msgstr "嗷！@BREEDER_NAME@……你太让我吃惊了。"
 
 #. Key:	7BD230084E2B289F72FCC48F4E4B7CB8
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraPracticeMe.Default__PetraPracticeMe_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Petra/Default/PetraPracticeMe.Default__PetraPracticeMe_C.SessionData.Lines(0).Lines
 msgctxt ",7BD230084E2B289F72FCC48F4E4B7CB8"
 msgid "How sweet! Awww..."
-msgstr ""
+msgstr "多么甜蜜!哇……"
 
 #. Key:	7BF991CE424A23FC457D0E9B71CACEBE
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMGreeting01.Default__DMGreeting01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMGreeting01.Default__DMGreeting01_C.SessionData.Lines(1).Lines
 msgctxt ",7BF991CE424A23FC457D0E9B71CACEBE"
 msgid "Is this a dream? Humans aren't supposed to exist."
-msgstr ""
+msgstr "这是梦吗?人类本不应该存在的。"
 
 #. Key:	7C125E5D4D9517525ACC16A414D5C0E1
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadGreeting01.Default__DryadGreeting01_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Autumn/Default/DryadGreeting01.Default__DryadGreeting01_C.SessionData.Lines(4).Lines
 msgctxt ",7C125E5D4D9517525ACC16A414D5C0E1"
 msgid "I didn't notice I had a visitor. A human visitor... how interesting."
-msgstr ""
+msgstr "“我没注意到有人来拜访我。一个人类访问者……真有意思。"
 
 #. Key:	7C3236894BBFE97A5B89BC84CF6B44F2
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraDefault01.Default__PetraDefault01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Petra/Default/PetraDefault01.Default__PetraDefault01_C.SessionData.Lines(0).Lines
 msgctxt ",7C3236894BBFE97A5B89BC84CF6B44F2"
 msgid "Aww the cute human has returned."
-msgstr ""
+msgstr "哇，可爱的人类回来了。"
 
 #. Key:	7C3F628D4E83DBC5016EC8A8263D2372
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowDefault01_RL.Default__WidowDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/Widow/Default/WidowDefault01_RL.Default__WidowDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",7C3F628D4E83DBC5016EC8A8263D2372"
 msgid "Scary!"
-msgstr ""
+msgstr "哇哦~好吓人！"
 
 #. Key:	7C4054234127D8843978CD80C4B540B7
 #. SourceLocation:	/Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToMale(1).LinesToMale
@@ -6570,14 +6571,14 @@ msgstr "你的……哦，好棒，感觉好舒服! 更深点!"
 #: /Game/Dialogue/Kybele/Default/KybeleAnyMeans_RL_T.Default__KybeleAnyMeans_RL_T_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",7C47118C4A51AA8F9E612C99BCE37ABF"
 msgid "I will be leaving now..."
-msgstr ""
+msgstr "我现在要走了……"
 
 #. Key:	7C5554A44E14D8611780E99EAC37F747
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyLockedDungeon.Default__RomyLockedDungeon_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Romy/Default/RomyLockedDungeon.Default__RomyLockedDungeon_C.SessionData.Lines(0).Lines
 msgctxt ",7C5554A44E14D8611780E99EAC37F747"
 msgid "I don't know how to access it, but beware."
-msgstr ""
+msgstr "我不知道怎么打开它，但是请小心。"
 
 #. Key:	7C5853BA4383F9B61021B3A6AD59FA09
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01.Default__ParvatiDefault01_C.SessionData.Lines(3).Lines
@@ -6612,42 +6613,42 @@ msgstr "*舔，啧啧水声*"
 #: /Game/Dialogue/Petra/Default/PetraDefault01_RL.Default__PetraDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",7D4C4BD949BF041F9FA20CB373FAA9DB"
 msgid "Tell me about Pawsmatti."
-msgstr ""
+msgstr "跟我说说帕丝玛媞吧。"
 
 #. Key:	7D4DC0064FB622869AA3E3B8CFCF2444
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryCockblockGates.Default__EmissaryCockblockGates_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryCockblockGates.Default__EmissaryCockblockGates_C.SessionData.Lines(0).Lines
 msgctxt ",7D4DC0064FB622869AA3E3B8CFCF2444"
 msgid "Ah you mean the Cockblock Gates."
-msgstr ""
+msgstr "啊，你说的是鸡鸡门啊"
 
 #. Key:	7D9B8CD848A3DAA68B924CA2B1E60858
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToFemale(2).LinesToFemale
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",7D9B8CD848A3DAA68B924CA2B1E60858"
 msgid "Our preference is always for semen from the source, if you know what I mean."
-msgstr ""
+msgstr ""我们的偏好总是来自源头的精液，如果你懂我的意思的话"
 
 #. Key:	7DC88423439E72249A6A439C756B59B8
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeDefault01.Default__BeeDefault01_C.SessionData.LinesToFemale(2).LinesToFemale
 #: /Game/Dialogue/QueenBee/Default/BeeDefault01.Default__BeeDefault01_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",7DC88423439E72249A6A439C756B59B8"
 msgid "Good thing I have my toy!"
-msgstr ""
+msgstr "幸好我有玩具!"
 
 #. Key:	7DEDC34249AC42CB6EF8018004CA4FF0
 #. SourceLocation:	/Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToFemale(3).LinesToFemale
 #: /Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",7DEDC34249AC42CB6EF8018004CA4FF0"
 msgid "The way you lick my ear... ahhh, it tickles hehe!"
-msgstr "你舔我耳朵的方式……哈啊！真的好痒！"
+msgstr "你舔我耳朵的方式……哈啊！真的好痒！哈哈"
 
 #. Key:	7E36966C48C520604CCDB1B0B9BC0D6E
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadDefault01_RL.Default__DryadDefault01_RL_C.ResponseData(3).ResponseData.BreederPrompt
 #: /Game/Dialogue/Autumn/Default/DryadDefault01_RL.Default__DryadDefault01_RL_C.ResponseData(3).ResponseData.BreederPrompt
 msgctxt ",7E36966C48C520604CCDB1B0B9BC0D6E"
 msgid "So I met this lamia with a huge ass..."
-msgstr ""
+msgstr "所以我遇到了这个大屁股的拉米亚…"
 
 #. Key:	7E841B634D3F978AEFAC20B8445DB231
 #. SourceLocation:	/Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToMale(2).LinesToMale
@@ -6661,21 +6662,21 @@ msgstr "当你的肉棒触到我的上颚时，感受我丝绒般的舌头抚摸
 #: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TravelShrines(10 - Value).TravelShrines.ShrineName
 msgctxt ",7E871257404E27C20903A3877220C69A"
 msgid "Pleasure Pastures"
-msgstr "快感牧野"
+msgstr "快感牧场"
 
 #. Key:	7E8B7E764E94AEB05F7AEBA0A2B30442
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiDefault03_RL_F.Default__FesssiDefault03_RL_F_C.ResponseData(2).ResponseData.BreederPrompt
 #: /Game/Dialogue/Fesssi/Default/FesssiDefault03_RL_F.Default__FesssiDefault03_RL_F_C.ResponseData(2).ResponseData.BreederPrompt
 msgctxt ",7E8B7E764E94AEB05F7AEBA0A2B30442"
 msgid "Where does that cave lead?"
-msgstr ""
+msgstr "那个洞穴通向哪里?”"
 
 #. Key:	7EB70BCB424768DDF719C0A18F381AB6
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiStuck.Default__FesssiStuck_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiStuck.Default__FesssiStuck_C.SessionData.Lines(0).Lines
 msgctxt ",7EB70BCB424768DDF719C0A18F381AB6"
 msgid "Oh... yessss I suppose it would be easier to mate if I was free."
-msgstr ""
+msgstr "哦……是的，我想如果我是自由的话做爱会更容易些。"
 
 #. Key:	7ECA06BA481C3327A91288A9BFF1F23D
 #. SourceLocation:	/Game/Dialogue/Mirru/SexScenes/MirruKrakVag.Default__MirruKrakVag_C.SessionData.Lines(1).Lines
@@ -6689,7 +6690,7 @@ msgstr "啊……噢……就是这样！"
 #: /Game/Dialogue/Blossom/Default/BlossomDefault01_R03.Default__BlossomDefault01_R03_C.SessionData.Lines(1).Lines
 msgctxt ",7ED8B0A7419F30B18D98B1BF4842D4A5"
 msgid "When mastah not want harvest... Blossom do it."
-msgstr "当主人不想自己采集魔弗灵的汁液时，小小蕨来干！"
+msgstr "当主银不想自己采集魔弗灵的汁液时，花花来干！"
 
 #. Key:	7EF1ACD74571884FC8F3A9B17EC12FEC
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.SylvanTreehouse.ManageActionMessage
@@ -6710,28 +6711,28 @@ msgstr "发散性"
 #: /Game/Dialogue/Kybele/Default/KybeleTaskFulfilled.Default__KybeleTaskFulfilled_C.SessionData.LinesToFemale(4).LinesToFemale
 msgctxt ",7F23CD5A4568538ECF60ED883E7BBAFA"
 msgid "Her large mouth can take a lot of it, and I make sure to shoot loads down her throat."
-msgstr ""
+msgstr "她的大嘴能吞下很多，我一定会把子弹深深地射进她的喉咙"
 
 #. Key:	7F6924F64E3D07A056BFC7903542E0AB
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeHaveKeystone.Default__BeeHaveKeystone_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/QueenBee/Default/BeeHaveKeystone.Default__BeeHaveKeystone_C.SessionData.Lines(4).Lines
 msgctxt ",7F6924F64E3D07A056BFC7903542E0AB"
 msgid "If you thought my honey was delicious now, it is but a shadow of what it once was."
-msgstr ""
+msgstr "如果你认为我的蜂蜜现在很好吃的话，那也只不过是它曾经的影子"
 
 #. Key:	7FD5123E4461F41BFB2CAF8A15B94955
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraGreeting01.Default__PetraGreeting01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Petra/Default/PetraGreeting01.Default__PetraGreeting01_C.SessionData.Lines(1).Lines
 msgctxt ",7FD5123E4461F41BFB2CAF8A15B94955"
 msgid "Have you also come to this jungle to seek the Enlightened One?"
-msgstr ""
+msgstr "您也来到这片丛林来寻找开悟之人吗?"
 
 #. Key:	7FEBA6A748A632320A5759BABB317345
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R02.Default__CamillaDefault01_R02_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R02.Default__CamillaDefault01_R02_C.SessionData.Lines(4).Lines
 msgctxt ",7FEBA6A748A632320A5759BABB317345"
 msgid "Dragons like the canyons of Virgin Breaks."
-msgstr "龙人喜欢呆在落红之地的峡谷。"
+msgstr "龙人喜欢呆在落红断崖的峡谷。"
 
 #. Key:	7FEBDCF1488DFD58CEB8F28DF96358B3
 #. SourceLocation:	/Game/Dialogue/Neela/SexScenes/NeelaSnakeCuddleF.Default__NeelaSnakeCuddleF_C.SessionData.Lines(5).Lines
@@ -6745,14 +6746,14 @@ msgstr "你的小屁股真漂亮，恨不得把脸埋进去，把这些淫荡的
 #: /Game/Dialogue/Camilla/Default/CamillaHadSex02.Default__CamillaHadSex02_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",7FF4B7A846AB31C139AAB39A8D7D52E6"
 msgid "Ohhh but I did!"
-msgstr ""
+msgstr "噢！但是我做到了!"
 
 #. Key:	7FFABE9A47E55779EE09758A40C05E71
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowTaskFullfilled2.Default__WidowTaskFullfilled2_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Widow/Default/WidowTaskFullfilled2.Default__WidowTaskFullfilled2_C.SessionData.Lines(0).Lines
 msgctxt ",7FFABE9A47E55779EE09758A40C05E71"
 msgid "No human... it is love."
-msgstr ""
+msgstr "不，人类……这是爱"
 
 #. Key:	803D82954112367C37478B894372AB5A
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_FloatRhyme.Default__ParvatiDefault01_FloatRhyme_C.SessionData.Lines(5).Lines
@@ -6773,14 +6774,14 @@ msgstr "浴池温暖，音乐醉人，如今还有人类的绝妙陪伴."
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePlay1.Default__MegaSlimePlay1_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",809919A3474406E99443B39588E9EAE7"
 msgid "You are so kind! No one has ever been so nice to me!"
-msgstr ""
+msgstr "你真好!从来没有人对我这么好!"
 
 #. Key:	80E41C3F423650528E6EDA8372C9D9E8
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMAboutDragons.Default__DMAboutDragons_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMAboutDragons.Default__DMAboutDragons_C.SessionData.Lines(0).Lines
 msgctxt ",80E41C3F423650528E6EDA8372C9D9E8"
 msgid "We are the masters of this mountain range."
-msgstr ""
+msgstr "我们是这片山脉的主人。"
 
 #. Key:	8103840A43F7351F6B263C98CC5A6335
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeDefault01_SuckJugs.Default__AmberMaeDefault01_SuckJugs_C.SessionData.Lines(2).Lines
@@ -6794,14 +6795,14 @@ msgstr "俺的咪咪里装满了奶，尼确定尼的小身体能全吞下去哦
 #: /Game/Dialogue/Kybele/Default/KybeleHadSex01.Default__KybeleHadSex01_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",8169C4CD4FCCAEC60B1417A262737D1E"
 msgid "Oh that felt amazing!!"
-msgstr ""
+msgstr "哦，那感觉棒呆了!!"
 
 #. Key:	8178665B4810CB468AA548A496C72040
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaHadSex01.Default__LeylannaHadSex01_C.SessionData.LinesToMale(3).LinesToMale
 #: /Game/Dialogue/Leylanna/Default/LeylannaHadSex01.Default__LeylannaHadSex01_C.SessionData.LinesToMale(3).LinesToMale
 msgctxt ",8178665B4810CB468AA548A496C72040"
 msgid "Bring that hard cock over here... I want to feel it inside me."
-msgstr ""
+msgstr "把那只硬鸡巴带到这儿来……”我想要细细品味。"
 
 #. Key:	81AE34CA41E9CDDCF3756EBC867EF3A5
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_NoSpiritVariant.Default__LeylannaDefault01_NoSpiritVariant_C.SessionData.LinesToFuta(0).LinesToFuta
@@ -6815,7 +6816,7 @@ msgstr "等你抓住一只扶她狐灵再回来找我吧。"
 #: /Game/Dialogue/Cassie/Default/CassieDungeon2.Default__CassieDungeon2_C.SessionData.Lines(0).Lines
 msgctxt ",81AEB34842855FDDE393E2B3B0568109"
 msgid "It's the old temple because I guess the new one is better."
-msgstr ""
+msgstr "是旧的圣殿，因为我猜测新的圣殿更好吧。"
 
 #. Key:	81BA7F3C4947D886880CA687DA5D133F
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TravelShrines(7 - Value).TravelShrines.ShrineName
@@ -6836,21 +6837,21 @@ msgstr "测试2"
 #: /Game/Dialogue/Widow/Default/WidowTaskFullfilled2.Default__WidowTaskFullfilled2_C.SessionData.Lines(1).Lines
 msgctxt ",8249C21F4D54352D41F755B9013E7ACE"
 msgid "She loves my soft silky webs, and especially my tongue."
-msgstr ""
+msgstr "她爱我柔软如丝的网，尤其是我的舌头。"
 
 #. Key:	827D026847F470B33C9BA5B6E24201F5
 #. SourceLocation:	/Game/Breeding/Positions/Lifted.Default__Lifted_C.SessionData.PositionName
 #: /Game/Breeding/Positions/Lifted.Default__Lifted_C.SessionData.PositionName
 msgctxt ",827D026847F470B33C9BA5B6E24201F5"
 msgid "Lifted"
-msgstr ""
+msgstr "已提升"
 
 #. Key:	829C4F164806E6C664338C969BCB960E
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_RL_M.Default__FernDefault02_RL_M_C.ResponseData(4).ResponseData.BreederPrompt
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02_RL_M.Default__FernDefault02_RL_M_C.ResponseData(4).ResponseData.BreederPrompt
 msgctxt ",829C4F164806E6C664338C969BCB960E"
 msgid "The Queen Bee demands flowers."
-msgstr ""
+msgstr "蜂后渴望鲜花的簇拥"
 
 #. Key:	8323A0B240DA89AE9385A6970E54FC26
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryBlessedInquiry01_R01.Default__EmissaryBlessedInquiry01_R01_C.SessionData.Lines(3).Lines
@@ -6864,7 +6865,7 @@ msgstr "为汝之侍，吾将以肉身成全。欢愉将席卷汝，于吾而言
 #: /Game/Dialogue/Mirru/Default/MirruHadSex01.Default__MirruHadSex01_C.SessionData.LinesToFuta(3).LinesToFuta
 msgctxt ",833370124F1D6AF95E5FC9844AB0DA75"
 msgid "It's not often one so small has the courage to dick a kraken. I hope my fleshy body pleased you."
-msgstr ""
+msgstr "很少有这么小的人有勇气去日一只克拉肯，我希望我的肉体能取悦你"
 
 #. Key:	8362C8D747AF6B672FEF0CB58B2B5B0C
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R02.Default__FaleneDefault01_R02_C.SessionData.Lines(3).Lines
@@ -6878,14 +6879,14 @@ msgstr "为什么有些魔弗灵受到神佑而有些没有是我花了好多年
 #: /Game/Dialogue/Camilla/Default/CamillaFaleneWeek.Default__CamillaFaleneWeek_C.SessionData.Lines(5).Lines
 msgctxt ",83A7F89A4658D8B1BD522891AAAC0578"
 msgid "Majority of the time, I end up stuffed in all holes."
-msgstr ""
+msgstr "大多数时候，我都被堵在洞里。"
 
 #. Key:	83B1D0DD4F37A2E70289CEAAC491EB74
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaHadSex02.Default__CamillaHadSex02_C.SessionData.LinesToFuta(0).LinesToFuta
 #: /Game/Dialogue/Camilla/Default/CamillaHadSex02.Default__CamillaHadSex02_C.SessionData.LinesToFuta(0).LinesToFuta
 msgctxt ",83B1D0DD4F37A2E70289CEAAC491EB74"
 msgid "Wow human, you must have been desperate to give this nugget your love."
-msgstr ""
+msgstr "“哇，人类，你一定是不顾一切地给这个小东西你的爱。"
 
 #. Key:	83C8B41F462880323A7E26B8AE678AA1
 #. SourceLocation:	/Game/Dialogue/Mirru/SexScenes/MirruSnatchT.Default__MirruSnatchT_C.SessionData.Lines(6).Lines
@@ -6899,28 +6900,28 @@ msgstr "啊，把你美味的种子种在我的身体里吧……啊哈……"
 #: /Game/Dialogue/Kybele/Default/KybeleHaveKeystone.Default__KybeleHaveKeystone_C.SessionData.Lines(1).Lines
 msgctxt ",83F4F4214C815B64605575ADD36AEAC7"
 msgid "Tell you what, since you're a breeder, if you give me one of your best offspring, I will let you use the keystone."
-msgstr ""
+msgstr "这样吧，既然你是一个育种家，如果你愿意把你最好的后代中的一个给我，这样我就让你用钥石。"
 
 #. Key:	83F96FD847C509C2689331A208A49D12
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault02.Default__EmissaryDefault02_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault02.Default__EmissaryDefault02_C.SessionData.Lines(5).Lines
 msgctxt ",83F96FD847C509C2689331A208A49D12"
 msgid "Now... cometh thy to offer @MONSTER_RACE@?"
-msgstr ""
+msgstr "此刻，汝是来提供魔弗灵的吗？"
 
 #. Key:	840B179B496FE7BBE7487EAE11227191
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TravelShrines(9 - Value).TravelShrines.ShrineName
 #: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TravelShrines(9 - Value).TravelShrines.ShrineName
 msgctxt ",840B179B496FE7BBE7487EAE11227191"
 msgid "Lustwood"
-msgstr "欲望之森"
+msgstr "迷情之森"
 
 #. Key:	84434E3542D0C07128FBC2B58AED1250
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchDefault01_RL.Default__MonarchDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
 #: /Game/Dialogue/Monarch/Default/MonarchDefault01_RL.Default__MonarchDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
 msgctxt ",84434E3542D0C07128FBC2B58AED1250"
 msgid "Can I have that keystone?"
-msgstr ""
+msgstr "我可以拿走那个钥石吗？"
 
 #. Key:	844B2E20423E6D2A12D638A2DC6596BE
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_RL.Default__FaleneDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
@@ -6948,7 +6949,7 @@ msgstr "什么是魂灵状态？"
 #: /Game/Dialogue/Yasmine/Default/YasminePearls.Default__YasminePearls_C.SessionData.Lines(0).Lines
 msgctxt ",84A341BF4990E1976FD7BDBD84B9102F"
 msgid "Yeah!"
-msgstr ""
+msgstr "耶！棒极了！"
 
 #. Key:	84B9634D4CF62651B1D08F9FBD40F8DD
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01.Default__FaleneDefault01_C.SessionData.Lines(2).Lines
@@ -6962,7 +6963,7 @@ msgstr "我如果在这附近待久了，我就会被欲望吞噬，然后咱俩
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R03.Default__CamillaDefault01_R03_C.SessionData.Lines(3).Lines
 msgctxt ",84B9704445972C08434F0F82443C6CDA"
 msgid "I'm tired of just licking Titans until I get drenched in their warm sticky pleasure! I want to feel a Titan deep inside me."
-msgstr "我厌倦了舔弄巨人，直到我在他们温暖粘粘的肉棒中湿透!我想感受在我体内深处的巨物。"
+msgstr "我厌倦了舔弄巨人，直到我在他们温暖粘粘的肉棒中湿透!我想要感受泰坦深入我的身体。"
 
 #. Key:	84C1FC4348F6E50C24A897A279A2655C
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_Emissary.Default__LeylannaDefault01_Emissary_C.SessionData.Lines(7).Lines
@@ -7018,7 +7019,7 @@ msgstr "那么，就到这吧，祝你好运！"
 #: /Game/Dialogue/OrcChief/Default/OrcWantWrestle.Default__OrcWantWrestle_C.SessionData.Lines(0).Lines
 msgctxt ",85468CFB4BEE917F4F0BBAA2DF296686"
 msgid "Grrrrrrr!!!!!!!! Hahaha! You weak little human."
-msgstr ""
+msgstr "咕噜噜噜噜！！！！！哈哈哈，你这个弱小的人类。"
 
 #. Key:	854AE3F2484BF88BB14875815FEE38B4
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(20 - Value).TraitIcons.DisplayName
@@ -7039,7 +7040,7 @@ msgstr "小型体型"
 #: /Game/World/Overworld.Overworld:PersistentLevel.EM_OrcSwitch.ActivateMessage
 msgctxt ",856492FE47B9932F7B6974BC6ADA5EE7"
 msgid "Open Gate"
-msgstr ""
+msgstr "打开大门"
 
 #. Key:	8583D0EF44A4998B0C96F2AD09B65314
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDefault01_Meow.Default__CassieDefault01_Meow_C.SessionData.LinesToFemale(2).LinesToFemale
@@ -7053,70 +7054,70 @@ msgstr "看看你干的好事儿，人家现在好想要啊。"
 #: /Game/Dialogue/Leylanna/Default/LeylannaDefault01_BlueSmoke2.Default__LeylannaDefault01_BlueSmoke2_C.SessionData.Lines(2).Lines
 msgctxt ",859B4BA447F1B280EC046E90944CED54"
 msgid "Oh... so beautiful... ahhhhhhh."
-msgstr ""
+msgstr "哦……美……美极了……啊……"
 
 #. Key:	85C0F318409CD0EE03C6A0866A2BC236
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleAnyMeans.Default__KybeleAnyMeans_C.SessionData.LinesToFemale(3).LinesToFemale
 #: /Game/Dialogue/Kybele/Default/KybeleAnyMeans.Default__KybeleAnyMeans_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",85C0F318409CD0EE03C6A0866A2BC236"
 msgid "My greatest weapon is my spear, the massive one between my legs!"
-msgstr ""
+msgstr "我最大的武器是我的矛，夹在我两腿之间的那根巨大的矛!"
 
 #. Key:	85D697914BECD8CA4AD94DB4BE76C00A
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMAboutDragons.Default__DMAboutDragons_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMAboutDragons.Default__DMAboutDragons_C.SessionData.Lines(4).Lines
 msgctxt ",85D697914BECD8CA4AD94DB4BE76C00A"
 msgid "Dragons are old, very old. We were the first to claim these mountains."
-msgstr ""
+msgstr "巨龙一族很古老，非常古老。我们是第一批声称拥有这些山脉的龙。"
 
 #. Key:	85E58BD244C80942385F1793A5D30333
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiCave.Default__FesssiCave_C.SessionData.Lines(6).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiCave.Default__FesssiCave_C.SessionData.Lines(6).Lines
 msgctxt ",85E58BD244C80942385F1793A5D30333"
 msgid "Hidden in the depths, away from judging eyes, one can indulge in untold hedonism. The cavern dwellers have perfected the pleasurable arts of dark magic."
-msgstr ""
+msgstr "藏在深处，远离众目睽睽，尽情享受。洞穴居民已经完善了令人愉悦的黑魔法艺术。"
 
 #. Key:	85EBB13040FCB54F971A719C5A67F240
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_Leylanna.Default__EmissaryDefault01_Leylanna_C.SessionData.Lines(8).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_Leylanna.Default__EmissaryDefault01_Leylanna_C.SessionData.Lines(8).Lines
 msgctxt ",85EBB13040FCB54F971A719C5A67F240"
 msgid "She will then play with my breasts and pussy for hours, begging me to return the favor."
-msgstr ""
+msgstr "然后她会玩我的乳房和阴部几个小时，求我收回这个帮忙。"
 
 #. Key:	85F4F7D540B5915CFE03BCB33A1C34E7
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02.Default__FernDefault02_C.SessionData.LinesToFuta(3).LinesToFuta
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02.Default__FernDefault02_C.SessionData.LinesToFuta(3).LinesToFuta
 msgctxt ",85F4F7D540B5915CFE03BCB33A1C34E7"
 msgid "Let me wrap my lips around that fat cock of yours, my body longs for your warm cum."
-msgstr "“让我把嘴唇包裹在你的大鸡鸡上，我的身体渴望你温暖的精液。”"
+msgstr "“让我把嘴唇包裹在您的大鸡鸡上，我的身体渴望您温暖的精液。”"
 
 #. Key:	85F88762464249CF2ADFD0AFB3D92DB4
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R05.Default__FaleneDefault01_R05_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R05.Default__FaleneDefault01_R05_C.SessionData.Lines(3).Lines
 msgctxt ",85F88762464249CF2ADFD0AFB3D92DB4"
 msgid "Our stripes and spots are natural birth marks, and they look like paint strokes!"
-msgstr "我们身上的条纹和斑点都是天生的，它们看起来就像画的笔触！"
+msgstr "我们身上的条纹和斑点都是天生的，它们看起来就像画的一样！"
 
 #. Key:	8608CD3E4A24FE889A9114BB9C69E23E
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcHadSex01.Default__OrcHadSex01_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/OrcChief/Default/OrcHadSex01.Default__OrcHadSex01_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",8608CD3E4A24FE889A9114BB9C69E23E"
 msgid "Human feel very good. Swallowed tons of cum hahaha!"
-msgstr ""
+msgstr "人类感觉非常好。吞下数吨的精液哈哈哈!"
 
 #. Key:	86354AD5497243D13289CF9220240F60
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleDefault01_RL.Default__KybeleDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
 #: /Game/Dialogue/Kybele/Default/KybeleDefault01_RL.Default__KybeleDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
 msgctxt ",86354AD5497243D13289CF9220240F60"
 msgid "Can I ride you?"
-msgstr ""
+msgstr "我可以骑你吗？"
 
 #. Key:	863580FA480DA6167885D1A2BBF22B9C
 #. SourceLocation:	/Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToMale(8).LinesToMale
 #: /Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToMale(8).LinesToMale
 msgctxt ",863580FA480DA6167885D1A2BBF22B9C"
 msgid "Sweet delicious human seed, let it all go! Ahhh..."
-msgstr "甜美的人类种子，全部都进来！啊....."
+msgstr "多么甜美可口的的人类种子，全流出来，都射给我！啊……""
 
 #. Key:	863C3850414A8A0B8C0C45907E4898EA
 #. SourceLocation:	/Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToFemale(4).LinesToFemale
@@ -7130,7 +7131,7 @@ msgstr "哦……呃啊……对！人类……哦……"
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R02.Default__FaleneDefault01_R02_C.SessionData.Lines(15).Lines
 msgctxt ",86705CF240B11C01C39F05BA7F02F512"
 msgid "Be sure to look out for needy blessed @MONSTER_RACE@, just be vigilant as you venture around the world, you can't miss them!"
-msgstr "一定要留心那些受神佑的饥渴的魔弗灵，在世界各地冒险时要保持警惕，你躲不开他们的！"
+msgstr "一定要留心那些受神佑的饥渴的魔弗灵，在世界各地冒险时要保持警惕，你就不会错过他们的！"
 
 #. Key:	86818D694AB04782DD1A299E28AC5BAF
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R03.Default__FaleneDefault01_R03_C.SessionData.Lines(11).Lines
@@ -7144,7 +7145,7 @@ msgstr "或者……你可以按照自己的想法主动出击。"
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePearl.Default__MegaSlimePearl_C.SessionData.Lines(0).Lines
 msgctxt ",86BA29A64B876404EC611EBF5E4E3F55"
 msgid "Wow! It's so beautiful."
-msgstr ""
+msgstr "哇哦，这也太出色了"
 
 #. Key:	86C230E147542961EF516C854DF91DDB
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiGreeting01.Default__ParvatiGreeting01_C.SessionData.LinesToFemale(9).LinesToFemale
@@ -7179,7 +7180,7 @@ msgstr "管理你的恶魔族"
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeVerySad.Default__MegaSlimeVerySad_C.SessionData.Lines(3).Lines
 msgctxt ",86F7371A4137035AE44922A31E9A0F25"
 msgid "*Sniff*"
-msgstr ""
+msgstr "*嗅*"
 
 #. Key:	86F7401346D43F3587BFEFAB87819829
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R03.Default__FaleneDefault01_R03_C.SessionData.Lines(8).Lines
@@ -7193,7 +7194,7 @@ msgstr "去祭坛雕像附近散散步，你会找到漫无目的游荡的野生
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02_R02_R01.Default__FernDefault02_R02_R01_C.SessionData.Lines(1).Lines
 msgctxt ",8702885F4AD8627AC254029214EED99B"
 msgid "Sure, it can be tempting to drink all of the fluids, but I love you Master and know you need them."
-msgstr "当然，喝掉所有体液可能很诱人，但我爱您，主人，知道您需要它们。"
+msgstr "当然，喝掉所有体液可能很诱人，但我爱您，主人，我知道您需要它们。"
 
 #. Key:	870E3E9A4756B06E4D8C9FB1967261E9
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_BatheAllDay.Default__RomyDefault01_BatheAllDay_C.SessionData.Lines(0).Lines
@@ -7207,49 +7208,49 @@ msgstr "这感觉真好，而且作为美人鱼，我必须靠近水。"
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePlay.Default__MegaSlimePlay_C.SessionData.LinesToMale(3).LinesToMale
 msgctxt ",8738B95245E3A4C3EBFE789CB296F4FD"
 msgid "Well what are you waiting for? Come on in!"
-msgstr ""
+msgstr "那你还在等什么?快进来吧!"
 
 #. Key:	876C0AAA40651DB0D464218A41FDE0CB
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleDragonMatriarch.Default__KybeleDragonMatriarch_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Kybele/Default/KybeleDragonMatriarch.Default__KybeleDragonMatriarch_C.SessionData.Lines(1).Lines
 msgctxt ",876C0AAA40651DB0D464218A41FDE0CB"
 msgid "A centaur never backs down from her duty. I have sworn an oath and nothing will sway me!"
-msgstr ""
+msgstr "半人马从不放弃她的职责。我已经发过誓，没有什么能动摇我!"
 
 #. Key:	8778E21C45BEF3475418C79BD3B95062
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeGreeting01.Default__MegaSlimeGreeting01_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeGreeting01.Default__MegaSlimeGreeting01_C.SessionData.Lines(2).Lines
 msgctxt ",8778E21C45BEF3475418C79BD3B95062"
 msgid "Amazing! I never thought I would see a real living human."
-msgstr ""
+msgstr "不可思议！我从来没亲眼看到过活生生的人类！"
 
 #. Key:	8797C4C64E06B6CA137B77BA4824489F
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadFlowers.Default__DryadFlowers_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Autumn/Default/DryadFlowers.Default__DryadFlowers_C.SessionData.Lines(4).Lines
 msgctxt ",8797C4C64E06B6CA137B77BA4824489F"
 msgid "How sad... they haven't grown in hundreds of years. Those poor bees!"
-msgstr ""
+msgstr "多么可怜……它们已经几百年没生长了。那些可怜的蜜蜂!"
 
 #. Key:	87AE8529473D2DEE9E580591D88F1EE5
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadFlowers.Default__DryadFlowers_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Autumn/Default/DryadFlowers.Default__DryadFlowers_C.SessionData.Lines(5).Lines
 msgctxt ",87AE8529473D2DEE9E580591D88F1EE5"
 msgid "As you might have guessed from the name, ejaculum-phallis are famous for producing tons of nectar."
-msgstr ""
+msgstr "你可能已经从它的名字猜到了，“射精鸡巴”以产生大量的花蜜而闻名"
 
 #. Key:	87F01F0B48F45D7E461449960ED82A56
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaGreeting01.Default__LeylannaGreeting01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Leylanna/Default/LeylannaGreeting01.Default__LeylannaGreeting01_C.SessionData.Lines(1).Lines
 msgctxt ",87F01F0B48F45D7E461449960ED82A56"
 msgid "I am high priestess Leylanna, enlightened servant of the Goddess most high."
-msgstr "我是大祭司莱兰娜。至高女神的大启明侍者"
+msgstr "我是大祭司蕾莱娜。至高女神的大启明侍者"
 
 #. Key:	88006BFC4372D17451C7D19A862A2574
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeHaveKeystone.Default__BeeHaveKeystone_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/QueenBee/Default/BeeHaveKeystone.Default__BeeHaveKeystone_C.SessionData.Lines(5).Lines
 msgctxt ",88006BFC4372D17451C7D19A862A2574"
 msgid "When we had access to that nectar, the honey I made lured even the angels of Sensual Heavens to worship my nipples."
-msgstr ""
+msgstr "当我们得到那甘露的时候，我酿的蜂蜜甚至引诱了感官天堂的天使来崇拜我的乳头。"
 
 #. Key:	8800985D4901B4EF2FE2FD9B6D818E41
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_Pregnancy.Default__FaleneDefault01_Pregnancy_C.SessionData.Lines(1).Lines
@@ -7263,7 +7264,7 @@ msgstr "没有出生，没有胚胎而且丝毫没有痛苦。"
 #: /Game/Dialogue/Widow/Default/WidowDefault01.Default__WidowDefault01_C.SessionData.Lines(2).Lines
 msgctxt ",8839893A45BD5AC8569BAD8798ACEE15"
 msgid "..."
-msgstr ""
+msgstr "……"
 
 #. Key:	887E11C1414E35B9B9420BA80FD5A411
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R01.Default__FaleneDefault01_R01_C.SessionData.Lines(13).Lines
@@ -7277,14 +7278,14 @@ msgstr "我们都知道魔弗灵是半人类。不过说实话我们这从没有
 #: /Game/Dialogue/Kybele/Default/KybeleAnyMeans_RL.Default__KybeleAnyMeans_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",889821A14F372C605AB0A58DD716FB9E"
 msgid "Pfff I can handle a titty pony."
-msgstr ""
+msgstr "好吧，我能搞定小奶驹的。"
 
 #. Key:	889D5D974E2DA932F5EAC7B50EC85E50
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(5).Lines
 msgctxt ",889D5D974E2DA932F5EAC7B50EC85E50"
 msgid "What do I do with the milk I buy?"
-msgstr "尼问俺咋处理俺买下来的奶？"
+msgstr "尼问俺咋处理俺买下来的奶？俺也不知道……"
 
 #. Key:	88B965E0435F9EAD252E91913254E01A
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R04.Default__FaleneDefault01_R04_C.SessionData.Lines(1).Lines
@@ -7312,14 +7313,14 @@ msgstr "所以说，你应该留下来并且听听我的诗歌"
 #: /Game/Dialogue/Monarch/Default/MonarchShySexF_RL.Default__MonarchShySexF_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",88C799D944DFFE73BC3FD485C3770EEE"
 msgid "No!"
-msgstr ""
+msgstr "不！"
 
 #. Key:	88DA748247D4C0C5CE3BEC9851A55E05
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadAboutDryads.Default__DryadAboutDryads_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Autumn/Default/DryadAboutDryads.Default__DryadAboutDryads_C.SessionData.Lines(3).Lines
 msgctxt ",88DA748247D4C0C5CE3BEC9851A55E05"
 msgid "Our nature inclines us to plant roots and help life flourish. In my case, I saw so many cows wandering aimlessly here."
-msgstr ""
+msgstr "我们的天性倾向于扎根，帮助生命茁壮成长。就我而言，我看到很多牛漫无目的地在这里游荡。"
 
 #. Key:	88E908134B3B56C2274F33974CFB4AE5
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(0).LinesToMale
@@ -7354,7 +7355,7 @@ msgstr "能有和人类交配的机会，简直让我所有的心脏都怦怦直
 #: /Game/Dialogue/Autumn/Default/DryadCherryHelp.Default__DryadCherryHelp_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",89B96FEA426FD3ECBA90259F724E6DF2"
 msgid "I'm getting wet just thinking about us rubbing our labia together."
-msgstr ""
+msgstr "一想到我们在一起摩擦阴唇，我就浑身湿透了"
 
 #. Key:	89C2CF4D4CB264FC19F1259B533341FD
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_HowToSpiritForm.Default__LeylannaDefault01_HowToSpiritForm_C.SessionData.LinesToFemale(1).LinesToFemale
@@ -7396,28 +7397,28 @@ msgstr "我柔软的精灵嘴唇侍弄得你舒服吗？好好享受我吸舔你
 #: /Game/Dialogue/OrcChief/Default/OrcDefault03_RL.Default__OrcDefault03_RL_C.ResponseData(5).ResponseData.BreederPrompt
 msgctxt ",8A77725E4111005E08D6A08330057BBF"
 msgid "How is that Akabeko treating you?"
-msgstr ""
+msgstr "那只红牛带你如何呀？"
 
 #. Key:	8A7AA1664D50A6AD3F66CE8B9B57C01F
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_Daze.Default__EmissaryDefault01_Daze_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_Daze.Default__EmissaryDefault01_Daze_C.SessionData.Lines(3).Lines
 msgctxt ",8A7AA1664D50A6AD3F66CE8B9B57C01F"
 msgid "But beware, a toll will she require."
-msgstr ""
+msgstr "但要小心，她需要付出代价。"
 
 #. Key:	8AF6FC6641A12C2B4A5B90B25313D5E2
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03.Default__FernDefault03_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03.Default__FernDefault03_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",8AF6FC6641A12C2B4A5B90B25313D5E2"
 msgid "I am a full grown Alraune now!"
-msgstr "我现在是一个完全体的曼陀罗啦"
+msgstr "我现在长成成熟的曼陀罗啦！"
 
 #. Key:	8B1379924334951ADC6F618BF40ECB55
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_Daze.Default__EmissaryDefault01_Daze_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_Daze.Default__EmissaryDefault01_Daze_C.SessionData.Lines(1).Lines
 msgctxt ",8B1379924334951ADC6F618BF40ECB55"
 msgid "Once the body is pushed beyond capacity, it will lose conciousness and for an undetermined time, thou shall not perceive the world."
-msgstr ""
+msgstr "一旦身体承受无法承受的伤害（高处掉落），它就会失去意识，在一段不确定的时间里，你将无法感知世界。"
 
 #. Key:	8B26942A46ED0C778AE5E1BC7C39336A
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(11 - Value).TraitIcons.HelpText
@@ -7445,21 +7446,22 @@ msgstr "享乐主义者"
 #: /Game/Dialogue/Fern/DefaultP3/FernGreeting03.Default__FernGreeting03_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",8B8E6E7E442F870ECD9423A21D60D95B"
 msgid "Your fluids have nourished me so well Master..."
-msgstr "是主人的汁液把我滋养的如此好"
+msgstr "是主人您的汁液把我滋养的如此好……"
 
 #. Key:	8B99E6244548DDC5BAF8798C9395ED84
 #. SourceLocation:	/Game/Ranch/Upgrades/ThriaeHive.Default__ThriaeHive_C.Upgrade.TypeDisplay
 #: /Game/Ranch/Upgrades/ThriaeHive.Default__ThriaeHive_C.Upgrade.TypeDisplay
 msgctxt ",8B99E6244548DDC5BAF8798C9395ED84"
 msgid "Nephelym Barn"
-msgstr "魔弗灵谷仓"
+msgstr "魔弗灵牧场
+"
 
 #. Key:	8BADB4BC4F48C251A1FDE2BA89B03B22
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcBrashDumb.Default__OrcBrashDumb_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcBrashDumb.Default__OrcBrashDumb_C.SessionData.Lines(4).Lines
 msgctxt ",8BADB4BC4F48C251A1FDE2BA89B03B22"
 msgid "Wrestling usually turns into sex. Weak outsiders can't tell if we are mating or fighting!"
-msgstr ""
+msgstr "摔跤通常会变成做爱。弱小的外人无法分辨我们是在交配还是在战斗!”"
 
 #. Key:	8BF8D9C84BBFA034861E1CA3B675AE2F
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R04.Default__CamillaDefault01_R04_C.SessionData.Lines(2).Lines
@@ -7473,7 +7475,7 @@ msgstr "但我想她喜欢更容易进入我的胯部…"
 #: /Game/Dialogue/Cassie/SexScenes/CassieButterButtF.Default__CassieButterButtF_C.SessionData.Lines(3).Lines
 msgctxt ",8C159EEF4934350128EF61B587714DE0"
 msgid "Meow! It feels so good! Kitty cum for you soon ohhh!"
-msgstr "喵呜！这感觉太舒服了！我快要去了！哦哦哦!!!"
+msgstr "喵呜！这感觉太赞了我快要射了！哦哦哦!!!"
 
 #. Key:	8C3EC08A4B6E0CBD02C0D9A1DF7CF43E
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R01.Default__FaleneDefault01_R01_C.SessionData.Lines(16).Lines
@@ -7487,14 +7489,14 @@ msgstr "但是，魔弗灵的那一半基因的主导性确保了后代永远是
 #: /Game/World/Overworld.Overworld:PersistentLevel.CBGate_Breaks.BlockMessage
 msgctxt ",8C5FB38741A249FFD19CB3AB1EDFCC3D"
 msgid "Kybele guards this Cockblock Gate."
-msgstr ""
+msgstr "凯布莉守卫着这个鸡鸡大门"
 
 #. Key:	8C93DBB64045A67B0309ACB46E0AD026
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimePlay1.Default__MegaSlimePlay1_C.SessionData.LinesToFemale(3).LinesToFemale
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePlay1.Default__MegaSlimePlay1_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",8C93DBB64045A67B0309ACB46E0AD026"
 msgid "You will feel so good as I flood your womb with my slime..."
-msgstr ""
+msgstr "我用我的粘液灌满你的子宫，你会爽的直翻白眼的"
 
 #. Key:	8C95D2A04A969135BDEC06A780BBC656
 #. SourceLocation:	/Game/Characters/Procedural/Variants/Hybrid/Harvest/HybridHarvest.Default__HybridHarvest_C.Harvest.Description
@@ -7508,21 +7510,21 @@ msgstr "混血族体液"
 #: /Game/Dialogue/Monarch/Default/MonarchHaveKeystone2.Default__MonarchHaveKeystone2_C.SessionData.Lines(0).Lines
 msgctxt ",8C9B5804468F5F400DC62BBD043B050E"
 msgid "Please take it... maybe we will cross paths again."
-msgstr ""
+msgstr "请收下它…也许我们还会再次相遇"
 
 #. Key:	8CA4D43149A0F1DAAAC64681E65FE7BE
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiDefault03_RL_T.Default__FesssiDefault03_RL_T_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/Fesssi/Default/FesssiDefault03_RL_T.Default__FesssiDefault03_RL_T_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",8CA4D43149A0F1DAAAC64681E65FE7BE"
 msgid "Wow... this world is full of idiots."
-msgstr ""
+msgstr "哇哦，这个世界充满了笨蛋"
 
 #. Key:	8CB5ACBF46F02BEA48B084A15F2AD8C2
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(3).Lines
 msgctxt ",8CB5ACBF46F02BEA48B084A15F2AD8C2"
 msgid "Once the Seraphim had started propagating, the Goddess ordered them to spread their light across the empty expanse."
-msgstr ""
+msgstr "一旦六翼天使开始繁殖，女神就命令他们把他们的散布到空旷的区域。"
 
 #. Key:	8CD67FB74B2E43F406AB5B932B717B19
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToMale(2).LinesToMale
@@ -7536,7 +7538,7 @@ msgstr "能有和人类交配的机会，简直让我所有的心脏都怦怦直
 #: /Game/Dialogue/QueenBee/Default/BeeAboutBees.Default__BeeAboutBees_C.SessionData.Lines(4).Lines
 msgctxt ",8CDBFE6141B0505672CA5BAAD842B1B4"
 msgid "Ahhh... the milking process is... quite pleasurable trust me human."
-msgstr ""
+msgstr "啊…挤奶的过程是…非常愉快，相信我，人类"
 
 #. Key:	8D055D5140B28DADFD055EA100CF2F32
 #. SourceLocation:	/Game/Characters/Procedural/Variants/Vulwarg/Harvest/VulwargHarvest.Default__VulwargHarvest_C.Harvest.Description
@@ -7550,7 +7552,7 @@ msgstr "狼人体液"
 #: /Game/Dialogue/Neela/Default/NeelaHadSex01.Default__NeelaHadSex01_C.SessionData.Lines(1).Lines
 msgctxt ",8D12D3854864E7395B64589A2754A1A5"
 msgid "I waited so long to experience the pleasure only a human could offer..."
-msgstr ""
+msgstr "我等了这么久，才体验到只有人类才能提供的快乐……"
 
 #. Key:	8D19606C4C2EC6C25E3CF1A4F53B952A
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_HowToSpiritForm.Default__LeylannaDefault01_HowToSpiritForm_C.SessionData.LinesToFemale(0).LinesToFemale
@@ -7564,7 +7566,7 @@ msgstr "人们在不熟悉魔弗灵灵魂形态的情况下，是无法操控这
 #: /Game/Dialogue/Fesssi/Default/FesssiHowLong.Default__FesssiHowLong_C.SessionData.Lines(7).Lines
 msgctxt ",8D1DC11348D4FCEB4B6BC6A7DE4D5D75"
 msgid "Yessss, before the gate closed, random cavern dwellers would sneak up behind me and have their way with my body."
-msgstr ""
+msgstr "是呀嘶，在大门关上以前，不知道会从哪个洞穴出来的生物会悄悄地从后面靠近我，用我的身体来发泄他们的欲望。
 
 #. Key:	8D3533C24DF82A263421E5AD13FC2CE1
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_MultipleHearts.Default__MirruDefault01_MultipleHearts_C.SessionData.Lines(0).Lines
@@ -7578,7 +7580,7 @@ msgstr "什么？对的…不止一个…海妖需要两个心脏。"
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02_R01.Default__FernDefault02_R01_C.SessionData.Lines(3).Lines
 msgctxt ",8D3E28104D0EAE4C533EE39A8D65B6DB"
 msgid "It's going to be sad to lose the ability to move, but at least I have you Master!"
-msgstr "虽然失去移动能力很可惜，但我至少还有主人"
+msgstr "虽然失去移动能力很可惜，但我至少还有主人您！"
 
 #. Key:	8D4C9C144C33EE6A19B08696ABFFB5DA
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_FloatRhyme.Default__ParvatiDefault01_FloatRhyme_C.SessionData.Lines(7).Lines
@@ -7592,7 +7594,7 @@ msgstr "如果你是来需求快活的话，我能让你爽上天"
 #: /Game/Dialogue/Widow/Default/WidowHadSex01.Default__WidowHadSex01_C.SessionData.Lines(2).Lines
 msgctxt ",8D8E77CB4454DA71E9231DA6647955ED"
 msgid "My hunger is satiated, but not for long... be assured when it returns I will again suck you dry."
-msgstr ""
+msgstr "我的饥渴暂时被满足了，但不会持续太久……相信我，当它回来的时候，我发誓绝对会把你榨干的~"
 
 #. Key:	8DA42A584992D1AF833DDA8EA615FB7B
 #. SourceLocation:	/Game/Dialogue/Fern/SexScenes/FernCum_01.Default__FernCum_01_C.SessionData.Lines(3).Lines
@@ -7620,35 +7622,35 @@ msgstr "狐狸体液"
 #: /Game/Dialogue/Autumn/Default/DryadHadSex01.Default__DryadHadSex01_C.SessionData.Lines(3).Lines
 msgctxt ",8E34225A44160F2F0BD6DD9EFC546B2E"
 msgid "Ohhhh... we should do it again."
-msgstr ""
+msgstr "噢……我们应该再做一次。"
 
 #. Key:	8E5478244452BC05131C69AB8D675563
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeSuckJugs_RL.Default__AmberMaeSuckJugs_RL_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/AmberMae/Default/AmberMaeSuckJugs_RL.Default__AmberMaeSuckJugs_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",8E5478244452BC05131C69AB8D675563"
 msgid "On second thought, I'm not thirsty."
-msgstr "我再想想吧，我现在不是很渴。"
+msgstr "我再考虑一下吧，我现在不是很渴。"
 
 #. Key:	8E670FBC49A79D7C192CB5916E7E2B4B
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleAnyMeans.Default__KybeleAnyMeans_C.SessionData.LinesToFemale(5).LinesToFemale
 #: /Game/Dialogue/Kybele/Default/KybeleAnyMeans.Default__KybeleAnyMeans_C.SessionData.LinesToFemale(5).LinesToFemale
 msgctxt ",8E670FBC49A79D7C192CB5916E7E2B4B"
 msgid "If you do not leave this place, your little human pussy will become aquainted with it!"
-msgstr ""
+msgstr "如果你不离开这个地方，你的人类小阴道将变得熟悉并且离不开它"
 
 #. Key:	8E6A9EEC45D5EC9F679747AFFA8DA855
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchHaveKeystone.Default__MonarchHaveKeystone_C.SessionData.Lines(6).Lines
 #: /Game/Dialogue/Monarch/Default/MonarchHaveKeystone.Default__MonarchHaveKeystone_C.SessionData.Lines(6).Lines
 msgctxt ",8E6A9EEC45D5EC9F679747AFFA8DA855"
 msgid "M-m-maybe one of those adorable Foxen!"
-msgstr ""
+msgstr "也…也……也许是也许是一只可爱的狐狸呢？"
 
 #. Key:	8F007620423E7F8C613814916858A58C
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_BlueSmoke2.Default__LeylannaDefault01_BlueSmoke2_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Leylanna/Default/LeylannaDefault01_BlueSmoke2.Default__LeylannaDefault01_BlueSmoke2_C.SessionData.Lines(0).Lines
 msgctxt ",8F007620423E7F8C613814916858A58C"
 msgid "..."
-msgstr ""
+msgstr "……"
 
 #. Key:	8F1086D44A2F92032FB2109D420506BA
 #. SourceLocation:	/Game/Dialogue/Fern/SexScenes/FernMilk_01.Default__FernMilk_01_C.SessionData.Lines(3).Lines
@@ -7662,7 +7664,7 @@ msgstr "*啧吮 舔舐*"
 #: /Game/Dialogue/AmberMae/Default/AmberMaeDefault01.Default__AmberMaeDefault01_C.SessionData.Lines(2).Lines
 msgctxt ",8F1A20C3401841EB835DBDA94858E823"
 msgid "Oh, mayhaps tis milk ye want?"
-msgstr "噢，或许尼是想要这个奶？"
+msgstr "噢，或许尼是想要俺这里的奶？"
 
 #. Key:	8F8279FC4A2E364B7CE585981E0279EF
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.SeraphimLoft.ManageActionMessage
@@ -7676,7 +7678,7 @@ msgstr "管理你的天使族"
 #: /Game/Dialogue/Petra/Default/PetraGreeting01.Default__PetraGreeting01_C.SessionData.Lines(3).Lines
 msgctxt ",8F881FCB45236FE8DB057EBCF2939A73"
 msgid "I recently finished a session with her... ahhh. My mind is so clear and open."
-msgstr ""
+msgstr "我最近和她刚聊了一次。。。啊哈。我的思想是如此清晰和开放通透。"
 
 #. Key:	8FD6281749815A4E5D3B62A257075F76
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R02.Default__FaleneDefault01_R02_C.SessionData.Lines(9).Lines
@@ -7704,7 +7706,7 @@ msgstr "多产多育"
 #: /Game/Dialogue/QueenBee/Default/BeeHaveKeystone1.Default__BeeHaveKeystone1_C.SessionData.Lines(0).Lines
 msgctxt ",9006FF4140E2EBD3C3E40ABD8F0E2D40"
 msgid "Hmm... perhaps."
-msgstr ""
+msgstr "恩，也许吧……"
 
 #. Key:	900A82D44250A3392806469644B7B93B
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryGreeting01.Default__EmissaryGreeting01_C.SessionData.Lines(3).Lines
@@ -7718,21 +7720,21 @@ msgstr "不过，漫游在这片土地之上的皆是较小的魔灵，大多都
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02.Default__FernDefault02_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",902A41DB403EFA60B99E8CB596EFE0BF"
 msgid "My body longs for your delicious breast milk."
-msgstr "我的身体渴望您的美味牛奶。"
+msgstr "我的身体渴望您的美味乳汁。"
 
 #. Key:	906D8350484725AED7108C8EB418C5AF
 #. SourceLocation:	/Game/UI/TaskDescriptions.TaskDescriptions.TextEntries(5).TextEntries
 #: /Game/UI/TaskDescriptions.TaskDescriptions.TextEntries(5).TextEntries
 msgctxt ",906D8350484725AED7108C8EB418C5AF"
 msgid "This one isn't for me, but the beautiful golden angel Emissary. She doesn't seem interested when I try to please her... and oh have I tried. I want to get her something really special, bring me the most lusty Nephelym you can breed. When you do, I will let it make love with Emissary until she cums. If she doesn't, I definitely will while watching.  -Leylanna"
-msgstr ""
+msgstr "这次不是为了我，而是给美丽的金色天使使者的。当我试图取悦她时，她似乎不感兴趣。哦，我试过了。我想给她一些特别的东西，给我你能培育的精力最充沛的魔弗灵吗。到时候，我会让它和使者做爱直到她高潮。如果她不高潮，我相信她一定会高潮的。——蕾莱娜"
 
 #. Key:	907E7C35462D4EC3BC72C5B05C7ABDB9
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyGreeting01.Default__RomyGreeting01_C.SessionData.LinesGrungy(2).LinesGrungy
 #: /Game/Dialogue/Romy/Default/RomyGreeting01.Default__RomyGreeting01_C.SessionData.LinesGrungy(2).LinesGrungy
 msgctxt ",907E7C35462D4EC3BC72C5B05C7ABDB9"
 msgid "I hear your eyes working your way down my voluptuous form, your heart beats faster, but... oh... no."
-msgstr "我感受到你的眼睛在向我性感的下体看去，我能感受到你的心跳加快"
+msgstr "我感受到你的眼睛在向我性感的下体看去，我能感受到你的心跳加快，哦不……"
 
 #. Key:	90AAD27D43E39D45DAC8A492F1373436
 #. SourceLocation:	/Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToMale(9).LinesToMale
@@ -7753,70 +7755,70 @@ msgstr "享乐主义者：掠夺交配对象本应该获得的经验值"
 #: /Game/Dialogue/Blossom/Default/BlossomGreeting01.Default__BlossomGreeting01_C.SessionData.Lines(4).Lines
 msgctxt ",90CF176E415EE7CEA27716868800482A"
 msgid "Timeeee for the fluidsssss?"
-msgstr "收获嘶嘶...汁液的时间到了吗嘶嘶...?"
+msgstr "收获嘶嘶...汁液的时间到了吗……嘶嘶?"
 
 #. Key:	90DA01BE4F6814F010ECF99D4730B696
 #. SourceLocation:	/Game/Characters/Procedural/Variants/Dragon/Harvest/DragonHarvest.Default__DragonHarvest_C.Harvest.RaceName
 #: /Game/Characters/Procedural/Variants/Dragon/Harvest/DragonHarvest.Default__DragonHarvest_C.Harvest.RaceName
 msgctxt ",90DA01BE4F6814F010ECF99D4730B696"
 msgid "Dragon"
-msgstr "龙"
+msgstr "龙族"
 
 #. Key:	911090974165315ED68A81A7F5257175
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaHadSex01.Default__LeylannaHadSex01_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/Leylanna/Default/LeylannaHadSex01.Default__LeylannaHadSex01_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",911090974165315ED68A81A7F5257175"
 msgid "You felt so good... we can spend hours together."
-msgstr ""
+msgstr "你真的太出色了…我们可以一起做上好几个小时。”"
 
 #. Key:	912A5F994D44D6C64F6E35AE76B06D09
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchHaveKeystone.Default__MonarchHaveKeystone_C.SessionData.Lines(7).Lines
 #: /Game/Dialogue/Monarch/Default/MonarchHaveKeystone.Default__MonarchHaveKeystone_C.SessionData.Lines(7).Lines
 msgctxt ",912A5F994D44D6C64F6E35AE76B06D09"
 msgid "*Blush*"
-msgstr ""
+msgstr "*脸红*"
 
 #. Key:	91512E3C41CA91E3C203E3BFD899DA24
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToFuta(7).LinesToFuta
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToFuta(7).LinesToFuta
 msgctxt ",91512E3C41CA91E3C203E3BFD899DA24"
 msgid "Human cum is something I have always wanted."
-msgstr ""
+msgstr "人类精液是我一直想要的东西"
 
 #. Key:	918C772C4F35E159A184638CC564271F
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowScary.Default__WidowScary_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Widow/Default/WidowScary.Default__WidowScary_C.SessionData.Lines(1).Lines
 msgctxt ",918C772C4F35E159A184638CC564271F"
 msgid "Did you not experience immense pleasure as I sucked your genitals for all they had to offer?"
-msgstr ""
+msgstr "当我吮吸你的大鸡鸡的时候，你难道没有感到无比的快感吗?
 
 #. Key:	91922DC94FEA86B72D24D097B1B9B169
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.EM_Keystone_Dryad.FailMessage
 #: /Game/World/Overworld.Overworld:PersistentLevel.EM_Keystone_Dryad.FailMessage
 msgctxt ",91922DC94FEA86B72D24D097B1B9B169"
 msgid "Tree roots hold it in place."
-msgstr ""
+msgstr "树根把它固定在了这里。"
 
 #. Key:	91BFB5AF42AF2A7DA5B8219CB5296CAC
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault02.Default__FaleneDefault02_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault02.Default__FaleneDefault02_C.SessionData.Lines(2).Lines
 msgctxt ",91BFB5AF42AF2A7DA5B8219CB5296CAC"
 msgid "..."
-msgstr ""
+msgstr "……"
 
 #. Key:	91C04C0641057656CC61A48472D8954C
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_R03.Default__FernDefault02_R03_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02_R03.Default__FernDefault02_R03_C.SessionData.Lines(1).Lines
 msgctxt ",91C04C0641057656CC61A48472D8954C"
 msgid "I need human cum to grow into my final form. Your dick will slide all the way down my throat as I suck every drop."
-msgstr "小蕨需要人类的精液来长成最终形态！！主人的鸡巴会一路滑到我的喉咙里面，当我吞咽的时候。”"
+msgstr "小蕨需要人类的精液来长成最终形态！！当我吞咽的时候，主人的鸡巴会一路滑到我的喉咙里面，我会吸干主人的每一滴精液的。"
 
 #. Key:	91EBB0754C1505A5258A0CB3E6CE0D71
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraGetKeystone.Default__PetraGetKeystone_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Petra/Default/PetraGetKeystone.Default__PetraGetKeystone_C.SessionData.Lines(0).Lines
 msgctxt ",91EBB0754C1505A5258A0CB3E6CE0D71"
 msgid "Sure can! I'm a bunny, so hopping up there wouldn't be a problem."
-msgstr ""
+msgstr "当然可以!我可是兔子，跳上去不成问题。"
 
 #. Key:	926325814BBC6464CA76E097764B7F27
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(0 - Value).TraitIcons.HelpText
@@ -7830,91 +7832,91 @@ msgstr "趋近人型：继承了更多人类的特征"
 #: /Game/Dialogue/Kybele/Default/KybeleTittyPony_T.Default__KybeleTittyPony_T_C.SessionData.LinesToFuta(1).LinesToFuta
 msgctxt ",926950C44065493241D67FA1816D2447"
 msgid "It's been sometime since I have been mouted, so I might get rough!"
-msgstr ""
+msgstr "我已经有一段时间没活动活动了，所以我可能会变得粗暴的哟！"
 
 #. Key:	92840010469055DB3A7EADA0FB5C99E1
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcTribeSucks.Default__OrcTribeSucks_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcTribeSucks.Default__OrcTribeSucks_C.SessionData.Lines(1).Lines
 msgctxt ",92840010469055DB3A7EADA0FB5C99E1"
 msgid "Human is right... tribe is weak."
-msgstr ""
+msgstr "人类是正确的…部落太弱了。"
 
 #. Key:	929A4EF9420407BC85391A864F8E955D
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToFuta(2).LinesToFuta
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",929A4EF9420407BC85391A864F8E955D"
 msgid "Our preference is always for semen from the source, if you are interested... it will feel amazing!"
-msgstr ""
+msgstr "我们的偏好总是来自源头的精液，如果你感兴趣的话……那可太让人激动了"
 
 #. Key:	92CD80ED43FA1902AD31098F05B9E924
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDungeon.Default__CassieDungeon_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Cassie/Default/CassieDungeon.Default__CassieDungeon_C.SessionData.Lines(0).Lines
 msgctxt ",92CD80ED43FA1902AD31098F05B9E924"
 msgid "Oh the old temple?"
-msgstr ""
+msgstr "哦呀，你说的是那个老的圣殿呀？"
 
 #. Key:	92E3821949A8C289A4AAFCA4103F1915
 #. SourceLocation:	/Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToMale(3).LinesToMale
 #: /Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToMale(3).LinesToMale
 msgctxt ",92E3821949A8C289A4AAFCA4103F1915"
 msgid "Yes! Ohhhh, so big... keep going human! Ahh..."
-msgstr "是的!哈~这么大……继续,人类!啊..."
+msgstr "太棒了!哦噢噢！太大了……继续,人类!啊..."
 
 #. Key:	92E810794E27E1F318AD0C9D4701705B
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDefault01_Meow.Default__CassieDefault01_Meow_C.SessionData.LinesToFuta(5).LinesToFuta
 #: /Game/Dialogue/Cassie/Default/CassieDefault01_Meow.Default__CassieDefault01_Meow_C.SessionData.LinesToFuta(5).LinesToFuta
 msgctxt ",92E810794E27E1F318AD0C9D4701705B"
 msgid "My fuzzy hands will fix this, but some human love could help too..."
-msgstr "虽然我毛绒绒的双爪可以解决一些问题，但是一些来自人类的爱也可是很有帮助哟..."
+msgstr "虽然我毛绒绒的双爪可以解决一些问题，但是一些来自人类的爱也可是很有帮助的哟..."
 
 #. Key:	9309BD074F9B0FFE924A35B157A44C07
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadBossomCherries.Default__DryadBossomCherries_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Autumn/Default/DryadBossomCherries.Default__DryadBossomCherries_C.SessionData.Lines(5).Lines
 msgctxt ",9309BD074F9B0FFE924A35B157A44C07"
 msgid "The thunderous clash of their fall sometimes even shakes the fruit loose."
-msgstr ""
+msgstr "它们重重地坠落到地面上，有时甚至会把在枝头的水果震松了。"
 
 #. Key:	931A324E4A49D084F8210CA54C479750
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryHadSex01.Default__EmissaryHadSex01_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/Emissary/Default/EmissaryHadSex01.Default__EmissaryHadSex01_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",931A324E4A49D084F8210CA54C479750"
 msgid "Well your tongue certainly found it's way around @BREEDER_NAME@."
-msgstr ""
+msgstr "你的舌头肯定找到了@BREEDER_NAME@"
 
 #. Key:	93200BC643D32038D21FA9A6972CB59F
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryBlessedInquiry01_RL.Default__EmissaryBlessedInquiry01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/Emissary/Default/EmissaryBlessedInquiry01_RL.Default__EmissaryBlessedInquiry01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",93200BC643D32038D21FA9A6972CB59F"
 msgid "Amazing!"
-msgstr "鹅妹子嘤！"
+msgstr "鹅妹子嘤！（真棒呀）"
 
 #. Key:	934029E9456E811CFA0084839F9BABE4
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadGreeting01.Default__DryadGreeting01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Autumn/Default/DryadGreeting01.Default__DryadGreeting01_C.SessionData.Lines(0).Lines
 msgctxt ",934029E9456E811CFA0084839F9BABE4"
 msgid "Sweet and juicy, but just a little squishy."
-msgstr ""
+msgstr "又甜又多汁，只是有点黏糊糊的。"
 
 #. Key:	93692542487EDBAE8A18A699EC9053E1
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeHadSex01.Default__MegaSlimeHadSex01_C.SessionData.LinesToFemale(4).LinesToFemale
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeHadSex01.Default__MegaSlimeHadSex01_C.SessionData.LinesToFemale(4).LinesToFemale
 msgctxt ",93692542487EDBAE8A18A699EC9053E1"
 msgid "So much excitement for one day, getting sleepy."
-msgstr ""
+msgstr "这么兴奋的一天，我都要犯困了"
 
 #. Key:	936951A3415054668ED149B82FBDB343
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchPrettyButterfly.Default__MonarchPrettyButterfly_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Monarch/Default/MonarchPrettyButterfly.Default__MonarchPrettyButterfly_C.SessionData.Lines(1).Lines
 msgctxt ",936951A3415054668ED149B82FBDB343"
 msgid "Butterflies are a rare Thriae variant, but not a strong one."
-msgstr ""
+msgstr "蝴蝶是一种罕见的蜂娘变种，但不是很强大。"
 
 #. Key:	9376B5AE48D48B7CA5084B81F2F5181E
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraGreeting01.Default__PetraGreeting01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Petra/Default/PetraGreeting01.Default__PetraGreeting01_C.SessionData.Lines(0).Lines
 msgctxt ",9376B5AE48D48B7CA5084B81F2F5181E"
 msgid "A human? How neat!"
-msgstr ""
+msgstr "一个人类？多么小巧玲珑啊！"
 
 #. Key:	9386C1184C3F241BDF4D33BB1297FF2B
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_Forgot.Default__ParvatiDefault01_Forgot_C.SessionData.Lines(3).Lines
@@ -7928,21 +7930,21 @@ msgstr "速速褪去衣物，汝需赤身裸体"
 #: /Game/Ranch/Upgrades/DemonPool.Default__DemonPool_C.Upgrade.TypeDisplay
 msgctxt ",93965A5D468FD50976A359A6DC4ABD45"
 msgid "Nephelym Barn"
-msgstr "魔弗灵谷仓"
+msgstr "魔弗灵牧场"
 
 #. Key:	939FC3974789211249F6CB84A4A9FCB8
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeDefault02_RL.Default__BeeDefault02_RL_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/QueenBee/Default/BeeDefault02_RL.Default__BeeDefault02_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",939FC3974789211249F6CB84A4A9FCB8"
 msgid "Can I have that keystone?"
-msgstr ""
+msgstr "我可以拿走那个钥石了吗？"
 
 #. Key:	93ACD44B44EFF7C20AF15E9D718C3166
 #. SourceLocation:	/Game/Breeding/Positions/Missionary.Default__Missionary_C.SessionData.PositionName
 #: /Game/Breeding/Positions/Missionary.Default__Missionary_C.SessionData.PositionName
 msgctxt ",93ACD44B44EFF7C20AF15E9D718C3166"
 msgid "Missionary"
-msgstr "传教士"
+msgstr "传教士体位"
 
 #. Key:	93B6CD7C4E7ECCBA8FD7F38BD9A11025
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDefault01_RL.Default__CassieDefault01_RL_C.ResponseData(3).ResponseData.BreederPrompt
@@ -7963,7 +7965,7 @@ msgstr "这将允许你捕捉和存放所有的龙族"
 #: /Game/Dialogue/Camilla/Default/CamillaDungeon.Default__CamillaDungeon_C.SessionData.Lines(1).Lines
 msgctxt ",93DE33A2469E1BAFBEC17DAF59AF4070"
 msgid "Go talk to bulge kitty, she pretends to be exactly that."
-msgstr ""
+msgstr "去和裤裤隆起的猫咪谈谈，她的感觉一向很准。
 
 #. Key:	941010544E6432D137832FA1B37E0C10
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_Teach.Default__ParvatiDefault01_Teach_C.SessionData.Lines(3).Lines
@@ -7977,7 +7979,7 @@ msgstr "因此我们可以尝试任何想到的体位"
 #: /Game/Dialogue/Fern/Default/FernDefault01_RL_M.Default__FernDefault01_RL_M_C.ResponseData(3).ResponseData.BreederPrompt
 msgctxt ",943C15EB4C419656532B6A8A133CD0F3"
 msgid "You may have my cum!"
-msgstr "你可以用我的精液滋润自己了！"
+msgstr "您可以用我射精的精液滋润自己了！"
 
 #. Key:	94451EBE42500C5CEC2E988DDD887046
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(19 - Value).TraitIcons.HelpText
@@ -7991,14 +7993,14 @@ msgstr "性狂热：从性行为中获取双倍忠诚度"
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03_RL_F.Default__FernDefault03_RL_F_C.ResponseData(3).ResponseData.BreederPrompt
 msgctxt ",9458CFDE4690A312D5CC8F94BF4AE00A"
 msgid "Who is the pink Alraune?"
-msgstr "为什么是粉色的曼陀罗?"
+msgstr "为什么是粉色的曼陀罗花?"
 
 #. Key:	945B516446601CCDF45E92B6DC0D6175
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryHadSex01.Default__EmissaryHadSex01_C.SessionData.LinesToFemale(2).LinesToFemale
 #: /Game/Dialogue/Emissary/Default/EmissaryHadSex01.Default__EmissaryHadSex01_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",945B516446601CCDF45E92B6DC0D6175"
 msgid "Is that a comforting feeling?"
-msgstr ""
+msgstr "这是一种很舒服的感觉吗?"
 
 #. Key:	945CB3304860CBDF1DCD348F2BE3E32B
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R03.Default__FaleneDefault01_R03_C.SessionData.Lines(1).Lines
@@ -8026,7 +8028,7 @@ msgstr "不像其他大多海妖是双性，她是非常罕见的纯正女性。
 #: /Game/Dialogue/Kybele/Default/KybeleHadSex01.Default__KybeleHadSex01_C.SessionData.LinesToFuta(1).LinesToFuta
 msgctxt ",94DDBB0049FCED99D5C08FB803C12B7D"
 msgid "You paid the price, now your little human ejaculation is all mine."
-msgstr ""
+msgstr "你付出了代价，现在你可以全部射给我了。"
 
 #. Key:	94FAC38648F37068EA98D4BEB220AA61
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_AboutLamias.Default__NeelaDefault01_AboutLamias_C.SessionData.Lines(4).Lines
@@ -8040,14 +8042,14 @@ msgstr "哦对了，我们族类的男性和扶她有两根屌。"
 #: /Game/Dialogue/Monarch/Default/MonarchStartShySexT.Default__MonarchStartShySexT_C.SessionData.Lines(0).Lines
 msgctxt ",954CCB0A40A176E6B34A32A8E4590B0A"
 msgid "*Blush*"
-msgstr ""
+msgstr "*脸红*"
 
 #. Key:	9562407547DB97CDA2482285D47741B5
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchShySex_RL.Default__MonarchShySex_RL_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/Monarch/Default/MonarchShySex_RL.Default__MonarchShySex_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",9562407547DB97CDA2482285D47741B5"
 msgid "You can have sex with me!"
-msgstr ""
+msgstr "还不快来和我做爱！"
 
 #. Key:	9575F3C94F07BC8A511E8D85F3737E68
 #. SourceLocation:	/Game/Characters/Procedural/Variants/Harpy/Harvest/HarpyHarvest.Default__HarpyHarvest_C.Harvest.Description
@@ -8061,21 +8063,21 @@ msgstr "哈比体液"
 #: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TravelShrines(5 - Value).TravelShrines.ShrineName
 msgctxt ",95781B414AAF336B071430A39FC2F698"
 msgid "Esoteric Glade"
-msgstr "秘传之地"
+msgstr "密荫之地"
 
 #. Key:	9589965546B48748E41BA7942844189B
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03.Default__FernDefault03_C.SessionData.LinesToFuta(2).LinesToFuta
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03.Default__FernDefault03_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",9589965546B48748E41BA7942844189B"
 msgid "I am a growing Alraune, perhaps you have fluids to spare?"
-msgstr "我已经是成长中的曼陀罗了，也许您还有没被榨干的液体？"
+msgstr "我作为曼陀罗还在成长中，也许您可以分我一些您的体液？"
 
 #. Key:	960E85EF4CA91DAAA4DCFF93B84D183E
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToFuta(4).LinesToFuta
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToFuta(4).LinesToFuta
 msgctxt ",960E85EF4CA91DAAA4DCFF93B84D183E"
 msgid "Imagine all of the places you could slide your dick in human... and I promise I would make them all feel so good..."
-msgstr "想象一下，你的性器在我的触手中会感觉多么爽……我保证我会爱抚到每一分每一寸。"
+msgstr "想象一下，你的性器在我的触手中会感觉多么爽……我保证我会细细爱抚到每一分每一寸。"
 
 #. Key:	96151D60454DB0FB521DD6A507DA6C07
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_Forgot_RL.Default__ParvatiDefault01_Forgot_RL_C.ResponseData(2).ResponseData.BreederPrompt
@@ -8089,35 +8091,35 @@ msgstr "骑乘位"
 #: /Game/Dialogue/Kybele/Default/KybeleTittyPony.Default__KybeleTittyPony_C.SessionData.LinesToMale(2).LinesToMale
 msgctxt ",96224E4C41C21D56ABD895A4ACFB4843"
 msgid "That should teach you to cross this titty po--I mean mighty centaur warmaiden, again!"
-msgstr ""
+msgstr "这再一次教会你如何深入这个大奶驹……——我是说！强大的半人马女战士"
 
 #. Key:	9656DDC24323054BCA6436A90C28AD1C
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleDragonMatriarch.Default__KybeleDragonMatriarch_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Kybele/Default/KybeleDragonMatriarch.Default__KybeleDragonMatriarch_C.SessionData.Lines(2).Lines
 msgctxt ",9656DDC24323054BCA6436A90C28AD1C"
 msgid "Even if it means... ugh... no leaving to find sexual encounters."
-msgstr ""
+msgstr "即使这意味着…啊…不能离开去找性伴侣"
 
 #. Key:	9668736F4FE45C7CD14E0C9DE8400813
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFemale(10).LinesToFemale
 #: /Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFemale(10).LinesToFemale
 msgctxt ",9668736F4FE45C7CD14E0C9DE8400813"
 msgid "Unlike nephnip, blue smoke destroys your mind... just look how dumb that kitsune priestess is."
-msgstr ""
+msgstr "蓝烟会摧毁你的大脑，你看看那个个九尾狐仙祭祀有多蠢。"
 
 #. Key:	96824C894B9B4241DBDFEEB68C760057
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(30).LinesToMale
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(30).LinesToMale
 msgctxt ",96824C894B9B4241DBDFEEB68C760057"
 msgid "If you want to learn about how to catch @MONSTER_RACE@, head to the town located up the plateau ahead and speak to my assistant Camilla. You can't miss her... actually wait you might, she's so tiny and cute hehehe."
-msgstr "如果你想学习如何抓住魔弗灵，从前面那条小路往上走到高处的小镇，去问问我的助手蜜拉。你可千万不能错过她……事实上她有可能也在等你，她是那么娇小可爱…嘿嘿嘿……"
+msgstr "如果你想学习如何抓住魔弗灵，从前面那条小路往上走到高处的小镇，去问问我的助手卡米拉。你不可能错过她的……事实上她有可能也在等你，她是那么娇小可爱…嘿嘿嘿……"
 
 #. Key:	9697386D4E5433DC67FA228576AC58B4
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernBeeFlowers3.Default__FernBeeFlowers3_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Fern/DefaultP3/FernBeeFlowers3.Default__FernBeeFlowers3_C.SessionData.Lines(0).Lines
 msgctxt ",9697386D4E5433DC67FA228576AC58B4"
 msgid "Even in my current form, I am not powerful enough to control the plants in other lands."
-msgstr ""
+msgstr "即使在我现在的状态下，我也没有足够的力量来控制其他地方的植物。"
 
 #. Key:	96BF4241443E0334BA81569BD0CAB916
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01.Default__LeylannaDefault01_C.SessionData.Lines(1).Lines
@@ -8145,7 +8147,7 @@ msgstr "我几乎见识过了所有魔弗灵引以为傲的家伙们。"
 #: /Game/Dialogue/Emissary/Default/EmissaryCockblockGates.Default__EmissaryCockblockGates_C.SessionData.Lines(1).Lines
 msgctxt ",96FA042F4830A4781D9FA0874F4705D7"
 msgid "The Goddess wisely placed them there to test your ability."
-msgstr ""
+msgstr "女神明智地把她们放在那里来测试你的能力"
 
 #. Key:	97086CA946BFA31C6199599097E76015
 #. SourceLocation:	/Game/Dialogue/Cassie/SexScenes/CassieButterButtF.Default__CassieButterButtF_C.SessionData.Lines(4).Lines
@@ -8159,7 +8161,7 @@ msgstr "*咕噜咕噜声*"
 #: /Game/Ranch/Upgrades/FoxenHouse.Default__FoxenHouse_C.Upgrade.Description
 msgctxt ",9717FEC243A7CD17EDAAD89765F8E2A8"
 msgid "This allows you to catch and store all variants of Foxen."
-msgstr ""
+msgstr "这允许你捕捉和存储所有的狐娘。"
 
 #. Key:	97244FB84D6D7CC0273CD3BB89B847D9
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(22 - Value).TraitIcons.DisplayName
@@ -8173,21 +8175,21 @@ msgstr "敏捷的"
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_Teach.Default__ParvatiDefault01_Teach_C.SessionData.LinesToMale(0).LinesToMale
 msgctxt ",975E8DE7431AB39F97281DB7BD7DE314"
 msgid "Remove your garments, for you must be nude."
-msgstr ""
+msgstr "脱下你的衣服，因为你必须赤忱相见。"
 
 #. Key:	97819B7A480CF2968256F1AD74021DAD
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_AboutMusic.Default__RomyDefault01_AboutMusic_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Romy/Default/RomyDefault01_AboutMusic.Default__RomyDefault01_AboutMusic_C.SessionData.Lines(4).Lines
 msgctxt ",97819B7A480CF2968256F1AD74021DAD"
 msgid "Then... well you might imagine what we do."
-msgstr "然后...你觉得我们接下来会做什么。"
+msgstr "然后...你觉得我们接下来会做什么呢~"
 
 #. Key:	9787E49C47227601EF65578F30C5CCA2
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeDefault01.Default__BeeDefault01_C.SessionData.LinesToFuta(2).LinesToFuta
 #: /Game/Dialogue/QueenBee/Default/BeeDefault01.Default__BeeDefault01_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",9787E49C47227601EF65578F30C5CCA2"
 msgid "Is t-t-there something... you want human?"
-msgstr ""
+msgstr "有…有…有什么……你想要的吗，人类？"
 
 #. Key:	97A580FD4F8820DD9E8FA09B6B69797A
 #. SourceLocation:	/Game/Ranch/Upgrades/SeraphimLoft.Default__SeraphimLoft_C.Upgrade.DisplayName
@@ -8201,49 +8203,49 @@ msgstr "天堂阁楼"
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03_R02.Default__FernDefault03_R02_C.SessionData.Lines(3).Lines
 msgctxt ",97B6C8DB42BBC06231748889E00AC3AE"
 msgid "Sink inside my silky body and I will make you feel good for hours. You can spend all day in here, I don't mind."
-msgstr ""
+msgstr "沉浸在我柔滑的温暖乡里，我会让您愉悦数个小时。您可以在这里待一整天，我完全不介意。"
 
 #. Key:	97B7D1BE4E385C8A6215AC8465CF6026
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMWantHuman.Default__DMWantHuman_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMWantHuman.Default__DMWantHuman_C.SessionData.Lines(4).Lines
 msgctxt ",97B7D1BE4E385C8A6215AC8465CF6026"
 msgid "Your little body will be overwhelmed, and the next thing you know will be the sweet embrace of the Reaper."
-msgstr ""
+msgstr "你小小的身体将会不知所措，接下来你知道的就是死神甜蜜的拥抱"
 
 #. Key:	97B89613437939D3F62A4F9364D46263
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchPrettyButterfly.Default__MonarchPrettyButterfly_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Monarch/Default/MonarchPrettyButterfly.Default__MonarchPrettyButterfly_C.SessionData.Lines(5).Lines
 msgctxt ",97B89613437939D3F62A4F9364D46263"
 msgid "*Blush*"
-msgstr ""
+msgstr "*脸红*"
 
 #. Key:	97C48C5D4FCF938DF123EA94C35A3858
 #. SourceLocation:	/Game/Dialogue/Mirru/SexScenes/MirruSnatchT.Default__MirruSnatchT_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Mirru/SexScenes/MirruSnatchT.Default__MirruSnatchT_C.SessionData.Lines(3).Lines
 msgctxt ",97C48C5D4FCF938DF123EA94C35A3858"
 msgid "Feel my soft girthy tentacles embrace you... oh... yes."
-msgstr "感受我柔软的触手拥着你……唔……"
+msgstr "感受我柔软的触手拥抱着你……对……放轻松."
 
 #. Key:	97DE1E2D44F75CDC8B07A3ACE527EFC4
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03_R03.Default__FernDefault03_R03_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03_R03.Default__FernDefault03_R03_C.SessionData.Lines(1).Lines
 msgctxt ",97DE1E2D44F75CDC8B07A3ACE527EFC4"
 msgid "I need human cum to grow into my final form. Your dick will slide all the way down my throat as I suck every drop."
-msgstr ""
+msgstr "小蕨需要人类的精液来长成最终形态！！当我吞咽的时候，主人的鸡巴会一路滑到我的喉咙里面，我会吸干主人的每一滴精液的。"
 
 #. Key:	97E28C894118E126ABF5B3B0124EB241
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeDefault02_RL.Default__BeeDefault02_RL_C.ResponseData(3).ResponseData.BreederPrompt
 #: /Game/Dialogue/QueenBee/Default/BeeDefault02_RL.Default__BeeDefault02_RL_C.ResponseData(3).ResponseData.BreederPrompt
 msgctxt ",97E28C894118E126ABF5B3B0124EB241"
 msgid "More honey!"
-msgstr ""
+msgstr "更多的钱！"
 
 #. Key:	97E4D09B44D082B3154FEE94A88EE112
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFemale(8).LinesToFemale
 #: /Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFemale(8).LinesToFemale
 msgctxt ",97E4D09B44D082B3154FEE94A88EE112"
 msgid "That must have been you, perhaps you should go and talk to her."
-msgstr ""
+msgstr "那一定是你，也许你应该去和她谈谈。"
 
 #. Key:	9823997B4369C9710C0858A44B670A9D
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_RL.Default__CamillaDefault01_RL_C.ResponseData(4).ResponseData.BreederPrompt
@@ -8264,14 +8266,14 @@ msgstr "在这个世界你肯定会邂逅到到被神佑开智却一心只想满
 #: /Game/Dialogue/Blossom/Default/BlossomDefault01.Default__BlossomDefault01_C.SessionData.Lines(2).Lines
 msgctxt ",9828516944EAF3071BF52881396D2B01"
 msgid "Timeeee for harvest fluidsssss?"
-msgstr ""
+msgstr "已经到了收割精液的时间了吗，嘶？"
 
 #. Key:	982CC755420F84E3E4F0E5A5452A5A48
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiHadSex01.Default__ParvatiHadSex01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Parvati/Default/ParvatiHadSex01.Default__ParvatiHadSex01_C.SessionData.Lines(1).Lines
 msgctxt ",982CC755420F84E3E4F0E5A5452A5A48"
 msgid "I want to make love with you, I will not lie."
-msgstr ""
+msgstr "我想和你做爱，我不会撒谎。"
 
 #. Key:	985E4BA14797DC7FF94FF4974E66471A
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R06.Default__FaleneDefault01_R06_C.SessionData.Lines(6).Lines
@@ -8292,42 +8294,42 @@ msgstr "管理你的狐狸族"
 #: /Game/Dialogue/DragonMatriarch/Default/DMClimaxPeak.Default__DMClimaxPeak_C.SessionData.Lines(2).Lines
 msgctxt ",9894566A4CC22E8EE536A59E367BF98A"
 msgid "*Yawn*"
-msgstr ""
+msgstr "*打哈欠*"
 
 #. Key:	9906C87647695E1D9105C3867D704EB0
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMAboutDragons.Default__DMAboutDragons_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMAboutDragons.Default__DMAboutDragons_C.SessionData.Lines(3).Lines
 msgctxt ",9906C87647695E1D9105C3867D704EB0"
 msgid "I have taken the... heavy burden... upon myself of growing the dragon population."
-msgstr ""
+msgstr "我有着…沉重的包袱……因为我,族才得以不断扩张，我以此为傲。"
 
 #. Key:	992B062D49B06DDE4398A58352D2F7DF
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchStartShySexF.Default__MonarchStartShySexF_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Monarch/Default/MonarchStartShySexF.Default__MonarchStartShySexF_C.SessionData.Lines(0).Lines
 msgctxt ",992B062D49B06DDE4398A58352D2F7DF"
 msgid "*Blush*"
-msgstr ""
+msgstr "*脸红*"
 
 #. Key:	9935EBCD498F8B600AAED699613B52E9
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01_R02_R01.Default__FernDefault01_R02_R01_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Fern/Default/FernDefault01_R02_R01.Default__FernDefault01_R02_R01_C.SessionData.Lines(3).Lines
 msgctxt ",9935EBCD498F8B600AAED699613B52E9"
 msgid "Many shiny does Fern find in soil. Fern try to eat shiny, too hard."
-msgstr "小蕨在平原上找到了很多这样的闪闪亮……嘶嘶…小蕨尝试吃亮晶晶，但是实在太硬啦……好难咽。"
+msgstr "小蕨在平原的土地里找到了很多这样的亮片……嘶嘶…小蕨尝试吃这亮片，但是实在太硬啦……好难咽。"
 
 #. Key:	9948725645B6492AE76EDB8B38DB1C7F
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.HarpyAviary.ManageActionMessage
 #: /Game/World/Overworld.Overworld:PersistentLevel.HarpyAviary.ManageActionMessage
 msgctxt ",9948725645B6492AE76EDB8B38DB1C7F"
 msgid "Manage your Harpies"
-msgstr "管理你的哈比"
+msgstr "管理你的哈比族"
 
 #. Key:	996ED4764E0D1E469F8958853E2AABAD
 #. SourceLocation:	/Game/Dialogue/Yasmine/Default/YasmineHadSex01.Default__YasmineHadSex01_C.SessionData.LinesGrungy(1).LinesGrungy
 #: /Game/Dialogue/Yasmine/Default/YasmineHadSex01.Default__YasmineHadSex01_C.SessionData.LinesGrungy(1).LinesGrungy
 msgctxt ",996ED4764E0D1E469F8958853E2AABAD"
 msgid "You need a bath. Come now, place your body between my breasts and let's get you clean."
-msgstr ""
+msgstr "你需要洗个澡。来吧，把你的身体放在我的乳房中间，让她们帮你洗干净。"
 
 #. Key:	99AAA6394A3838FD6FEF1EAA31AD6102
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaGreeting01.Default__LeylannaGreeting01_C.SessionData.Lines(0).Lines
@@ -8341,21 +8343,21 @@ msgstr "凡人终来探寻我的智慧。"
 #: /Game/Dialogue/Widow/Default/WidowDefault01_RL.Default__WidowDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
 msgctxt ",99D4A5E745FE69C8C652C6AC80533D2D"
 msgid "Can I have that keystone?"
-msgstr ""
+msgstr "我可以拿走钥石了吗？"
 
 #. Key:	99E0E26846BB80B4206E7DB11488DCC4
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernBeeFlowers.Default__FernBeeFlowers_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Fern/Default/FernBeeFlowers.Default__FernBeeFlowers_C.SessionData.Lines(2).Lines
 msgctxt ",99E0E26846BB80B4206E7DB11488DCC4"
 msgid "Fern don't know... not powerful enough."
-msgstr ""
+msgstr "小蕨不知道…嘶嘶…小蕨还太弱小……"
 
 #. Key:	99F080324D7FD127AB659FB7CC382C5A
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraGetKeystone.Default__PetraGetKeystone_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Petra/Default/PetraGetKeystone.Default__PetraGetKeystone_C.SessionData.Lines(5).Lines
 msgctxt ",99F080324D7FD127AB659FB7CC382C5A"
 msgid "Perhaps Pawsmaati is testing me... maybe succubus is a metaphore for my own lust..."
-msgstr ""
+msgstr "也许是帕丝妈媞在考验我……也许魅魔是我欲望的一种暗喻吧……”"
 
 #. Key:	9A0EF6A841D0C76A871BD39DB09AEFD4
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01_R03.Default__FernDefault01_R03_C.SessionData.Lines(0).Lines
@@ -8369,14 +8371,14 @@ msgstr "嘶嘶嘶嘶嘶主人嘶！小蕨终于等到您来滋润小蕨了吗？
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_Forgot.Default__ParvatiDefault01_Forgot_C.SessionData.Lines(0).Lines
 msgctxt ",9A173A0445AB01F578033CA42A8E9C8F"
 msgid "Oh! Ahem..."
-msgstr ""
+msgstr "恩，哼……"
 
 #. Key:	9A872CD1493BC95421F01C946AF0F7E4
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaHadSex01.Default__CamillaHadSex01_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/Camilla/Default/CamillaHadSex01.Default__CamillaHadSex01_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",9A872CD1493BC95421F01C946AF0F7E4"
 msgid "Wow human, you must have been desperate to give this nugget your love."
-msgstr ""
+msgstr "哇，人类，你一定是不顾一切地给这个小东西你的爱。"
 
 #. Key:	9A9EDF3448107C0855BB35BBD9D849F5
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(23).LinesToFemale
@@ -8390,7 +8392,7 @@ msgstr "同我一样受神庇佑而开智的魔弗灵则和人类一般聪明。
 #: /Game/Dialogue/Blossom/Default/BlossomDefault01_R02.Default__BlossomDefault01_R02_C.SessionData.Lines(0).Lines
 msgctxt ",9AF5988A4B6D8F174F3241B67F4033C8"
 msgid "Blossom!"
-msgstr ""
+msgstr "花花！"
 
 #. Key:	9B115CE5485736847F748591F0C8FB2A
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToMale(3).LinesToMale
@@ -8404,7 +8406,7 @@ msgstr "不可否认那真是令我爽翻天，但是啊…我总觉得我还缺
 #: /Game/Dialogue/Fern/SexScenes/FernCum_01.Default__FernCum_01_C.SessionData.Lines(4).Lines
 msgctxt ",9B2F56474FA9D82EE9F76EBEB5723F74"
 msgid "Hiss... Fern like this... much pleasure, taste is good."
-msgstr "嘶嘶……小蕨好喜欢……如此款待我，主人的精液好美味。"
+msgstr "嘶嘶……小蕨好喜欢……如此款待我，主人射的精液好美味。"
 
 #. Key:	9B3D729A40A0E93316F524B863B2BAED
 #. SourceLocation:	/Game/Characters/Procedural/Variants/Neko/Harvest/NekoHarvest.Default__NekoHarvest_C.Harvest.RaceName
@@ -8425,56 +8427,56 @@ msgstr "天使"
 #: /Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToMale(0).LinesToMale
 msgctxt ",9B8AE2F943E1AF24641C2BB8C4C41176"
 msgid "Ohhhh your dick! Finally!"
-msgstr "哦，你的肉棒！终于进来了！"
+msgstr "哦，你的肉棒！我感受到了！"
 
 #. Key:	9BCB9BF649F84B0314EFF688539A52A5
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeGreeting01.Default__BeeGreeting01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/QueenBee/Default/BeeGreeting01.Default__BeeGreeting01_C.SessionData.Lines(0).Lines
 msgctxt ",9BCB9BF649F84B0314EFF688539A52A5"
 msgid "Kneel before your queen... ahhh.... ohhh..."
-msgstr ""
+msgstr "在你的女王面前跪下……啊…噢…"
 
 #. Key:	9BD2015749AE3D2CD457DDB2CBC112F4
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleGreeting01.Default__KybeleGreeting01_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Kybele/Default/KybeleGreeting01.Default__KybeleGreeting01_C.SessionData.Lines(2).Lines
 msgctxt ",9BD2015749AE3D2CD457DDB2CBC112F4"
 msgid "The offspring of the Dragon Matriarch will be protected by any means necessary."
-msgstr ""
+msgstr "巨龙女族长的后代将会受到一切必要的保护。"
 
 #. Key:	9BDBC0EB4511337E7515C89A6620BBA0
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeHadSex01.Default__AmberMaeHadSex01_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeHadSex01.Default__AmberMaeHadSex01_C.SessionData.Lines(3).Lines
 msgctxt ",9BDBC0EB4511337E7515C89A6620BBA0"
 msgid "Come back and drink up anytime."
-msgstr ""
+msgstr "随时都欢迎尼回来喝哦。"
 
 #. Key:	9BF2AD09410781A66302329DB25BA0EC
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_Forgot.Default__ParvatiDefault01_Forgot_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_Forgot.Default__ParvatiDefault01_Forgot_C.SessionData.Lines(5).Lines
 msgctxt ",9BF2AD09410781A66302329DB25BA0EC"
 msgid "As I meditate, all I want is to make love with you."
-msgstr ""
+msgstr "在我冥想的时候，我只想和你云雨一番"
 
 #. Key:	9C0628944A08387197D344B7CBC502FB
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMYourChildren.Default__DMYourChildren_C.SessionData.LinesToFemale(3).LinesToFemale
 #: /Game/Dialogue/DragonMatriarch/Default/DMYourChildren.Default__DMYourChildren_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",9C0628944A08387197D344B7CBC502FB"
 msgid "The dragon race will reign supreme over all of @WORLD_NAME@!"
-msgstr ""
+msgstr "龙族将统治整个 @WORLD_NAME@！"
 
 #. Key:	9C25CF834B78D0D105D4C98D2D869441
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiHadSex01.Default__FesssiHadSex01_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/Fesssi/Default/FesssiHadSex01.Default__FesssiHadSex01_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",9C25CF834B78D0D105D4C98D2D869441"
 msgid "Sssso tasty. Hiss!"
-msgstr ""
+msgstr "太……太美味了，嘶嘶"
 
 #. Key:	9C2CBDE44BB47D22C9F6A5AFB2316748
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcDefault01.Default__OrcDefault01_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcDefault01.Default__OrcDefault01_C.SessionData.Lines(3).Lines
 msgctxt ",9C2CBDE44BB47D22C9F6A5AFB2316748"
 msgid "Grrr! Do it or you will breed with me now."
-msgstr ""
+msgstr "咕噜噜！不然你现在就跟我生孩子。"
 
 #. Key:	9C3FDDD5490B3180DDD3329C692C0B4D
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R01.Default__CamillaDefault01_R01_C.SessionData.Lines(3).Lines
@@ -8488,21 +8490,21 @@ msgstr "最快速的方法就是和它们交欢直到它们屈服为止，用你
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeLikesPresent.Default__MegaSlimeLikesPresent_C.SessionData.Lines(0).Lines
 msgctxt ",9C7CF64D42692442A687709D5C22BB3D"
 msgid "The pearl you gave me is wonderful, I love it."
-msgstr ""
+msgstr "你给我的珍珠太美了，我爱死了。"
 
 #. Key:	9CA55551425FE9DE83AB5B9535E62AFC
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadDefault01_RL.Default__DryadDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/Autumn/Default/DryadDefault01_RL.Default__DryadDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",9CA55551425FE9DE83AB5B9535E62AFC"
 msgid "Tell me about dryads!"
-msgstr ""
+msgstr "跟我讲讲树妖的事吧"
 
 #. Key:	9CB6C5E14DD6C412AD7898B8D2120925
 #. SourceLocation:	/Game/UI/TaskDescriptions.TaskDescriptions.TextEntries(8).TextEntries
 #: /Game/UI/TaskDescriptions.TaskDescriptions.TextEntries(8).TextEntries
 msgctxt ",9CB6C5E14DD6C412AD7898B8D2120925"
 msgid "Having fins makes moving on dry land challenging. Would you breed me a loveable Nephelym that can fetch things around town? I suppose it doesn't HAVE to be attractive... though if you could... just in case.  -Romy"
-msgstr ""
+msgstr "有鱼鳍让我在在旱地上行走变得及其具有挑战性，你能不能帮我养一个漂亮的魔弗灵，可以帮我去城里拿东西……如果可以的话……只是以防万一啦——罗咪"
 
 #. Key:	9D593DC94FAA9CCF2CB35CBA7EA06A73
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToMale(2).LinesToMale
@@ -8516,28 +8518,28 @@ msgstr "我几乎见识过了所有魔弗灵引以为傲的家伙们。"
 #: /Game/Dialogue/Fesssi/Default/FesssiDefault03_RL_T.Default__FesssiDefault03_RL_T_C.ResponseData(2).ResponseData.BreederPrompt
 msgctxt ",9D875449461B56179F1FE9A457741C3B"
 msgid "Where does that cave lead?"
-msgstr ""
+msgstr "那个山洞通向哪里?"
 
 #. Key:	9DCE82F542FEDB443D7432A9C8EE7AF6
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleDefault01_RL.Default__KybeleDefault01_RL_C.ResponseData(3).ResponseData.BreederPrompt
 #: /Game/Dialogue/Kybele/Default/KybeleDefault01_RL.Default__KybeleDefault01_RL_C.ResponseData(3).ResponseData.BreederPrompt
 msgctxt ",9DCE82F542FEDB443D7432A9C8EE7AF6"
 msgid "By any means necessary..."
-msgstr ""
+msgstr "尽一切可能……"
 
 #. Key:	9E0F2A7F4F6510D820FB12BE4580D421
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_EnlightenedOne.Default__NeelaDefault01_EnlightenedOne_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_EnlightenedOne.Default__NeelaDefault01_EnlightenedOne_C.SessionData.Lines(3).Lines
 msgctxt ",9E0F2A7F4F6510D820FB12BE4580D421"
 msgid "She is kind and loving, you will experience untold pleasures... trust me."
-msgstr ""
+msgstr "她既善良又赋有有爱心，相信我你会体验到无尽的快感……。"
 
 #. Key:	9E15F19C4964C11243C2BE906C8DB6C9
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_RL.Default__EmissaryDefault01_RL_C.ResponseData(3).ResponseData.BreederPrompt
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_RL.Default__EmissaryDefault01_RL_C.ResponseData(3).ResponseData.BreederPrompt
 msgctxt ",9E15F19C4964C11243C2BE906C8DB6C9"
 msgid "What do you think of Leylanna?"
-msgstr "你觉得Leylanna怎么样？"
+msgstr "你觉得蕾莱娜怎么样？"
 
 #. Key:	9E44475F4EB585010826CC9A936D628F
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeDefault01_RL.Default__AmberMaeDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
@@ -8551,28 +8553,28 @@ msgstr "让我看看你的奶制品吧。"
 #: /Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToFuta(0).LinesToFuta
 msgctxt ",9E5B0BA14AE1E009AC9A5BA4D423863D"
 msgid "Ohhh how I have waited to wrap my soft lips around a human dick! Ahhh..."
-msgstr "哦，我一直在等待着将人类的大宝贝吸进我柔软的嘴唇里！ 啊..."
+msgstr "哦，我一直在等待着将人类的大宝贝吸进我柔软的嘴唇里的机会！ 啊~..."
 
 #. Key:	9E8424C246BEBF834649DAABF8B5CD18
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_RL.Default__EmissaryDefault01_RL_C.ResponseData(7).ResponseData.BreederPrompt
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_RL.Default__EmissaryDefault01_RL_C.ResponseData(7).ResponseData.BreederPrompt
 msgctxt ",9E8424C246BEBF834649DAABF8B5CD18"
 msgid "How do I open the stone gates?"
-msgstr ""
+msgstr "我要怎么打开这个石门呢？"
 
 #. Key:	9E8C52C446FF788D61D6B98D9189D88D
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFuta(3).LinesToFuta
 #: /Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFuta(3).LinesToFuta
 msgctxt ",9E8C52C446FF788D61D6B98D9189D88D"
 msgid "Maybe between my fat ass cheeks?"
-msgstr ""
+msgstr "也许在我的丰满的双臀之间?"
 
 #. Key:	9EB1E11442BB00388C518B8B9CDC9A62
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiDefault01.Default__FesssiDefault01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiDefault01.Default__FesssiDefault01_C.SessionData.Lines(1).Lines
 msgctxt ",9EB1E11442BB00388C518B8B9CDC9A62"
 msgid "But it's time for a change... time to once again roam the surface in search of pleasure."
-msgstr ""
+msgstr "是时候改变了…是时候再一次徜徉于尘世，寻找快感了。"
 
 #. Key:	9ECA418E4EC2E9617CD48B82C43CB5FA
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(2 - Value).TraitIcons.HelpText
@@ -8586,28 +8588,28 @@ msgstr "庞大体型：身高约10英尺（3.05米）"
 #: /Game/Dialogue/Autumn/Default/DryadAboutDryads.Default__DryadAboutDryads_C.SessionData.Lines(8).Lines
 msgctxt ",9ECDE7F64C28F7F9624081B927CA3030"
 msgid "Compared to other Alraunes, dryads are wise and mobile. We use our pleasure to help others."
-msgstr ""
+msgstr "与其他的曼德拉草相比，树妖聪明且行动灵活。我们用快乐来互相帮助。"
 
 #. Key:	9EEBDB0446F2AAFA8F605E8A3DE83534
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_YourMusic.Default__RomyDefault01_YourMusic_C.SessionData.LinesToFuta(2).LinesToFuta
 #: /Game/Dialogue/Romy/Default/RomyDefault01_YourMusic.Default__RomyDefault01_YourMusic_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",9EEBDB0446F2AAFA8F605E8A3DE83534"
 msgid "Your face will know the sweet melody of my soft large breasts."
-msgstr ""
+msgstr "你的脸会知道我温柔的大乳房的甜美旋律。"
 
 #. Key:	9EEFE8B54303A99BB5053CA7F7960A23
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.FormurianPond.ManageActionMessage
 #: /Game/World/Overworld.Overworld:PersistentLevel.FormurianPond.ManageActionMessage
 msgctxt ",9EEFE8B54303A99BB5053CA7F7960A23"
 msgid "Manage your Formurians"
-msgstr "管理你的深海族人"
+msgstr "管理你的深海族"
 
 #. Key:	9F2120194C14A491202338AEB2C05883
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieHadSex01.Default__CassieHadSex01_C.SessionData.LinesToFuta(5).LinesToFuta
 #: /Game/Dialogue/Cassie/Default/CassieHadSex01.Default__CassieHadSex01_C.SessionData.LinesToFuta(5).LinesToFuta
 msgctxt ",9F2120194C14A491202338AEB2C05883"
 msgid "I want to release again already... you humans have it so easy."
-msgstr ""
+msgstr "我想要再高潮一次…你们人类很轻松就能让我高潮了"
 
 #. Key:	9F25BEB847378BA942933C8A503B4F1A
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(22 - Value).TraitIcons.HelpText
@@ -8621,7 +8623,7 @@ msgstr "迅捷：在任何行动中，情欲值消耗将会根据当前敏捷值
 #: /Game/Dialogue/DragonMatriarch/Default/DMGrasslandsTrees.Default__DMGrasslandsTrees_C.SessionData.Lines(1).Lines
 msgctxt ",9F82F5BC4976131C6A3861A1CAF32EFA"
 msgid "Yeah... I suppose you're right though."
-msgstr ""
+msgstr "是啊……我想你是对的"
 
 #. Key:	9F83DE504D98E2D4C149568C1F8DE768
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(4 - Value).TraitIcons.HelpText
@@ -8635,49 +8637,49 @@ msgstr "巨大体型：身高约15英尺（4.57米）"
 #: /Game/Dialogue/Kybele/Default/KybeleTittyPony_T.Default__KybeleTittyPony_T_C.SessionData.LinesToFuta(0).LinesToFuta
 msgctxt ",9F883FFA4CA5D4B34A5726989E26C6C5"
 msgid "That's it human, you have annoyed me long enough. Get against that rock and prepare to be smashed."
-msgstr ""
+msgstr "够了，人类，你烦我够久了。靠在那块石头上，准备被碾碎吧。"
 
 #. Key:	9F8F75924886323A16353D90FDCB1B1C
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernBeeFlowers.Default__FernBeeFlowers_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Fern/Default/FernBeeFlowers.Default__FernBeeFlowers_C.SessionData.Lines(0).Lines
 msgctxt ",9F8F75924886323A16353D90FDCB1B1C"
 msgid "Queen Bee?"
-msgstr ""
+msgstr "蜂后？"
 
 #. Key:	9F98C71B4D9DFE442CACEAAB6F21EB92
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeGreeting01.Default__MegaSlimeGreeting01_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeGreeting01.Default__MegaSlimeGreeting01_C.SessionData.Lines(5).Lines
 msgctxt ",9F98C71B4D9DFE442CACEAAB6F21EB92"
 msgid "We can be friends too! Why don't you stay and play in my slime?"
-msgstr ""
+msgstr "我们也可以成为朋友!你为什么不留下来在我史莱姆粘液里玩呢?"
 
 #. Key:	9F9D5BEE4F26E405A81EB09066622552
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_FloatRhyme.Default__ParvatiDefault01_FloatRhyme_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_FloatRhyme.Default__ParvatiDefault01_FloatRhyme_C.SessionData.Lines(4).Lines
 msgctxt ",9F9D5BEE4F26E405A81EB09066622552"
 msgid "Eons in Her embrace have taught me bodily forms."
-msgstr ""
+msgstr "在祂无尽的怀抱中，我学会了变化我自己的形态"
 
 #. Key:	9FAD5CA34B7A4B192E688C9C72A825B3
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R06.Default__FaleneDefault01_R06_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R06.Default__FaleneDefault01_R06_C.SessionData.Lines(1).Lines
 msgctxt ",9FAD5CA34B7A4B192E688C9C72A825B3"
 msgid "According to the high priestess Leylana at the temple, the Goddess and her angels descended from the heavens."
-msgstr "据圣殿的九尾大祭司莱兰娜所说，至高女神和她的天使从天堂降临"
+msgstr "据圣殿的九尾大祭司蕾莱娜所说，至高女神和她的天使从天堂降临"
 
 #. Key:	9FE3B8C04B35B846B4CFB99902294CDE
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcWantWrestle.Default__OrcWantWrestle_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcWantWrestle.Default__OrcWantWrestle_C.SessionData.Lines(1).Lines
 msgctxt ",9FE3B8C04B35B846B4CFB99902294CDE"
 msgid "I knew human liked feeling this mighty body."
-msgstr ""
+msgstr "我知道人类喜欢感受这种强大的身体。"
 
 #. Key:	9FE7AADC4372F0B32E971C838E6554EA
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(20).LinesToFemale
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(20).LinesToFemale
 msgctxt ",9FE7AADC4372F0B32E971C838E6554EA"
 msgid "Since you're a breeder, it's your job to catch and mate as many @MONSTER_RACE@ as possible!"
-msgstr "自你正式成为一名饲魔者，你的工作就是尽可能去抓你所能抓到的魔弗灵并与每一个交配！"
+msgstr "自你正式成为一名饲魔者起，你的工作就是尽可能去抓你所能抓到的魔弗灵并与之交配！"
 
 #. Key:	9FF8B7CE43E6A9321DDB60919962BBB7
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(17).LinesToMale
@@ -8705,14 +8707,14 @@ msgstr "哦我真傻，我还没有做过自我介绍。"
 #: /Game/Dialogue/Leylanna/Default/LeylannaOldTempleDungeon.Default__LeylannaOldTempleDungeon_C.SessionData.Lines(3).Lines
 msgctxt ",A084B03140D9C320BD31DCA76ED4873F"
 msgid "There's something under this temple?"
-msgstr ""
+msgstr "这圣殿下面有什么东西?"
 
 #. Key:	A0B0E60C4AD4856B54C5298236CC5BC3
 #. SourceLocation:	/Game/Ranch/Upgrades/MuttHut.Default__MuttHut_C.Upgrade.DisplayName
 #: /Game/Ranch/Upgrades/MuttHut.Default__MuttHut_C.Upgrade.DisplayName
 msgctxt ",A0B0E60C4AD4856B54C5298236CC5BC3"
 msgid "Mutt Hut"
-msgstr ""
+msgstr "混血族小屋"
 
 #. Key:	A0B57F5941F9CAEBBB30CF828C3E26AC
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R01.Default__FaleneDefault01_R01_C.SessionData.Lines(12).Lines
@@ -8726,14 +8728,14 @@ msgstr "我们的假说很有可能触及到了一些真相，所以这个假说
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02_RL_T.Default__FernDefault02_RL_T_C.ResponseData(2).ResponseData.BreederPrompt
 msgctxt ",A0DC38DD454D19C4375D3CAADA8796AA"
 msgid "What can you do?"
-msgstr ""
+msgstr "你能做什么呢？"
 
 #. Key:	A1243ACB4057D3CAD0A25787BA4DF627
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimePlay1.Default__MegaSlimePlay1_C.SessionData.LinesToFuta(1).LinesToFuta
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePlay1.Default__MegaSlimePlay1_C.SessionData.LinesToFuta(1).LinesToFuta
 msgctxt ",A1243ACB4057D3CAD0A25787BA4DF627"
 msgid "I think... you might be my best friend of all time."
-msgstr ""
+msgstr "我认为……你可能是我有史以来最好的朋友。"
 
 #. Key:	A12A50F34FE88A004CB5458C982B3915
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(16).LinesToFemale
@@ -8747,21 +8749,21 @@ msgstr "我想要感受你的酥胸……跟我的乳房紧紧交叠……啊啊
 #: /Game/Dialogue/Leylanna/Default/LeylannaGreeting01.Default__LeylannaGreeting01_C.SessionData.Lines(3).Lines
 msgctxt ",A208709240369AEC212F70B1CEFE7BE8"
 msgid "Let us make love to form a covenant in Her holy temple, and you can meet your spirit form."
-msgstr "让我们共度鱼水之欢，在圣殿中立下誓约，你就可以见到你的魂灵形态。"
+msgstr "让我们共度鱼水之欢，在圣殿中立下契约，你就可以见到你的魂灵形态。"
 
 #. Key:	A21511DE4632808A0555608E6F6880C6
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowScary.Default__WidowScary_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Widow/Default/WidowScary.Default__WidowScary_C.SessionData.Lines(2).Lines
 msgctxt ",A21511DE4632808A0555608E6F6880C6"
 msgid "Oh how I did... for nothing pleases a lonely spider more."
-msgstr ""
+msgstr "哦，我是怎么做到的……因为没有什么比你能够取悦孤独的蜘蛛了"
 
 #. Key:	A257204E40613ED62BA7D982059BC6E7
 #. SourceLocation:	/Game/Ranch/Upgrades/SeraphimLoft.Default__SeraphimLoft_C.Upgrade.TypeDisplay
 #: /Game/Ranch/Upgrades/SeraphimLoft.Default__SeraphimLoft_C.Upgrade.TypeDisplay
 msgctxt ",A257204E40613ED62BA7D982059BC6E7"
 msgid "Nephelym Barn"
-msgstr ""
+msgstr "魔弗灵小棚"
 
 #. Key:	A2DA50B44D0A24E096AF488F787D4928
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(28).LinesToFemale
@@ -8775,77 +8777,77 @@ msgstr "那么，就到这吧，祝你好运！"
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R03.Default__CamillaDefault01_R03_C.SessionData.Lines(2).Lines
 msgctxt ",A2EE900942F55DC4C6AA92BC44E482E4"
 msgid "Most dicks in this world are larger than me! As someone who collects and studies cum, you can't imagine how miserable it is stroking dick after dick and never being able to feel them penetrate me."
-msgstr "世界上大多数的肉棒都比我大!作为一个收集和研究精液的人，你无法想象抚摸着一个又一个肉棒，却永远感觉不到它们的存在是多么的痛苦。"
+msgstr "世界上大多数的肉棒都比我大!作为一个收集和研究精液的人，你无法想象抚摸一个又一个肉棒却永远感觉不到它们进入我体内有多痛苦……"
 
 #. Key:	A350122B4286C7BCFA490982F8390CB1
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieGreeting01.Default__CassieGreeting01_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Cassie/Default/CassieGreeting01.Default__CassieGreeting01_C.SessionData.Lines(2).Lines
 msgctxt ",A350122B4286C7BCFA490982F8390CB1"
 msgid "Ranch? Oh right, and your ranch too!"
-msgstr "牧场？啊对，你还有牧场要修建！"
+msgstr "牧场？哦对，你还有牧场要修建！"
 
 #. Key:	A3546DAB440D5D09BE7F809541FB90C3
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcGoneWorse.Default__OrcGoneWorse_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcGoneWorse.Default__OrcGoneWorse_C.SessionData.Lines(1).Lines
 msgctxt ",A3546DAB440D5D09BE7F809541FB90C3"
 msgid "Chieftain very horny, you will regret this. Come here!"
-msgstr ""
+msgstr "酋长欲火中烧，你会后悔的。过来吧你!"
 
 #. Key:	A3A36F6A453B245F5CA58C97B791509D
 #. SourceLocation:	/Game/Dialogue/Cassie/SexScenes/CassieButterButtF.Default__CassieButterButtF_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Cassie/SexScenes/CassieButterButtF.Default__CassieButterButtF_C.SessionData.Lines(0).Lines
 msgctxt ",A3A36F6A453B245F5CA58C97B791509D"
 msgid "Ohhh... soft human pussy feels amazing!"
-msgstr "哦...柔软的人类蜜穴感觉太棒了"
+msgstr "哦...柔软的人类蜜穴感觉爽呆了"
 
 #. Key:	A3D34227454452C74EC9BEBE9D5B4A17
 #. SourceLocation:	/Game/Dialogue/Fern/SexScenes/FernMilk_01.Default__FernMilk_01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Fern/SexScenes/FernMilk_01.Default__FernMilk_01_C.SessionData.Lines(0).Lines
 msgctxt ",A3D34227454452C74EC9BEBE9D5B4A17"
 msgid "Mastah's breast so soft! Fern like it."
-msgstr "主人的乳房好柔软！小蕨真的非常喜欢。"
+msgstr "嘶……主银的乳房好柔软！小蕨真的非常喜欢。"
 
 #. Key:	A40264BD4BB3E658212ECE987CC24B4A
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_Teach.Default__ParvatiDefault01_Teach_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_Teach.Default__ParvatiDefault01_Teach_C.SessionData.Lines(2).Lines
 msgctxt ",A40264BD4BB3E658212ECE987CC24B4A"
 msgid "Don't worry, for I can change my size."
-msgstr ""
+msgstr "别担心，我可以为了你改变我的尺寸。"
 
 #. Key:	A41D55094C37585E241DB98D76B52F65
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToFemale(6).LinesToFemale
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToFemale(6).LinesToFemale
 msgctxt ",A41D55094C37585E241DB98D76B52F65"
 msgid "If that doesn't suit you, I could put my slime in other places..."
-msgstr ""
+msgstr "如果你觉得不合适，我可以把我的黏液放到别的地方……”"
 
 #. Key:	A4367C3445DA16F7A5FC4584F73685FA
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01.Default__NeelaDefault01_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Neela/Default/NeelaDefault01.Default__NeelaDefault01_C.SessionData.Lines(2).Lines
 msgctxt ",A4367C3445DA16F7A5FC4584F73685FA"
 msgid "Perhaps, you care to experience what's in front of you now?"
-msgstr "还是，你想跟我一起体味点儿什么有意思的事儿？"
+msgstr "还是，你想跟我一起体味点儿什么有意思的事儿~？"
 
 #. Key:	A49D87C0482481404A2CD39993C62A1F
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieGreeting01.Default__CassieGreeting01_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Cassie/Default/CassieGreeting01.Default__CassieGreeting01_C.SessionData.Lines(4).Lines
 msgctxt ",A49D87C0482481404A2CD39993C62A1F"
 msgid "Don' matter now, that ranch's been like that for ages."
-msgstr "不过你现在不用担心啦~你的牧场已经这个状态很久了。"
+msgstr "现在无所谓了，反正那个牧场已经那样好多年了。。"
 
 #. Key:	A4A671C24CE09EFBA18364BA3C0F94EB
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraAboutPawsmaati.Default__PetraAboutPawsmaati_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Petra/Default/PetraAboutPawsmaati.Default__PetraAboutPawsmaati_C.SessionData.Lines(1).Lines
 msgctxt ",A4A671C24CE09EFBA18364BA3C0F94EB"
 msgid "Pawsmaati is ancient, much older than me or anyone else I've met."
-msgstr ""
+msgstr "帕丝玛媞是一位先祖，比我和我遇到的任何人都要年长得多。"
 
 #. Key:	A4B99F3C407E9C094C137DAF9E60A51F
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowHadSex01.Default__WidowHadSex01_C.SessionData.LinesGrungy(0).LinesGrungy
 #: /Game/Dialogue/Widow/Default/WidowHadSex01.Default__WidowHadSex01_C.SessionData.LinesGrungy(0).LinesGrungy
 msgctxt ",A4B99F3C407E9C094C137DAF9E60A51F"
 msgid "Oh you dirty dirty human... what have you done to yourself?"
-msgstr ""
+msgstr "哦，你这个脏兮兮的人类…你对自己做了什么?"
 
 #. Key:	A4C22B3045E8159B66E47CB636E23172
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(18 - Value).TraitIcons.DisplayName
@@ -8859,63 +8861,63 @@ msgstr "养育有方"
 #: /Game/Dialogue/Monarch/Default/MonarchDefault01.Default__MonarchDefault01_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",A4D2B8DD4CBF1E0294D5918B75F17CB7"
 msgid "This corner is n-n-nice and safe!"
-msgstr ""
+msgstr "这个角落真的是-真-真的是又棒又安全！"
 
 #. Key:	A4E670824F11C45EC16FA29BAF6EB6E1
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R02.Default__CamillaDefault01_R02_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R02.Default__CamillaDefault01_R02_C.SessionData.Lines(3).Lines
 msgctxt ",A4E670824F11C45EC16FA29BAF6EB6E1"
 msgid "Bovaur can be found sleeping in the soft grass of Pleasure Pastures."
-msgstr "奶牛娘可以在快乐牧场柔软的草地上找到。"
+msgstr "你可以看到奶牛娘们睡在快感牧场柔软的草地上。"
 
 #. Key:	A4F79CC74333E2131FC34EBBF3796A56
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchDefault01.Default__MonarchDefault01_C.SessionData.LinesToFemale(2).LinesToFemale
 #: /Game/Dialogue/Monarch/Default/MonarchDefault01.Default__MonarchDefault01_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",A4F79CC74333E2131FC34EBBF3796A56"
 msgid "Good thing I have my toy!"
-msgstr ""
+msgstr "好消息是我有玩具!"
 
 #. Key:	A5496AE246B786D1E975C6A2F4004B43
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMGreeting01.Default__DMGreeting01_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMGreeting01.Default__DMGreeting01_C.SessionData.Lines(3).Lines
 msgctxt ",A5496AE246B786D1E975C6A2F4004B43"
 msgid "That useless titty pony failed again I see. She will feel my wrath."
-msgstr ""
+msgstr "我看那匹无用的小奶驹又失败了。她会感受到我的愤怒的"
 
 #. Key:	A56B0F264A329DF192CE53B3DBA118EB
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiWantAss.Default__FesssiWantAss_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiWantAss.Default__FesssiWantAss_C.SessionData.Lines(2).Lines
 msgctxt ",A56B0F264A329DF192CE53B3DBA118EB"
 msgid "You are really going to enjoy thissss!"
-msgstr ""
+msgstr "你一定会喜欢的，嘶！"
 
 #. Key:	A58134D54AF7A503EDA75C88BD1471C1
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraDefault01.Default__PetraDefault01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Petra/Default/PetraDefault01.Default__PetraDefault01_C.SessionData.Lines(1).Lines
 msgctxt ",A58134D54AF7A503EDA75C88BD1471C1"
 msgid "I can't wait until my next lesson with Pawsmaati!"
-msgstr ""
+msgstr "我等不及要上帕丝玛媞的下一节性爱课程了!"
 
 #. Key:	A59547D94C2E8733CA14998734EBC002
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMWantHuman.Default__DMWantHuman_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMWantHuman.Default__DMWantHuman_C.SessionData.Lines(0).Lines
 msgctxt ",A59547D94C2E8733CA14998734EBC002"
 msgid "Haha! You joke human, my genitals are too big for you."
-msgstr ""
+msgstr "哈哈!你开玩笑，人类。我的生殖器对你来说太大了。"
 
 #. Key:	A5B9250C4C49694C624437927A399459
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeHaveKeystone1.Default__BeeHaveKeystone1_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/QueenBee/Default/BeeHaveKeystone1.Default__BeeHaveKeystone1_C.SessionData.Lines(2).Lines
 msgctxt ",A5B9250C4C49694C624437927A399459"
 msgid "Ohhh! Ahhh... that was a good one."
-msgstr ""
+msgstr "哦!啊…真是个好家伙！"
 
 #. Key:	A5C9D438443FEDCB4CF41985385B02E1
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiStuck.Default__FesssiStuck_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiStuck.Default__FesssiStuck_C.SessionData.Lines(4).Lines
 msgctxt ",A5C9D438443FEDCB4CF41985385B02E1"
 msgid "Such is how I learned of my buxom genetics, few blessed ones possess the trait and it is highly coveted."
-msgstr ""
+msgstr "我就是这样了解到我丰满的基因，很少有幸运的人拥有这种特性，这是非常令人垂涎的。"
 
 #. Key:	A6D19C3141AF406B6318CA8CB0A72613
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R02.Default__FaleneDefault01_R02_C.SessionData.Lines(0).Lines
@@ -8929,7 +8931,7 @@ msgstr "就是像我一样的！"
 #: /Game/Dialogue/Mirru/Default/MirruGreeting01.Default__MirruGreeting01_C.SessionData.Lines(1).Lines
 msgctxt ",A6DD5AA2419F165755885E8ED44BB09B"
 msgid "You are lucky, for today you have crossed paths with the Kraken princess of Formuria."
-msgstr "你很幸运，站在今天你要路过的这地方的，可是弗玛里亚的海妖公主。"
+msgstr "你很幸运，今天你遇到了深海族的克拉肯公主。。"
 
 #. Key:	A6EE239344DA6CC08AFE6E8689A1996F
 #. SourceLocation:	/Game/Dialogue/Neela/SexScenes/NeelaSnakeCuddleF.Default__NeelaSnakeCuddleF_C.SessionData.Lines(1).Lines
@@ -8950,7 +8952,7 @@ msgstr "你知道的，@WORLD_NAME@处处遍布我的脚印……滑痕，如果
 #: /Game/Dialogue/Blossom/Default/BlossomDefault_R03_RL.Default__BlossomDefault_R03_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",A709A6A94647E3F1218D6BB7BF74686D"
 msgid "Oh no not again..."
-msgstr ""
+msgstr "哦，哦不，又来……"
 
 #. Key:	A7310E5A43F60121BD9352B96FBB8369
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_RL.Default__RomyDefault01_RL_C.ResponseData(3).ResponseData.BreederPrompt
@@ -8964,14 +8966,14 @@ msgstr "你是怎么上来的？"
 #: /Game/Dialogue/QueenBee/Default/BeeUhNo.Default__BeeUhNo_C.SessionData.Lines(0).Lines
 msgctxt ",A77C67204806B8B31933BD9C7A4C5C54"
 msgid "Such... ahhh... deviance..."
-msgstr ""
+msgstr "这样……啊……有点奇怪……"
 
 #. Key:	A794490B471FFA8A958C3BA3B3BFDB9C
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchDefault01_RL.Default__MonarchDefault01_RL_C.ResponseData(3).ResponseData.BreederPrompt
 #: /Game/Dialogue/Monarch/Default/MonarchDefault01_RL.Default__MonarchDefault01_RL_C.ResponseData(3).ResponseData.BreederPrompt
 msgctxt ",A794490B471FFA8A958C3BA3B3BFDB9C"
 msgid "How adorable, may I have the keystone now?"
-msgstr ""
+msgstr "多么令人讨喜呀，我现在可以拿钥石了吗？"
 
 #. Key:	A7C8404E4B6C68006478148076380602
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R01.Default__FaleneDefault01_R01_C.SessionData.Lines(14).Lines
@@ -8985,28 +8987,28 @@ msgstr "我的猜想是，当一方是人类的时候，魔弗灵的一方的基
 #: /Game/Dialogue/Monarch/Default/MonarchTaskFulfilled.Default__MonarchTaskFulfilled_C.SessionData.Lines(1).Lines
 msgctxt ",A7E400D84D8F2911F46A3BA5FBA020A8"
 msgid "My nectar collection has grown considerably, and the wild ones around here can't keep up."
-msgstr ""
+msgstr "我收集的了太多花蜜了，以至于这里的野生花蜜都来不及分泌。"
 
 #. Key:	A7F13B9A43B11BD74FA2CB95A0F30AC2
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleTittyPony.Default__KybeleTittyPony_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/Kybele/Default/KybeleTittyPony.Default__KybeleTittyPony_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",A7F13B9A43B11BD74FA2CB95A0F30AC2"
 msgid "It's been sometime since I have released, so this is going to get messy."
-msgstr ""
+msgstr "我已经有一段时间没有释放了，所以我准备粗暴点哟"
 
 #. Key:	A7F62643438C0E70840CB3BDB7695B68
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleHaveKeystone2.Default__KybeleHaveKeystone2_C.SessionData.Message
 #: /Game/Dialogue/Kybele/Default/KybeleHaveKeystone2.Default__KybeleHaveKeystone2_C.SessionData.Message
 msgctxt ",A7F62643438C0E70840CB3BDB7695B68"
 msgid "Kybele is satisfied."
-msgstr ""
+msgstr "凯布莉满足了。"
 
 #. Key:	A8125055480BB34E28E96EB2CD3017F0
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiHowLong.Default__FesssiHowLong_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiHowLong.Default__FesssiHowLong_C.SessionData.Lines(3).Lines
 msgctxt ",A8125055480BB34E28E96EB2CD3017F0"
 msgid "They liked it and kept coming back for more. I gave many blow jobs and tasted cum from all over the world, it was great. Hiss!"
-msgstr ""
+msgstr "他们喜欢这么做，而且不断回来索取更多。我做了很多的口交也尝了全世界的射精，感觉好极了。嘶嘶！"
 
 #. Key:	A83161F4465E00C6CE9D718D3E76EDC6
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_RL.Default__FaleneDefault01_RL_C.ResponseData(6).ResponseData.BreederPrompt
@@ -9034,21 +9036,21 @@ msgstr "跟我讲讲印记精灵。"
 #: /Game/Dialogue/OrcChief/Default/OrcGreeting01.Default__OrcGreeting01_C.SessionData.Lines(1).Lines
 msgctxt ",A8F87DE746E7EF4E3350AA9C662E1BF0"
 msgid "You come to fix gate yes? Stupid elves broke it from their side."
-msgstr ""
+msgstr "你来修大门的恩？愚蠢的精灵从他们那侧打坏了它"
 
 #. Key:	A90E87E3497D9E41C08BE1AB25DF9AEE
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_SexPositions.Default__EmissaryDefault01_SexPositions_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_SexPositions.Default__EmissaryDefault01_SexPositions_C.SessionData.Lines(0).Lines
 msgctxt ",A90E87E3497D9E41C08BE1AB25DF9AEE"
 msgid "If thou must indulge your desires, seek the Enlightened One in Sultry Plateau."
-msgstr ""
+msgstr "如果你一定要放纵自己的欲望，那就在潮热高原上寻求开悟之人吧。"
 
 #. Key:	A913B249494A32A6AF263BAE0962E781
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeDefault01.Default__MegaSlimeDefault01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeDefault01.Default__MegaSlimeDefault01_C.SessionData.Lines(0).Lines
 msgctxt ",A913B249494A32A6AF263BAE0962E781"
 msgid "Slime slime slime... I can play with my slime all day!"
-msgstr ""
+msgstr "史莱姆，史莱姆，史莱姆……我可以整天都玩我的粘液都不觉得无聊！"
 
 #. Key:	A91571364DFC6A4FA3772D9FCBDB52AA
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMYourChildren.Default__DMYourChildren_C.SessionData.LinesToFemale(1).LinesToFemale
@@ -9062,28 +9064,28 @@ msgstr ""
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_Forgot_RL.Default__ParvatiDefault01_Forgot_RL_C.ResponseData(5).ResponseData.BreederPrompt
 msgctxt ",A91A80914B126F3C3F262D93E88AEA71"
 msgid "Missionary!"
-msgstr ""
+msgstr "传教士体位"
 
 #. Key:	A926E381450A057D1E6C1598ABA5B917
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_RL.Default__CamillaDefault01_RL_C.ResponseData(7).ResponseData.BreederPrompt
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_RL.Default__CamillaDefault01_RL_C.ResponseData(7).ResponseData.BreederPrompt
 msgctxt ",A926E381450A057D1E6C1598ABA5B917"
 msgid "About that dungeon over there..."
-msgstr ""
+msgstr "关于那个地牢"
 
 #. Key:	A931FB674A22AA9E31C00B9F0762AF5C
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleDefault01_RL.Default__KybeleDefault01_RL_C.ResponseData(5).ResponseData.BreederPrompt
 #: /Game/Dialogue/Kybele/Default/KybeleDefault01_RL.Default__KybeleDefault01_RL_C.ResponseData(5).ResponseData.BreederPrompt
 msgctxt ",A931FB674A22AA9E31C00B9F0762AF5C"
 msgid "Too much information... now, the keystone."
-msgstr ""
+msgstr "太多信息了……好吧，现在，给我你的钥石"
 
 #. Key:	A95B76C9415993E5F52ECDA4492EBE73
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiDefault03_RL_T.Default__FesssiDefault03_RL_T_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/Fesssi/Default/FesssiDefault03_RL_T.Default__FesssiDefault03_RL_T_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",A95B76C9415993E5F52ECDA4492EBE73"
 msgid "How long have you been stuck?"
-msgstr ""
+msgstr "你卡在这里多久了?"
 
 #. Key:	A97AEF8E47499B2AEB627CAE711C36BC
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDefault01_Meow_StartSplinters.Default__CassieDefault01_Meow_StartSplinters_C.SessionData.Lines(0).Lines
@@ -9104,63 +9106,63 @@ msgstr "哇！这怎么可能!"
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02.Default__FernDefault02_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",A9B242A6410BF5830F30419F32801AC2"
 msgid "Look at my beautiful flower, it bloomed! Oh my did it feel weird..."
-msgstr ""
+msgstr "快看看我美丽的花，它开放了!哦，我的天，是不是感觉怪怪的……"
 
 #. Key:	A9DC970946A02BBA89824685FB14ED6A
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeDefault01.Default__BeeDefault01_C.SessionData.LinesToFemale(3).LinesToFemale
 #: /Game/Dialogue/QueenBee/Default/BeeDefault01.Default__BeeDefault01_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",A9DC970946A02BBA89824685FB14ED6A"
 msgid "If I wiggle it the right way, it w-w-will distract any potential... mates."
-msgstr ""
+msgstr "如果我用正当的方法摇它们，它会分散任何潜在的注意力。。。亲爱的。"
 
 #. Key:	AA08081E4A0AF7A81D4B99B1527E6970
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(14).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(14).Lines
 msgctxt ",AA08081E4A0AF7A81D4B99B1527E6970"
 msgid "The demons took advantage of this and started using them as breeding toys."
-msgstr ""
+msgstr "恶魔们利用了这一点，开始把它们当作繁殖的玩具"
 
 #. Key:	AA14311148FE8C6A89D0DE953790D7E7
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcGreeting01.Default__OrcGreeting01_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcGreeting01.Default__OrcGreeting01_C.SessionData.Lines(4).Lines
 msgctxt ",AA14311148FE8C6A89D0DE953790D7E7"
 msgid "Human fix gate now!"
-msgstr ""
+msgstr "人类 修门，立刻！"
 
 #. Key:	AA16BE3B4732F407329ED6B450557C71
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyGreeting01.Default__RomyGreeting01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Romy/Default/RomyGreeting01.Default__RomyGreeting01_C.SessionData.Lines(0).Lines
 msgctxt ",AA16BE3B4732F407329ED6B450557C71"
 msgid "A strange song approaches me, a tune not heard in this land."
-msgstr "一曲奇怪的曲调接近了我，这片土地上从没有听过一种曲调。"
+msgstr "一首陌生的歌飘了过来，这片大陆上从未听到过这样的曲调。"
 
 #. Key:	AA18E8094B0BEABB8C6A948FC36B6552
 #. SourceLocation:	/Game/Dialogue/Yasmine/Default/YasmineHadSex01.Default__YasmineHadSex01_C.SessionData.LinesGrungy(0).LinesGrungy
 #: /Game/Dialogue/Yasmine/Default/YasmineHadSex01.Default__YasmineHadSex01_C.SessionData.LinesGrungy(0).LinesGrungy
 msgctxt ",AA18E8094B0BEABB8C6A948FC36B6552"
 msgid "Oh you dirty dirty human... what have you done to yourself?"
-msgstr ""
+msgstr "噢，你这脏兮兮的人类……你对你自己做了什么？"
 
 #. Key:	AA19D8F246FE5FAD5F7E9D8BEEDF10E3
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeHadSex01.Default__MegaSlimeHadSex01_C.SessionData.LinesToFemale(3).LinesToFemale
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeHadSex01.Default__MegaSlimeHadSex01_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",AA19D8F246FE5FAD5F7E9D8BEEDF10E3"
 msgid "You should stay down here and play with me all day, we can be friends forever!"
-msgstr ""
+msgstr "你应该呆在圣殿下面和我玩一整天，我们可以做永远的朋友!"
 
 #. Key:	AA3F14D64D5670190F05DD83A37D1AC9
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_RL_F.Default__FernDefault02_RL_F_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02_RL_F.Default__FernDefault02_RL_F_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",AA3F14D64D5670190F05DD83A37D1AC9"
 msgid "You've changed!"
-msgstr ""
+msgstr "你变了！"
 
 #. Key:	AA4B233A44217B671C811FA495E456B5
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadHaveKeystone.Default__DryadHaveKeystone_C.SessionData.Lines(6).Lines
 #: /Game/Dialogue/Autumn/Default/DryadHaveKeystone.Default__DryadHaveKeystone_C.SessionData.Lines(6).Lines
 msgctxt ",AA4B233A44217B671C811FA495E456B5"
 msgid "She can pollinate me all day, and together we will make amazing fruit."
-msgstr ""
+msgstr "她可以整天给我授粉，然后我们一起就能结出神奇的果实。"
 
 #. Key:	AAD8CEA34AE6DE13A8683089046598D3
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R02.Default__FaleneDefault01_R02_C.SessionData.Lines(6).Lines
@@ -9174,21 +9176,21 @@ msgstr "反正你也做不到，如果你试图给我们套上项圈我们就会
 #: /Game/World/Overworld.Overworld:PersistentLevel.EM_HedonDungeonSwitch.ActivateMessage
 msgctxt ",AB0597744358BD82828774A65E812AEE"
 msgid "Pull Lever"
-msgstr ""
+msgstr "拉动滑杆"
 
 #. Key:	AB0F23814A695DE61DBE5DB8FFDFC3EA
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcFixOwnGate.Default__OrcFixOwnGate_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/OrcChief/Default/OrcFixOwnGate.Default__OrcFixOwnGate_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",AB0F23814A695DE61DBE5DB8FFDFC3EA"
 msgid "No one says no to chieftain!"
-msgstr ""
+msgstr "没有人可以对酋长说不！"
 
 #. Key:	AB33AE4E444B3C498B0DFF9C8B60192F
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.CBGate_Crag.PlaceMessage
 #: /Game/World/Overworld.Overworld:PersistentLevel.CBGate_Crag.PlaceMessage
 msgctxt ",AB33AE4E444B3C498B0DFF9C8B60192F"
 msgid "Moaning Crag is now accessible."
-msgstr ""
+msgstr "现在可以访问娇喘峭壁了"
 
 #. Key:	AB9D2C374B19A9E1B3E16E8EF742C9C8
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01.Default__EmissaryDefault01_C.SessionData.Lines(1).Lines
@@ -9230,28 +9232,28 @@ msgstr "*舔舐* *亲*"
 #: /Game/Dialogue/OrcChief/Default/OrcTribeSucks.Default__OrcTribeSucks_C.SessionData.Lines(3).Lines
 msgctxt ",AC0651B441F4DE497F64ABAC64E703E2"
 msgid "Elves are soft and easy, they like making offspring with us."
-msgstr ""
+msgstr "精灵们很温柔也很简单，他们喜欢与我们孕育后代。"
 
 #. Key:	AC30709F43155DB485B91FA519412629
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleTittyPony_T.Default__KybeleTittyPony_T_C.SessionData.LinesToMale(0).LinesToMale
 #: /Game/Dialogue/Kybele/Default/KybeleTittyPony_T.Default__KybeleTittyPony_T_C.SessionData.LinesToMale(0).LinesToMale
 msgctxt ",AC30709F43155DB485B91FA519412629"
 msgid "That's it human, you have annoyed me long enough. Get against that rock and prepare to be smashed."
-msgstr ""
+msgstr "够了人类！你烦我够久了。靠在那块石头上准备被碾碎吧。"
 
 #. Key:	AC4DD54E4585ECFF9E20A9806DEDCEE4
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadGreeting01.Default__DryadGreeting01_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Autumn/Default/DryadGreeting01.Default__DryadGreeting01_C.SessionData.Lines(5).Lines
 msgctxt ",AC4DD54E4585ECFF9E20A9806DEDCEE4"
 msgid "My apologies human, I was lost in thought. I'm always busy making fruit for the cows."
-msgstr ""
+msgstr "对不起，人类，我陷入了沉思。我总是忙着给奶牛们种水果"
 
 #. Key:	ACB6D0AB4FEF709BE8976DAF20A467D6
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaGreeting01.Default__CamillaGreeting01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaGreeting01.Default__CamillaGreeting01_C.SessionData.Lines(0).Lines
 msgctxt ",ACB6D0AB4FEF709BE8976DAF20A467D6"
 msgid "That look on your face. All you see is a green midget!"
-msgstr "看看你脸上的表情，写满了“我看见了一个绿色的侏儒”！"
+msgstr "你该你脸上的表情，写满了“我看见了一个绿色的侏儒”！"
 
 #. Key:	ACD1C69F4B52BCF56888D3ABD4DD4BC6
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R01.Default__FaleneDefault01_R01_C.SessionData.Lines(3).Lines
@@ -9265,21 +9267,21 @@ msgstr "然而，我们的精子和卵子才是最为\"奇异\"之处。"
 #: /Game/Dialogue/Cassie/Default/CassieGreeting01.Default__CassieGreeting01_C.SessionData.Lines(1).Lines
 msgctxt ",AD1829A4465DB79DEB4829B81F4E7A03"
 msgid "Meow! That's a fine piece o' property ya got down there..."
-msgstr "喵呜！你那里可真是有些好东西而且还…有条好枪啊…"
+msgstr "喵呜！你那里可真是有^有条好枪啊…^"
 
 #. Key:	AD224A514AC35938B00457BC8B2C7422
 #. SourceLocation:	/Game/Dialogue/Blossom/Default/BlossomDefault01_R02.Default__BlossomDefault01_R02_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Blossom/Default/BlossomDefault01_R02.Default__BlossomDefault01_R02_C.SessionData.Lines(2).Lines
 msgctxt ",AD224A514AC35938B00457BC8B2C7422"
 msgid "Blossom needsss fluidsss!"
-msgstr ""
+msgstr "花花 需要嘶嘶……体液！"
 
 #. Key:	AD478B234D74F4166BEDE6A5C70593F6
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleCentaur.Default__KybeleCentaur_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Kybele/Default/KybeleCentaur.Default__KybeleCentaur_C.SessionData.Lines(3).Lines
 msgctxt ",AD478B234D74F4166BEDE6A5C70593F6"
 msgid "And believe me human... it has been awhile."
-msgstr ""
+msgstr "相信我，人类…已经有一段时间了。"
 
 #. Key:	AD4B293B4D8F1432446C92924F59456E
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(22).LinesToFemale
@@ -9293,21 +9295,21 @@ msgstr "你只能抓野生的魔弗灵，而他们的智力几乎同等一般动
 #: /Game/Dialogue/OrcChief/Default/OrcBrashDumb.Default__OrcBrashDumb_C.SessionData.Lines(2).Lines
 msgctxt ",AD729AD145061E3B808691AE861F3641"
 msgid "We fight and wrestle for the hell of it!"
-msgstr ""
+msgstr "我们为了那该死的东西而打架和摔跤!"
 
 #. Key:	AD8370D449B2058385D511BCC7D8B193
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadDefault01_RL.Default__DryadDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/Autumn/Default/DryadDefault01_RL.Default__DryadDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",AD8370D449B2058385D511BCC7D8B193"
 msgid "Bosom cherries?"
-msgstr ""
+msgstr "不来些乳房樱桃尝尝吗？
 
 #. Key:	ADE570A545B3D82C930945ACF5A2C3CE
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowTaskFulfilled.Default__WidowTaskFulfilled_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Widow/Default/WidowTaskFulfilled.Default__WidowTaskFulfilled_C.SessionData.Lines(1).Lines
 msgctxt ",ADE570A545B3D82C930945ACF5A2C3CE"
 msgid "Human, you have exceeded my expectations and pleased me greatly."
-msgstr ""
+msgstr "人类，你超出了我对你的期待，让我非常高兴。"
 
 #. Key:	ADECACEF405669C45FAC77AB2A48E637
 #. SourceLocation:	/Game/Dialogue/Emissary/SexScenes/EmissaryAngelGroinLove.Default__EmissaryAngelGroinLove_C.SessionData.LinesToFemale(1).LinesToFemale
@@ -9321,14 +9323,14 @@ msgstr "吾的蜜唇神圣又充满魔力，愿汝的舌头因其存在而得以
 #: /Game/Dialogue/Fesssi/Default/FesssiGreeting01.Default__FesssiGreeting01_C.SessionData.Lines(0).Lines
 msgctxt ",ADECFCE04009A18A9FCD358FEAD730A5"
 msgid "Hiss! Oh sexy human, come closer... I promise I won't bite."
-msgstr ""
+msgstr "嘶！哦可爱的人类，靠近点……我保证我不会咬你。"
 
 #. Key:	ADF357A1447CC164A3CF54A274E1EECF
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02.Default__FernDefault02_C.SessionData.LinesToFemale(2).LinesToFemale
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02.Default__FernDefault02_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",ADF357A1447CC164A3CF54A274E1EECF"
 msgid "I am a growing Alraune, perhaps you have fluids to spare?"
-msgstr ""
+msgstr "我是一颗正在成长的曼陀罗，也许您能分我一点体液？"
 
 #. Key:	AE10903F4F5306C2AF3432A0D40AD89F
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R02.Default__FaleneDefault01_R02_C.SessionData.Lines(14).Lines
@@ -9349,7 +9351,7 @@ msgstr "一个充满欲望与冒险的世界在等着你！"
 #: /Game/Dialogue/DragonMatriarch/Default/DMYourChildren.Default__DMYourChildren_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",AE940C0E4203F3605E98088D0827EA0B"
 msgid "Believe me human, I have sired many offspring."
-msgstr ""
+msgstr "相信我，人类，我有很多后代。"
 
 #. Key:	AE9DC6E246625CE553B669ADBD1EB570
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDefault01_Meow_RL_F.Default__CassieDefault01_Meow_RL_F_C.ResponseData(0).ResponseData.BreederPrompt
@@ -9363,35 +9365,35 @@ msgstr "请射在我的小穴里面！"
 #: /Game/Ranch/Upgrades/TitanCave.Default__TitanCave_C.Upgrade.Description
 msgctxt ",AF04F5A4417DBB7D20BC64B4B66C34DD"
 msgid "This allows you to catch and store all variants of Titan."
-msgstr ""
+msgstr "这将允许你捕获并饲养你的泰坦族人。"
 
 #. Key:	AF4962AA4EF7962370DC5D869BFFA992
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R01.Default__CamillaDefault01_R01_C.SessionData.Lines(8).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R01.Default__CamillaDefault01_R01_C.SessionData.Lines(8).Lines
 msgctxt ",AF4962AA4EF7962370DC5D869BFFA992"
 msgid "Don't give me that look!!"
-msgstr "别这样看着我！！"
+msgstr "别用那种脸色看我！！"
 
 #. Key:	AF56D3A1427EFDD2D086F09E5534EC68
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03_R01.Default__FernDefault03_R01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03_R01.Default__FernDefault03_R01_C.SessionData.Lines(0).Lines
 msgctxt ",AF56D3A1427EFDD2D086F09E5534EC68"
 msgid "You are the lord of this soil--or owner of Homestead in the common tongue."
-msgstr ""
+msgstr "您是这片土地的领主，换句话说您就是这片家园的主人"
 
 #. Key:	AF5E23FC4ED6AD9A92E6E98CE8F2080F
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeSad_RL.Default__MegaSlimeSad_RL_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeSad_RL.Default__MegaSlimeSad_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",AF5E23FC4ED6AD9A92E6E98CE8F2080F"
 msgid "Uh... are you alright?"
-msgstr ""
+msgstr "呃，你还好吗？"
 
 #. Key:	AF6126694453EEB0A7AA7787649EC605
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFuta(2).LinesToFuta
 #: /Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",AF6126694453EEB0A7AA7787649EC605"
 msgid "Perhaps you would like to stick that dick in my sparkly elf pussy? Ahhh I would love that..."
-msgstr ""
+msgstr "也许你想把你的鸡巴插进我闪闪发光的精灵的阴道?啊~我很乐意…"
 
 #. Key:	AFBF754C422E5E00DF8BB7A37B956DFB
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(10 - Value).TraitIcons.HelpText
@@ -9405,21 +9407,21 @@ msgstr "发散性：后代在出生时有几率获得一个随机特性"
 #: /Game/Dialogue/DragonMatriarch/Default/DMYourChildren.Default__DMYourChildren_C.SessionData.LinesToMale(1).LinesToMale
 msgctxt ",AFF40FDB49E0435621047691DD80B3DC"
 msgid "Who knows which of them are mine, and I don't care. This matriarch will continue reproducing until the end of time."
-msgstr ""
+msgstr "谁知道谁是我的，我不在乎。女族长将继续繁衍直到时间结束。"
 
 #. Key:	B00960644B62BA0C4CBBCD83C25D5855
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcHadSex01.Default__OrcHadSex01_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/OrcChief/Default/OrcHadSex01.Default__OrcHadSex01_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",B00960644B62BA0C4CBBCD83C25D5855"
 msgid "Ahhh! *snarl*"
-msgstr ""
+msgstr "啊！*咆哮*"
 
 #. Key:	B0133AC44E841D002819DB9289664369
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMAboutDragons.Default__DMAboutDragons_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMAboutDragons.Default__DMAboutDragons_C.SessionData.Lines(2).Lines
 msgctxt ",B0133AC44E841D002819DB9289664369"
 msgid "However, they are mere simpletons that serve as my breeding stock!"
-msgstr ""
+msgstr "然而，他们只是充当我的配种对象的蠢货!"
 
 #. Key:	B071E1E04B9EA4D9C227C2935955161A
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R03.Default__FaleneDefault01_R03_C.SessionData.Lines(0).Lines
@@ -9440,28 +9442,28 @@ msgstr "趋近人型"
 #: /Game/Dialogue/QueenBee/Default/BeeHaveKeystone1.Default__BeeHaveKeystone1_C.SessionData.Lines(1).Lines
 msgctxt ",B0D63ADB45CCFD884D1581A5725EA8BF"
 msgid "Should you manage to do it, the keystone will be granted to you."
-msgstr ""
+msgstr "如果你能做到的话，钥石就会送给你。"
 
 #. Key:	B0F5CCC741FEDFC39587579F638D56DC
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeMasturbate.Default__BeeMasturbate_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/QueenBee/Default/BeeMasturbate.Default__BeeMasturbate_C.SessionData.Lines(3).Lines
 msgctxt ",B0F5CCC741FEDFC39587579F638D56DC"
 msgid "Asking one of the @MONSTER_RACE@ if they masturbate all day is the most redundant question I've heard."
-msgstr ""
+msgstr "问其中一个@MONSTER_RACE@”，他们是不是整天手淫这是我我听过的最多余的问题。"
 
 #. Key:	B100F65E4495A60CD1761FA5FA43CBEE
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaHadSex02.Default__CamillaHadSex02_C.SessionData.LinesToMale(2).LinesToMale
 #: /Game/Dialogue/Camilla/Default/CamillaHadSex02.Default__CamillaHadSex02_C.SessionData.LinesToMale(2).LinesToMale
 msgctxt ",B100F65E4495A60CD1761FA5FA43CBEE"
 msgid "Ohhh but I did!"
-msgstr ""
+msgstr "噢!但是我做到了！"
 
 #. Key:	B11026CD462D3D9C5256F4A490A45911
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R07.Default__FaleneDefault01_R07_C.SessionData.LinesToFuta(1).LinesToFuta
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R07.Default__FaleneDefault01_R07_C.SessionData.LinesToFuta(1).LinesToFuta
 msgctxt ",B11026CD462D3D9C5256F4A490A45911"
 msgid "Errrr, I can't stand it anymore, I'm going to milk you dry! I have never tasted human cum before!"
-msgstr "呃，我忍受不了了，我要把你榨干，我还从来没有尝过人类的味道！"
+msgstr "呃，我忍受不了了，我要把你榨干，我还从来没有尝过人类精液的味道！"
 
 #. Key:	B12A342547F0295A52457D814E45C485
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_AreYouBlessed.Default__EmissaryDefault01_AreYouBlessed_C.SessionData.Lines(0).Lines
@@ -9475,35 +9477,35 @@ msgstr "当然了，@BREEDER_NAME@."
 #: /Game/Dialogue/DragonMatriarch/Default/DMDefault_RL2.Default__DMDefault_RL2_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",B1435DF7419D2F4948DD9B9EFF8E628E"
 msgid "Are all of these wild dragons your children?"
-msgstr ""
+msgstr "这些野生的龙族都是你的孩子吗?"
 
 #. Key:	B146211A43E4F159EC3A0C85790314DD
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimePlay1.Default__MegaSlimePlay1_C.SessionData.LinesToFuta(5).LinesToFuta
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePlay1.Default__MegaSlimePlay1_C.SessionData.LinesToFuta(5).LinesToFuta
 msgctxt ",B146211A43E4F159EC3A0C85790314DD"
 msgid "Well what are you waiting for? Come on in!"
-msgstr ""
+msgstr "那么你还在等什么？快进来吧！"
 
 #. Key:	B16A16AD4DAD11735CC38DBC5E9237B1
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleTittyPony.Default__KybeleTittyPony_C.SessionData.LinesToFuta(1).LinesToFuta
 #: /Game/Dialogue/Kybele/Default/KybeleTittyPony.Default__KybeleTittyPony_C.SessionData.LinesToFuta(1).LinesToFuta
 msgctxt ",B16A16AD4DAD11735CC38DBC5E9237B1"
 msgid "It's been sometime since I have been mouted, so I might get rough!"
-msgstr ""
+msgstr "我已经有一段时间没活动活动了，我可能会变得粗暴的哟"
 
 #. Key:	B17C429C4AE53B8CA98F5E8166D598D2
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadCherryHelp.Default__DryadCherryHelp_C.SessionData.LinesToFemale(3).LinesToFemale
 #: /Game/Dialogue/Autumn/Default/DryadCherryHelp.Default__DryadCherryHelp_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",B17C429C4AE53B8CA98F5E8166D598D2"
 msgid "Come closer human..."
-msgstr ""
+msgstr "靠近点，人类"
 
 #. Key:	B18F6EA040A16FCFD95EB3894A067B79
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeAboutOrb.Default__MegaSlimeAboutOrb_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeAboutOrb.Default__MegaSlimeAboutOrb_C.SessionData.Lines(5).Lines
 msgctxt ",B18F6EA040A16FCFD95EB3894A067B79"
 msgid "She speaks to me! Such wonderful stories about her adventures rolling around the world."
-msgstr ""
+msgstr "她跟我说了！说了很多有趣的，她周游世界的冒险与见闻。"
 
 #. Key:	B1A4C4984540058620CA09A3FC603DBE
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeDefault01_Accent.Default__AmberMaeDefault01_Accent_C.SessionData.Lines(1).Lines
@@ -9531,7 +9533,7 @@ msgstr "嗷~~俺真想把尼埋进俺的大咪咪压榨到尼爽翻天！"
 #: /Game/Dialogue/Leylanna/Default/LeylannaHadSex01.Default__LeylannaHadSex01_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",B1E706104468BBBC8C481498B5352B8D"
 msgid "When we please each other, the Goddess shares in that pleasure."
-msgstr ""
+msgstr "当我们互相取悦时，女神也会体会到我们分享的这种快乐。"
 
 #. Key:	B20F5D9040267E77436A9B94B5F68150
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(30 - Value).TraitIcons.DisplayName
@@ -9545,14 +9547,14 @@ msgstr "花哨打扮"
 #: /Game/Dialogue/Petra/Default/PetraDefault01.Default__PetraDefault01_C.SessionData.Lines(2).Lines
 msgctxt ",B22A0E0B459BF554FEEAB7920A478BAF"
 msgid "In the meantime... I've been a very naughty bunny. Perhaps you'd like to give me a spanking??"
-msgstr ""
+msgstr "同时……我也是一只非常淘气的小兔子。你不想要拍一拍我的小屁屁吗？？"
 
 #. Key:	B22CBCF74EE8D6771B1E7987993911F6
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiCave.Default__FesssiCave_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiCave.Default__FesssiCave_C.SessionData.Lines(0).Lines
 msgctxt ",B22CBCF74EE8D6771B1E7987993911F6"
 msgid "The cave leads to Amorous Hallows. Hiss!"
-msgstr ""
+msgstr "这个洞穴通向性欲圣地。嘶嘶!"
 
 #. Key:	B2323665415F7EE8A74204A9FD52D914
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(7).Lines
@@ -9566,21 +9568,21 @@ msgstr "尼可以把俺当成个鉴奶家。每个种族的奶都有它们独特
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_StartForgotten.Default__ParvatiDefault01_StartForgotten_C.SessionData.Lines(2).Lines
 msgctxt ",B235542C44D65B1D62C721A3C4CD289F"
 msgid "Pay close attention to my form, and learn you should."
-msgstr ""
+msgstr "请仔细观察我的动作，好好学着点。"
 
 #. Key:	B27218744AEBAD507E1037B620EC16DA
 #. SourceLocation:	/Game/Dialogue/Blossom/Default/BlossomDefault01_R03_R01.Default__BlossomDefault01_R03_R01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Blossom/Default/BlossomDefault01_R03_R01.Default__BlossomDefault01_R03_R01_C.SessionData.Lines(0).Lines
 msgctxt ",B27218744AEBAD507E1037B620EC16DA"
 msgid "Hiss! Blossom love you mastah!"
-msgstr ""
+msgstr "嘶，花花爱您，主银！"
 
 #. Key:	B27FC78147626E1ED81B86A06FCF68F9
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiWantAss.Default__FesssiWantAss_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiWantAss.Default__FesssiWantAss_C.SessionData.Lines(1).Lines
 msgctxt ",B27FC78147626E1ED81B86A06FCF68F9"
 msgid "My ass is the product of years of \"hard\" work."
-msgstr ""
+msgstr "我的屁股是岁月沉淀的产物，可重了."
 
 #. Key:	B2DF6AC642DDC3C552F43290DCBE4EA7
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFuta(1).LinesToFuta
@@ -9594,14 +9596,14 @@ msgstr "一个人类！一个超级可爱的人类……今天真是我的幸运
 #: /Game/Ranch/Upgrades/HarpyAviary.Default__HarpyAviary_C.Upgrade.DisplayName
 msgctxt ",B2E660614B8D73E10C0B2194E4C87529"
 msgid "Harpy Aviary"
-msgstr ""
+msgstr "哈比族鸟笼"
 
 #. Key:	B31209614A74AB1A0C2C14AD375B0165
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeHadSex01.Default__BeeHadSex01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/QueenBee/Default/BeeHadSex01.Default__BeeHadSex01_C.SessionData.Lines(0).Lines
 msgctxt ",B31209614A74AB1A0C2C14AD375B0165"
 msgid "I trust my honey was exquisite. Consider yourself honored to have tasted the thick sweet product of my teats."
-msgstr ""
+msgstr "我相信我的蜂蜜很微妙。你很荣幸能尝到我乳房的甜品。"
 
 #. Key:	B34ADF5D4AB31A7DC61000950C44B54F
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(1).LinesToMale
@@ -9629,7 +9631,7 @@ msgstr "高价值"
 #: /Game/Dialogue/Romy/Default/RomyGreeting01.Default__RomyGreeting01_C.SessionData.Lines(2).Lines
 msgctxt ",B3B231554333647A7518C9A44578C0B1"
 msgid "I hear your eyes working your way down my voluptuous form, your heart beats faster."
-msgstr "我感受到你的眼睛在向我性感的下体看去，我能感受到你的心跳加快"
+msgstr "我感受到你的眼睛在向我性感的下体瞟去，我甚至都能感受到你的心跳加快了"
 
 #. Key:	B3B7244F401573EDDD24A0BB5011F55C
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_HowToSpiritForm_RL_T.Default__LeylannaDefault01_HowToSpiritForm_RL_T_C.ResponseData(2).ResponseData.BreederPrompt
@@ -9643,49 +9645,49 @@ msgstr "事情好像变得有些奇怪了……"
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R03.Default__FaleneDefault01_R03_C.SessionData.Lines(7).Lines
 msgctxt ",B3B9D4DE46AC98F7EC5432A2F06C92D6"
 msgid "Also, you will be making more cute little @MONSTER_RACE@ for me to \"play\" with!"
-msgstr "而且，你会生出更多可爱的小魔弗灵给我\"玩\"！"
+msgstr "而且，你会生出更多可爱的小魔弗灵陪我\"玩\"！"
 
 #. Key:	B40913204435868CB2B615986906CFE4
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleTaskFulfilled.Default__KybeleTaskFulfilled_C.SessionData.LinesToFuta(1).LinesToFuta
 #: /Game/Dialogue/Kybele/Default/KybeleTaskFulfilled.Default__KybeleTaskFulfilled_C.SessionData.LinesToFuta(1).LinesToFuta
 msgctxt ",B40913204435868CB2B615986906CFE4"
 msgid "I've taken advantage of that massive cock many times."
-msgstr ""
+msgstr "我已经品尝过那只大鸡鸡很多次了。"
 
 #. Key:	B40DA93F4D87A08B36AB2198B2D523AF
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiHadSex01.Default__ParvatiHadSex01_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Parvati/Default/ParvatiHadSex01.Default__ParvatiHadSex01_C.SessionData.Lines(2).Lines
 msgctxt ",B40DA93F4D87A08B36AB2198B2D523AF"
 msgid "We can learn the origins of the universe."
-msgstr ""
+msgstr "我们可以了解宇宙的起源。"
 
 #. Key:	B41CF0334A59DC837984179B995A16B2
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_FloatRhyme.Default__ParvatiDefault01_FloatRhyme_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_FloatRhyme.Default__ParvatiDefault01_FloatRhyme_C.SessionData.Lines(0).Lines
 msgctxt ",B41CF0334A59DC837984179B995A16B2"
 msgid "Such is how I uncovered the truth of non-duality."
-msgstr ""
+msgstr "这就是我如何揭示非二元性的真面目。"
 
 #. Key:	B48E37AC4977FA95BA4EB3B39018F087
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03.Default__FernDefault03_C.SessionData.LinesToFemale(3).LinesToFemale
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03.Default__FernDefault03_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",B48E37AC4977FA95BA4EB3B39018F087"
 msgid "My body longs for your delicious breast milk."
-msgstr ""
+msgstr "我的身体渴望您美味的乳汁。"
 
 #. Key:	B49B5FD64432ADC45593F3B4F50455B6
 #. SourceLocation:	/Game/Breeding/Positions/Waterfall.Default__Waterfall_C.SessionData.PositionName
 #: /Game/Breeding/Positions/Waterfall.Default__Waterfall_C.SessionData.PositionName
 msgctxt ",B49B5FD64432ADC45593F3B4F50455B6"
 msgid "Waterfall"
-msgstr ""
+msgstr "瀑布式"
 
 #. Key:	B4EE3075417C568D59F3C0AC4A5049A3
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_SexPositions.Default__FaleneDefault01_SexPositions_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_SexPositions.Default__FaleneDefault01_SexPositions_C.SessionData.Lines(0).Lines
 msgctxt ",B4EE3075417C568D59F3C0AC4A5049A3"
 msgid "I have heard legends of the Enlightened One somewhere in Sultry Plateau."
-msgstr ""
+msgstr "我听说在一位传奇的开悟之人在潮热高原的某处。"
 
 #. Key:	B4EFBB67424526E49554149C5ADDE508
 #. SourceLocation:	/Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToFuta(0).LinesToFuta
@@ -9699,56 +9701,56 @@ msgstr "哦，你的肉棒！终于进来了！"
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_EnlightenedOne.Default__NeelaDefault01_EnlightenedOne_C.SessionData.Lines(0).Lines
 msgctxt ",B5227FC24AE0F8318DF7DBAF9AC7553A"
 msgid "So you want to learn new sex positions I see..."
-msgstr ""
+msgstr "我知道你想学习新的体位……"
 
 #. Key:	B5A2F9CD41C677116ECB32818AB2D2D7
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcDefault01.Default__OrcDefault01_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcDefault01.Default__OrcDefault01_C.SessionData.Lines(2).Lines
 msgctxt ",B5A2F9CD41C677116ECB32818AB2D2D7"
 msgid "Take them to Homestead and make offspring."
-msgstr ""
+msgstr "把他们带到家园，繁衍后代。"
 
 #. Key:	B5AD6A9A40AB4528FFC0BCBCD051C66B
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowDefault01.Default__WidowDefault01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Widow/Default/WidowDefault01.Default__WidowDefault01_C.SessionData.Lines(1).Lines
 msgctxt ",B5AD6A9A40AB4528FFC0BCBCD051C66B"
 msgid "Ah little one... you are now mine. Don't be afraid, for I only wish to please."
-msgstr ""
+msgstr "啊，小家伙。。。你现在是我的了。别害怕，我只想在你身上找些乐子。"
 
 #. Key:	B5B8312540B0C71F1DDBCEADEF6C3E02
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(10).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(10).Lines
 msgctxt ",B5B8312540B0C71F1DDBCEADEF6C3E02"
 msgid "I meant what I said about ye between 'mai jugs. Mayhaps we can have a li'l fun in the future?"
-msgstr "俺是说，关于俺刚才那些要把尼按进俺大咪咪里的话…大概咱以后可以\"找找乐子\"？"
+msgstr "俺是说，俺刚才说俺要把尼按进俺的大咪咪里…大概咱以后可以\"找找乐子\"？"
 
 #. Key:	B5C876DA4DBA230757C412BE4612735C
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcHaveKeystone.Default__OrcHaveKeystone_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcHaveKeystone.Default__OrcHaveKeystone_C.SessionData.Lines(4).Lines
 msgctxt ",B5C876DA4DBA230757C412BE4612735C"
 msgid "Grrrr!!! A cow with some spunk, now get to it human!"
-msgstr ""
+msgstr "咕噜噜，真是一头有勇气的母牛，那么让我们开始吧！"
 
 #. Key:	B5E173FA45294C4DE256EF836668F092
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFemale(5).LinesToFemale
 #: /Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFemale(5).LinesToFemale
 msgctxt ",B5E173FA45294C4DE256EF836668F092"
 msgid "Both?"
-msgstr ""
+msgstr "都要？"
 
 #. Key:	B5F3B5B2436545B9AAC067B451FA7563
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchQueen.Default__MonarchQueen_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Monarch/Default/MonarchQueen.Default__MonarchQueen_C.SessionData.Lines(2).Lines
 msgctxt ",B5F3B5B2436545B9AAC067B451FA7563"
 msgid "Her beautiful breasts make so much honey, she has an army of bee daughters to milk her."
-msgstr ""
+msgstr "她美丽的双峰酿了那么多的蜜，以至于她有一整支蜜蜂女儿的族群来给她榨出来。"
 
 #. Key:	B5FEFBB64D1BFCA1A84984AD156AFD02
 #. SourceLocation:	/Game/Dialogue/Yasmine/Default/YasminePearls.Default__YasminePearls_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Yasmine/Default/YasminePearls.Default__YasminePearls_C.SessionData.Lines(2).Lines
 msgctxt ",B5FEFBB64D1BFCA1A84984AD156AFD02"
 msgid "What else should a clam do?"
-msgstr ""
+msgstr "蛤蜊还能做什么呢？"
 
 #. Key:	B601DE914360E4E4962B9BAE17334C67
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryRaiseTraitLvl_Decline.Default__EmissaryRaiseTraitLvl_Decline_C.SessionData.Lines(0).Lines
@@ -9762,21 +9764,21 @@ msgstr "多么令人怜爱的人啊…吾本以为如此低的标准很是合适
 #: /Game/Dialogue/Petra/Default/PetraPracticeMe.Default__PetraPracticeMe_C.SessionData.Lines(1).Lines
 msgctxt ",B628775D4659A3C72D73DAAB3B931832"
 msgid "Pawsmaati never said I couldn't practice with a human, and I've become quite horny while waiting here."
-msgstr ""
+msgstr "帕丝玛媞从没说过我不能和人类一起练习，所以我在这里一边忍耐着无尽的欲火，一边等着一个人类的出现。"
 
 #. Key:	B63337A041FFD99C138E44AB261A71CE
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.CBGate_Cove.PlaceMessage
 #: /Game/World/Overworld.Overworld:PersistentLevel.CBGate_Cove.PlaceMessage
 msgctxt ",B63337A041FFD99C138E44AB261A71CE"
 msgid "Cove of Rapture is now accessible."
-msgstr ""
+msgstr "现在可以访问狂喜海湾了。"
 
 #. Key:	B685468D40290FF6E84B0D812D2A7F2F
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaGreeting01.Default__CamillaGreeting01_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaGreeting01.Default__CamillaGreeting01_C.SessionData.Lines(2).Lines
 msgctxt ",B685468D40290FF6E84B0D812D2A7F2F"
 msgid "Everyone wants Falene. She's so beautiful, and no one cares about the short girthy lump in the corner!"
-msgstr "每个人都想要法莲娜。她是如此的美丽动人，当然也没有人会在意我这个待在角落里的矮肥圆！"
+msgstr "每个人都想要上法莲娜。她是如此的美丽动人，当然也没有人会在意我这个待在角落里的矮肥圆！"
 
 #. Key:	B69447294A19D4E4338E36BBB1C2DADE
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_HowToSpiritForm.Default__LeylannaDefault01_HowToSpiritForm_C.SessionData.LinesToFuta(2).LinesToFuta
@@ -9790,42 +9792,42 @@ msgstr "如果你还没有抓过扶她狐灵，去抓一只。然后回来找我
 #: /Game/Dialogue/Romy/Default/RomyDefault01_BatheAllDay.Default__RomyDefault01_BatheAllDay_C.SessionData.Lines(1).Lines
 msgctxt ",B69F20F0421426CBBF0D7FBE2E7C76D6"
 msgid "The townsfolk come here to relax and make love, it is beautiful."
-msgstr "市民们来这里休息做爱，这很是美妙。"
+msgstr "市民们来这里享受时光和做爱，这很是美妙的一件事。"
 
 #. Key:	B72B154840C9EFADCC67BE89C1C467AA
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadFlowers.Default__DryadFlowers_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Autumn/Default/DryadFlowers.Default__DryadFlowers_C.SessionData.Lines(3).Lines
 msgctxt ",B72B154840C9EFADCC67BE89C1C467AA"
 msgid "I can feel the roots of many cuminus flowers, but no ejaculum-phallis. Hmm..."
-msgstr ""
+msgstr "我能感觉到许多孜然花的根盘根错节，但没有射精的阴茎……怎么办呢~"
 
 #. Key:	B740BA7F4ADFB18E32DFE99606B483B3
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeDefault01_SuckJugs.Default__AmberMaeDefault01_SuckJugs_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeDefault01_SuckJugs.Default__AmberMaeDefault01_SuckJugs_C.SessionData.Lines(0).Lines
 msgctxt ",B740BA7F4ADFB18E32DFE99606B483B3"
 msgid "Bless me for say'n so, but I was wish'n you'd ask that!"
-msgstr "这么说真要命，不过俺正希望尼能要俺这么做。"
+msgstr "这么说真要命，不过俺正希望尼能这么问俺。"
 
 #. Key:	B792D83B44DC1E7BF9DAE08B4D4A3E70
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_UpHere.Default__RomyDefault01_UpHere_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Romy/Default/RomyDefault01_UpHere.Default__RomyDefault01_UpHere_C.SessionData.Lines(0).Lines
 msgctxt ",B792D83B44DC1E7BF9DAE08B4D4A3E70"
 msgid "The real question is: how did you get here human?"
-msgstr "问题应该这么问：人类，你是怎么上来的？"
+msgstr "问题应该这么问：人类，你是怎么过来的？"
 
 #. Key:	B79398FF462643C6AD3C78BBEBD9E244
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernBeeFlowers3.Default__FernBeeFlowers3_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Fern/DefaultP3/FernBeeFlowers3.Default__FernBeeFlowers3_C.SessionData.Lines(1).Lines
 msgctxt ",B79398FF462643C6AD3C78BBEBD9E244"
 msgid "Only a dryad would be able to do such a thing."
-msgstr ""
+msgstr "只有树妖才有能力做到那样伟大的事情。"
 
 #. Key:	B79CA71847A95B814D43088A9A29BF45
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadBossomCherries.Default__DryadBossomCherries_C.SessionData.Lines(8).Lines
 #: /Game/Dialogue/Autumn/Default/DryadBossomCherries.Default__DryadBossomCherries_C.SessionData.Lines(8).Lines
 msgctxt ",B79CA71847A95B814D43088A9A29BF45"
 msgid "Besides, when I make love with them it spares them from dealing with the Reaper, and my orgasm creates another bosom cherry."
-msgstr ""
+msgstr "况且，当我和她们做爱时，她们就不用再和死神打交道了，而我的潮吹又创造了一个乳房樱桃。"
 
 #. Key:	B79CB910400AA9573644BCA03D3D9F51
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R01.Default__FaleneDefault01_R01_C.SessionData.Lines(15).Lines
@@ -9839,14 +9841,14 @@ msgstr "我的……\"实验\"证明我们人类的一半来自于人类父母�
 #: /Game/Dialogue/Widow/Default/WidowKeystone.Default__WidowKeystone_C.SessionData.Lines(0).Lines
 msgctxt ",B7A48A8D48179006F728B3895940A90C"
 msgid "Ah the glowing rock trapped in my web."
-msgstr ""
+msgstr "啊，在我的网里闪着微光的小石头。"
 
 #. Key:	B7A8AD6E44A41AB54281548D1A882FFC
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaHadSex02.Default__CamillaHadSex02_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/Camilla/Default/CamillaHadSex02.Default__CamillaHadSex02_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",B7A8AD6E44A41AB54281548D1A882FFC"
 msgid "Wow human, you must have been desperate to give this nugget your love."
-msgstr ""
+msgstr "人类啊，你一定是不顾一切地想给这个小东西你的爱。"
 
 #. Key:	B7AB851641C9ABEE4A178B9DFFD50B0B
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(33 - Value).TraitIcons.DisplayName
@@ -9860,14 +9862,14 @@ msgstr "混血儿"
 #: /Game/Breeding/Positions/Lifted.Default__Lifted_C.SessionData.Description
 msgctxt ",B7ABB23A457CC2E34BB616933364E7F3"
 msgid "A larger giver uses its strength to lift the receiver while penetrating from behind."
-msgstr ""
+msgstr "一个较大的播种者用它的力量完全托起被恩赐者，同时后入。"
 
 #. Key:	B7C8EAFE428A554328A015A9F572AEDC
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaHadSex01.Default__LeylannaHadSex01_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/Leylanna/Default/LeylannaHadSex01.Default__LeylannaHadSex01_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",B7C8EAFE428A554328A015A9F572AEDC"
 msgid "Make love with me again @BREEDER_NAME@, let us writhe in pleasure before Her gaze."
-msgstr ""
+msgstr "再和我做爱吧，让我们在祂的注视下快乐地书写。"
 
 #. Key:	B7DDB984480E5280CB46B69238C0654E
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(25 - Value).TraitIcons.HelpText
@@ -9881,140 +9883,140 @@ msgstr "婴儿肥：该个体含有较多体脂"
 #: /Game/Dialogue/Monarch/Default/MonarchHaveKeystone.Default__MonarchHaveKeystone_C.SessionData.Lines(2).Lines
 msgctxt ",B7F0D9A14870E8556879B3A948639F2A"
 msgid "Collecting nectar as a delicate butterfly is difficult."
-msgstr ""
+msgstr "作为一个娇贵的蝴蝶，采蜜并不是那么的容易。"
 
 #. Key:	B8035279491515770BA6408AEE0EC908
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_Forgot.Default__ParvatiDefault01_Forgot_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_Forgot.Default__ParvatiDefault01_Forgot_C.SessionData.Lines(1).Lines
 msgctxt ",B8035279491515770BA6408AEE0EC908"
 msgid "Worry not of your forgetful mind."
-msgstr ""
+msgstr "不要担心你的健忘"
 
 #. Key:	B8242BCA4C426CBD3195A28D03A195C3
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimePlay1.Default__MegaSlimePlay1_C.SessionData.LinesToFemale(4).LinesToFemale
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePlay1.Default__MegaSlimePlay1_C.SessionData.LinesToFemale(4).LinesToFemale
 msgctxt ",B8242BCA4C426CBD3195A28D03A195C3"
 msgid "Well what are you waiting for? Come on in!"
-msgstr ""
+msgstr "那么你还在等什么呢？快进来吧！"
 
 #. Key:	B825E1564FCBA4D960D238AFD10804AC
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMMuchEnergy.Default__DMMuchEnergy_C.SessionData.LinesToFuta(3).LinesToFuta
 #: /Game/Dialogue/DragonMatriarch/Default/DMMuchEnergy.Default__DMMuchEnergy_C.SessionData.LinesToFuta(3).LinesToFuta
 msgctxt ",B825E1564FCBA4D960D238AFD10804AC"
 msgid "The lucky Titan's cock won't be able to keep up!"
-msgstr ""
+msgstr "那个幸运的泰坦的大鸡鸡再也不会被允许高高翘起了"
 
 #. Key:	B8297A054AB04B137F3266B6480756F5
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchGreeting01.Default__MonarchGreeting01_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Monarch/Default/MonarchGreeting01.Default__MonarchGreeting01_C.SessionData.Lines(3).Lines
 msgctxt ",B8297A054AB04B137F3266B6480756F5"
 msgid "I'm here to collect nectar for our queen."
-msgstr ""
+msgstr "我来这里是为了给我们的女王采集花蜜。"
 
 #. Key:	B82A33C04616825E1FC07F99415D421D
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01_RL_M.Default__FernDefault01_RL_M_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/Fern/Default/FernDefault01_RL_M.Default__FernDefault01_RL_M_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",B82A33C04616825E1FC07F99415D421D"
 msgid "What a lovely talking fern..."
-msgstr "真是个可爱的小蕨。"
+msgstr "真是个会说话的可爱小蕨。"
 
 #. Key:	B82BF1F5413587624AD2A6919AF2A0BA
 #. SourceLocation:	/Game/World/Architecture/CockblockGate/EM_CBGate.Default__EM_CBGate_C.ActivateMessage
 #: /Game/World/Architecture/CockblockGate/EM_CBGate.Default__EM_CBGate_C.ActivateMessage
 msgctxt ",B82BF1F5413587624AD2A6919AF2A0BA"
 msgid "Place Keystone"
-msgstr ""
+msgstr "放置钥石"
 
 #. Key:	B832AA994DBADAA17A15049B206652C5
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R02.Default__CamillaDefault01_R02_C.SessionData.Lines(9).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R02.Default__CamillaDefault01_R02_C.SessionData.Lines(9).Lines
 msgctxt ",B832AA994DBADAA17A15049B206652C5"
 msgid "Well I've answered your question so you probably want to leave now. If you have any more questions you should feel free to ask me. Although I'm sure Falene could answer your questions too."
-msgstr "我已经回答了你的问题，所以你可能想要现在离开，如果你还有其他的问题，可以随时问我。虽然我相信法莲娜也可以回答你的问题。"
+msgstr "我已经回答了你的问题，所以你可能想告辞了。但是如果你还有什么问题，请随时来问我。不过我相信法莲娜也能回答你的问题。"
 
 #. Key:	B841784842366C72B99D7BABC88D97E6
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_RL.Default__FaleneDefault01_RL_C.ResponseData(3).ResponseData.BreederPrompt
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_RL.Default__FaleneDefault01_RL_C.ResponseData(3).ResponseData.BreederPrompt
 msgctxt ",B841784842366C72B99D7BABC88D97E6"
 msgid "Pregnancy doesn't make sense!"
-msgstr "怀孕完全解释不通！"
+msgstr "怀孕完全说不通嘛！"
 
 #. Key:	B8579E3C4F6006CC5CA3CF899F4C6E39
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchHaveKeystone.Default__MonarchHaveKeystone_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Monarch/Default/MonarchHaveKeystone.Default__MonarchHaveKeystone_C.SessionData.Lines(1).Lines
 msgctxt ",B8579E3C4F6006CC5CA3CF899F4C6E39"
 msgid "Can y-y-you help me first?"
-msgstr ""
+msgstr "你…你…你可以先帮我吗"
 
 #. Key:	B85AAF9E46DEE4DCD0E942BEAB518960
 #. SourceLocation:	/Game/Breeding/Positions/Butterfly.Default__Butterfly_C.SessionData.Description
 #: /Game/Breeding/Positions/Butterfly.Default__Butterfly_C.SessionData.Description
 msgctxt ",B85AAF9E46DEE4DCD0E942BEAB518960"
 msgid "The receiver lays elevated on her back, while the giver stands and thrusts."
-msgstr ""
+msgstr "被恩赐者仰卧在高处双腿环成蝴蝶状，而播种者则站着插入。"
 
 #. Key:	B864A1D642255D8E7C1821AC53EC9231
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMNapSomewhereElse.Default__DMNapSomewhereElse_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMNapSomewhereElse.Default__DMNapSomewhereElse_C.SessionData.Lines(2).Lines
 msgctxt ",B864A1D642255D8E7C1821AC53EC9231"
 msgid "*Yawn*"
-msgstr ""
+msgstr "打哈欠"
 
 #. Key:	B87369D344C73AFA3F04D49BC07D8BE3
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiTaskFulfilled.Default__FesssiTaskFulfilled_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiTaskFulfilled.Default__FesssiTaskFulfilled_C.SessionData.Lines(2).Lines
 msgctxt ",B87369D344C73AFA3F04D49BC07D8BE3"
 msgid "My ass can once again sway in the breeze, and trust me human, it will."
-msgstr ""
+msgstr "我的屁股又能性感的摆动起来了，相信我，人类，它会的。"
 
 #. Key:	B87B8D5E4C3F16D731F4EA884051A1FD
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_StartButterfly.Default__ParvatiDefault01_StartButterfly_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_StartButterfly.Default__ParvatiDefault01_StartButterfly_C.SessionData.Lines(0).Lines
 msgctxt ",B87B8D5E4C3F16D731F4EA884051A1FD"
 msgid "..."
-msgstr ""
+msgstr "……"
 
 #. Key:	B89AB95C43AA6DC8279A10A4ECA0DD22
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeAboutOrb.Default__MegaSlimeAboutOrb_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeAboutOrb.Default__MegaSlimeAboutOrb_C.SessionData.Lines(2).Lines
 msgctxt ",B89AB95C43AA6DC8279A10A4ECA0DD22"
 msgid "After being down here alone for so long, I had forgotten what it was like to speak with someone."
-msgstr ""
+msgstr "一个人在这里寂寞的待了这么久，我都忘了和人说话是什么感觉了。”"
 
 #. Key:	B8C3F96E4BB231CDD5684BA134FF69CB
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaHadSex02.Default__CamillaHadSex02_C.SessionData.LinesToFuta(1).LinesToFuta
 #: /Game/Dialogue/Camilla/Default/CamillaHadSex02.Default__CamillaHadSex02_C.SessionData.LinesToFuta(1).LinesToFuta
 msgctxt ",B8C3F96E4BB231CDD5684BA134FF69CB"
 msgid "Your cock was so big, I didn't think I could take all of it."
-msgstr ""
+msgstr "你的鸡鸡太大了，我感觉我可能'吃'不下整个。"
 
 #. Key:	B8D3474E436959F3B7C140BFE42CF3C0
 #. SourceLocation:	/Game/Breeding/Positions/Doggy.Default__Doggy_C.SessionData.Description
 #: /Game/Breeding/Positions/Doggy.Default__Doggy_C.SessionData.Description
 msgctxt ",B8D3474E436959F3B7C140BFE42CF3C0"
 msgid "On all fours, the receiver gets pounded from behind."
-msgstr ""
+msgstr "接受者四肢着地，如同狗一样，后面被深入。"
 
 #. Key:	B8D5DBD04A2C66CA06A044B457DC1B92
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToFuta(6).LinesToFuta
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToFuta(6).LinesToFuta
 msgctxt ",B8D5DBD04A2C66CA06A044B457DC1B92"
 msgid "Stick that lovely human dick deep into my Lamia body... yes..."
-msgstr "用那人类的阴茎深深埋进我Lamia族的身体里吧……就是那里……啊啊~"
+msgstr "用那人类的阴茎深深埋进我拉米娅一族的身体里吧……就是那里……啊啊~"
 
 #. Key:	B8E34EF44104C91D147557A4F02B0AD7
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiHadSex01.Default__FesssiHadSex01_C.SessionData.LinesToFuta(0).LinesToFuta
 #: /Game/Dialogue/Fesssi/Default/FesssiHadSex01.Default__FesssiHadSex01_C.SessionData.LinesToFuta(0).LinesToFuta
 msgctxt ",B8E34EF44104C91D147557A4F02B0AD7"
 msgid "Ahhh... yet another load for my giant ass. Hiss!"
-msgstr ""
+msgstr "啊~又给我的大屁股来了一枪！嘶~"
 
 #. Key:	B92677C94581B16A61827CA24E811637
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeAboutBees.Default__BeeAboutBees_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/QueenBee/Default/BeeAboutBees.Default__BeeAboutBees_C.SessionData.Lines(1).Lines
 msgctxt ",B92677C94581B16A61827CA24E811637"
 msgid "To harvest it, a queen will produce worker bee daughters who then mix the nectar with their breast milk."
-msgstr ""
+msgstr "为了收获它，蜂后会产下工蜂女儿，她们会把花蜜和蜂后的母乳混合在一起。"
 
 #. Key:	B98DBFC944D984D0B00D708EE1B9AB94
 #. SourceLocation:	/Game/Dialogue/Emissary/SexScenes/EmissaryAngelGroinLove.Default__EmissaryAngelGroinLove_C.SessionData.LinesToFuta(0).LinesToFuta
@@ -10028,42 +10030,42 @@ msgstr "纵享这一切吧，因为吾侍服于汝。"
 #: /Game/Dialogue/Autumn/Default/DryadFlowers.Default__DryadFlowers_C.SessionData.Lines(6).Lines
 msgctxt ",B9D395FA4457763F84E8BD94863D5FBD"
 msgid "Once the plant has stored enough nectar, it will wait for a horny little bee to come by and... well you know."
-msgstr ""
+msgstr "一旦植物储存了足够的花蜜，它就会等待一只性感的小蜜蜂过来，然后就……你懂的~"
 
 #. Key:	B9EEB95A4D8ACD7FAC9BD4AE769758FE
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiHowLong.Default__FesssiHowLong_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiHowLong.Default__FesssiHowLong_C.SessionData.Lines(2).Lines
 msgctxt ",B9EEB95A4D8ACD7FAC9BD4AE769758FE"
 msgid "Occasionally, random travellers would try to get around me, but they soon found their genitals on the receiving end of my tongue."
-msgstr ""
+msgstr "有时候，一些路过的人会试图绕到我的后面去，但他们很快就会发现他们的大鸡鸡在我的嘴中被我的舌头缴械了。"
 
 #. Key:	B9F630DD484439D0C2B6EFBC3D01D2C5
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_FutaBalls.Default__FaleneDefault01_FutaBalls_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_FutaBalls.Default__FaleneDefault01_FutaBalls_C.SessionData.Lines(1).Lines
 msgctxt ",B9F630DD484439D0C2B6EFBC3D01D2C5"
 msgid "Semen is stored internally to reduce the potential for damage and make more room for the vagina to expand."
-msgstr "精液储存在体内以减少潜在的伤害，并为阴道的扩张腾出更多空间。"
+msgstr "精液被储存在体内以减少潜在的损伤，而且可以为阴道扩张腾出更多的空间……"
 
 #. Key:	BA4F5C334B416E6C99C047BD1AF731C9
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R02.Default__FaleneDefault01_R02_C.SessionData.Lines(7).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R02.Default__FaleneDefault01_R02_C.SessionData.Lines(7).Lines
 msgctxt ",BA4F5C334B416E6C99C047BD1AF731C9"
 msgid "Feel free to try though... I will consider it foreplay,  rip your clothes off, and then mate with you for hours!"
-msgstr "随时都可以尝试哦……我会把这视为前戏，撕掉你的衣服然后和你翻云覆雨数小时！"
+msgstr "随时都欢迎尝试哦……我会把这视为前戏，撕掉你的衣服然后和你翻云覆雨数小时！"
 
 #. Key:	BABE7B1340FA36AADAE0E596C6FC1721
 #. SourceLocation:	/Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",BABE7B1340FA36AADAE0E596C6FC1721"
 msgid "How I envy this tall sexy body of yours, but ohhhhh it feels so good!"
-msgstr "我真嫉妒你这高大的人类躯体，但是……哦……这感觉真是太爽了！"
+msgstr "我真嫉妒你这高大的人类躯体，但是……哦噢噢……这感觉真是太爽了！"
 
 #. Key:	BAEE9CCB4074E077BFF0FBAE275D41CD
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(1).Lines
 msgctxt ",BAEE9CCB4074E077BFF0FBAE275D41CD"
 msgid "From the Void, she created this universe and began to indulge in creation."
-msgstr ""
+msgstr "在虚空中，祂创造了这个宇宙，并开始沉迷于创造。"
 
 #. Key:	BB0E7B2D4F49CAAB00A884BE87ED9F44
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieGreeting01.Default__CassieGreeting01_C.SessionData.Lines(7).Lines
@@ -10077,14 +10079,14 @@ msgstr "或者，你如果…想要用黄油涂满我的小屁股然后让我验
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePlay.Default__MegaSlimePlay_C.SessionData.LinesToFuta(0).LinesToFuta
 msgctxt ",BB111DD44D5B70DED7DD519DD967FEC8"
 msgid "Really?! These truly are the best days of my life!"
-msgstr ""
+msgstr "哇哦真的吗？那可真的是我人生中最快乐的日子了"
 
 #. Key:	BB8503A14E015AEDED4E1C866261B05C
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeHowLong.Default__MegaSlimeHowLong_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeHowLong.Default__MegaSlimeHowLong_C.SessionData.Lines(3).Lines
 msgctxt ",BB8503A14E015AEDED4E1C866261B05C"
 msgid "If I could only get some townsfolk to come here and feed me warm cum!"
-msgstr ""
+msgstr "要是我能找些镇上的人过来给我射点暖呼呼的精液就好了!"
 
 #. Key:	BB8EC0EA497B20CC5A726AA919605178
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R04.Default__CamillaDefault01_R04_C.SessionData.Lines(0).Lines
@@ -10098,35 +10100,35 @@ msgstr "真有意思！"
 #: /Game/Dialogue/Fern/DefaultP2/FernGreeting02.Default__FernGreeting02_C.SessionData.LinesToFuta(0).LinesToFuta
 msgctxt ",BBBCA38B49D367A566E07BA607FA7359"
 msgid "Oh Master, you have fed me well."
-msgstr ""
+msgstr "哦主人，您把我喂养的很好。"
 
 #. Key:	BC25BCBE4F9535F47E145F8384E62BA5
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03_R05.Default__FernDefault03_R05_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03_R05.Default__FernDefault03_R05_C.SessionData.Lines(2).Lines
 msgctxt ",BC25BCBE4F9535F47E145F8384E62BA5"
 msgid "You should name our daughter!"
-msgstr ""
+msgstr "您应该给我们的女儿起个名字！"
 
 #. Key:	BC29BB8B478C65C2CBA0898E60299364
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadCherryHelp_RL.Default__DryadCherryHelp_RL_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/Autumn/Default/DryadCherryHelp_RL.Default__DryadCherryHelp_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",BC29BB8B478C65C2CBA0898E60299364"
 msgid "Uh, I only make babies not fruit."
-msgstr ""
+msgstr "哦，我只会生孩子，不会生水果~"
 
 #. Key:	BC33AF644FC93D01CDEF628CB3209014
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchHadSex01.Default__MonarchHadSex01_C.SessionData.LinesToFuta(2).LinesToFuta
 #: /Game/Dialogue/Monarch/Default/MonarchHadSex01.Default__MonarchHadSex01_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",BC33AF644FC93D01CDEF628CB3209014"
 msgid "It felt very good. Maybe... w-w-we can do it again?"
-msgstr ""
+msgstr "那真的是舒服极了。也许……我……我……我们可以再来一次?"
 
 #. Key:	BC50064D4E4A670A496FFAB77DB95208
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToFemale(4).LinesToFemale
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToFemale(4).LinesToFemale
 msgctxt ",BC50064D4E4A670A496FFAB77DB95208"
 msgid "Something mythical... something forbidden... something... human!"
-msgstr "一些神圣的……一些禁忌的……一些人类的东西！"
+msgstr "一些神圣的……一些禁忌的……一些……人类的东西！"
 
 #. Key:	BC8D18A04D5B0C96E407F884999310E6
 #. SourceLocation:	/Game/Dialogue/AmberMae/SexScenes/AmberMilkyF.Default__AmberMilkyF_C.SessionData.Lines(5).Lines
@@ -10147,14 +10149,14 @@ msgstr "回想一下，你刚刚出现在一个紫色精灵面前的牧场上。
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R01.Default__CamillaDefault01_R01_C.SessionData.Lines(2).Lines
 msgctxt ",BCCE27C44B7552836451CAB377E5AE75"
 msgid "You also need to have something to... entice @MONSTER_RACE@ before you can bind them."
-msgstr "在和@MONSTER_RACE@进行交合之前，你还需要一些东西来……引诱他们"
+msgstr "在和@MONSTER_RACE@进行交合之前，你还需要一些东西来……引诱她们"
 
 #. Key:	BCD1086643EFC484462E0494A74B5A84
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcTribeSucks.Default__OrcTribeSucks_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcTribeSucks.Default__OrcTribeSucks_C.SessionData.Lines(4).Lines
 msgctxt ",BCD1086643EFC484462E0494A74B5A84"
 msgid "Grrrr! But elves are stupid. They broke gate again."
-msgstr ""
+msgstr "咕噜噜噜，但是精灵们都太蠢了。她们又弄坏了门。"
 
 #. Key:	BD2871634CBCB94F889B2FA98F0BF8DA
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryGreeting01.Default__EmissaryGreeting01_C.SessionData.Lines(4).Lines
@@ -10168,14 +10170,14 @@ msgstr "于这些迷惘的魂灵，汝是唯一能帮助他们之人。正当吾
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_RL.Default__EmissaryDefault01_RL_C.ResponseData(6).ResponseData.BreederPrompt
 msgctxt ",BD299A114393AB7ECF48C8A20700F593"
 msgid "What is the endless daze?"
-msgstr ""
+msgstr "什么是无尽的茫然？"
 
 #. Key:	BD326ED44A2732523BC286AA438967A7
 #. SourceLocation:	/Game/Dialogue/Yasmine/Default/YasmineHadSex01.Default__YasmineHadSex01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Yasmine/Default/YasmineHadSex01.Default__YasmineHadSex01_C.SessionData.Lines(1).Lines
 msgctxt ",BD326ED44A2732523BC286AA438967A7"
 msgid "Waves of ecstasy still course through my body."
-msgstr ""
+msgstr "狂喜的浪潮仍在我的身体里波涛汹涌!"
 
 #. Key:	BD61F6BE4278688EEA2B878F6E8C6994
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(14).LinesToFemale
@@ -10189,21 +10191,21 @@ msgstr "我的蜜穴在不停嚅嗫着..."
 #: /Game/Dialogue/Leylanna/Default/LeylannaDefault01_BlueSmoke2.Default__LeylannaDefault01_BlueSmoke2_C.SessionData.Lines(1).Lines
 msgctxt ",BD6CCEB440D9DEC7D0A7988EC78DC07B"
 msgid "Ahhhh..."
-msgstr ""
+msgstr "啊……啊……"
 
 #. Key:	BD73D4BA496C11214C7199AB3A0ED336
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleDragonMatriarch.Default__KybeleDragonMatriarch_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Kybele/Default/KybeleDragonMatriarch.Default__KybeleDragonMatriarch_C.SessionData.Lines(3).Lines
 msgctxt ",BD73D4BA496C11214C7199AB3A0ED336"
 msgid "But if the sexual encounter were to come to me..."
-msgstr ""
+msgstr "但如果两性交融的事情发生在我身上的话……"
 
 #. Key:	BDF0CA7D47EE073120067A9FCE686C17
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadBossomCherries.Default__DryadBossomCherries_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Autumn/Default/DryadBossomCherries.Default__DryadBossomCherries_C.SessionData.Lines(1).Lines
 msgctxt ",BDF0CA7D47EE073120067A9FCE686C17"
 msgid "They are for the Ayrshires that roam around here, and oh my can they eat!"
-msgstr ""
+msgstr "他们是为在这里闲逛的埃尔郡人准备的，哦，天哪，他们吃得太多了!"
 
 #. Key:	BDF9214F4D266A69032FE9921524969C
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFuta(2).LinesToFuta
@@ -10217,7 +10219,7 @@ msgstr "现在你就是@WORLD_NAME@大陆最新的居民啦！"
 #: /Game/Dialogue/Cassie/Default/CassieHadSex01.Default__CassieHadSex01_C.SessionData.LinesToFemale(4).LinesToFemale
 msgctxt ",BE16AB634A0B031F9DEEF79B3D80C4A5"
 msgid "Meow!"
-msgstr ""
+msgstr "喵呜！"
 
 #. Key:	BE3E92FA4D0B5FE720EA038B6A6FF27C
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryBlessedInquiry02_RL.Default__EmissaryBlessedInquiry02_RL_C.ResponseData(1).ResponseData.BreederPrompt
@@ -10231,42 +10233,42 @@ msgstr "还真不错嗷。"
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01.Default__CamillaDefault01_C.SessionData.Lines(0).Lines
 msgctxt ",BE946F0645DD9D40528D2A9DB1FB48B4"
 msgid "Sometimes Falene makes me ride on her back around town."
-msgstr "有时候法琳娜让我骑在她的肩上绕着小镇转悠。"
+msgstr "有时候法莲娜让我骑在她的肩上绕着小镇转悠。"
 
 #. Key:	BE9F677046DE7F9AE5246FB18D7F8FFB
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01.Default__CamillaDefault01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01.Default__CamillaDefault01_C.SessionData.Lines(1).Lines
 msgctxt ",BE9F677046DE7F9AE5246FB18D7F8FFB"
 msgid "Once she threw me into that pussy portal when Neela wasn't looking!"
-msgstr "有一次她趁霓拉不注意，把我扔进了那个传送门!"
+msgstr "有一次她趁妮拉不注意，把我扔进了那个传送门!"
 
 #. Key:	BED6E4EB4536C7A1E1D8EF8C6FA3F149
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryCockblockGates.Default__EmissaryCockblockGates_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryCockblockGates.Default__EmissaryCockblockGates_C.SessionData.Lines(3).Lines
 msgctxt ",BED6E4EB4536C7A1E1D8EF8C6FA3F149"
 msgid "But beware, other blessed @MONSTER_RACE@ have collected the keystones over the years."
-msgstr ""
+msgstr "但要注意，其他受祝福的魔弗灵已经拥有了钥石许多年。"
 
 #. Key:	BEDA154E4410DE62211DBFA48872ED35
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchHadSex01.Default__MonarchHadSex01_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/Monarch/Default/MonarchHadSex01.Default__MonarchHadSex01_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",BEDA154E4410DE62211DBFA48872ED35"
 msgid "Thank you h-h-human!"
-msgstr ""
+msgstr "谢……谢谢你，人类！"
 
 #. Key:	BEDA7D94498AC1A3091C29BABE2C94F7
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_RL.Default__CamillaDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_RL.Default__CamillaDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",BEDA7D94498AC1A3091C29BABE2C94F7"
 msgid "Falene said you could tell me how to catch @MONSTER_RACE@?"
-msgstr ""
+msgstr "法莲娜说你可以告诉我怎么捕获野生的魔弗灵？"
 
 #. Key:	BF0DF5C24AC9872B58BA689D790CE436
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeTaskFulfilled.Default__BeeTaskFulfilled_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/QueenBee/Default/BeeTaskFulfilled.Default__BeeTaskFulfilled_C.SessionData.Lines(3).Lines
 msgctxt ",BF0DF5C24AC9872B58BA689D790CE436"
 msgid "The keystone now belongs to you."
-msgstr ""
+msgstr "这枚钥石现在是你的了。"
 
 #. Key:	BF4DCF6B4CBF1E3FAE0D139E494C7673
 #. SourceLocation:	/Game/Characters/Procedural/Variants/Demon/Harvest/DemonHarvest.Default__DemonHarvest_C.Harvest.RaceName
@@ -10280,28 +10282,28 @@ msgstr "恶魔"
 #: /Game/Dialogue/OrcChief/Default/OrcAkabekoCheck.Default__OrcAkabekoCheck_C.SessionData.Lines(3).Lines
 msgctxt ",BF51DA004C841AAF7E6BE4B506111783"
 msgid "Now tribe sisters are making offspring with her. Tonight she will be mine again."
-msgstr ""
+msgstr "现在部落的姐妹们正在和她生育后代。今晚再次轮到我了"
 
 #. Key:	BF75C6BF46495EB7F48CD398677B4B16
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeDefault01.Default__BeeDefault01_C.SessionData.LinesToFemale(4).LinesToFemale
 #: /Game/Dialogue/QueenBee/Default/BeeDefault01.Default__BeeDefault01_C.SessionData.LinesToFemale(4).LinesToFemale
 msgctxt ",BF75C6BF46495EB7F48CD398677B4B16"
 msgid "Is t-t-there something... you want human?"
-msgstr ""
+msgstr "你…你需要什么吗？人类"
 
 #. Key:	BF7F7E1041AD5B8267C70694F83985F6
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R03.Default__CamillaDefault01_R03_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R03.Default__CamillaDefault01_R03_C.SessionData.Lines(0).Lines
 msgctxt ",BF7F7E1041AD5B8267C70694F83985F6"
 msgid "Meh... you're just another one of those who thinks I'm cute because I'm small!"
-msgstr "嚒……你只是另一个因为我个子小所以认为我可爱的人!"
+msgstr "嘛……你只是另一个因为我个子小所以认为我可爱的人!"
 
 #. Key:	BF975F284EF533BA005E9DB9E53ED275
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcBrashDumb.Default__OrcBrashDumb_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcBrashDumb.Default__OrcBrashDumb_C.SessionData.Lines(5).Lines
 msgctxt ",BF975F284EF533BA005E9DB9E53ED275"
 msgid "Orc who wins the most fights and makes the most offspring becomes chieftain."
-msgstr ""
+msgstr "赢得最多战斗并拥有最多后代的兽人将成为酋长。"
 
 #. Key:	BFA3EA894BDCD8476E3C3E83125BF435
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R04.Default__FaleneDefault01_R04_C.SessionData.Lines(3).Lines
@@ -10336,21 +10338,21 @@ msgstr "蜂人体液"
 #: /Game/Dialogue/Yasmine/Default/YasmineAwake.Default__YasmineAwake_C.SessionData.Lines(3).Lines
 msgctxt ",BFE69EFF42781D385F73FFB257B3F5C6"
 msgid "Wait, you're human?!"
-msgstr ""
+msgstr "等等！你是……人类？！"
 
 #. Key:	C0073F7149266435A304ECAB73399664
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadHadSex01.Default__DryadHadSex01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Autumn/Default/DryadHadSex01.Default__DryadHadSex01_C.SessionData.Lines(1).Lines
 msgctxt ",C0073F7149266435A304ECAB73399664"
 msgid "Ahhh... you made me feel so good, I've never produced such a large fruit."
-msgstr ""
+msgstr "哦，你让我爽翻了亲爱的，我从没制作出过这么大的水果。"
 
 #. Key:	C034823A4189F2EED2DFEBB7B3005286
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMDefault_RL4.Default__DMDefault_RL4_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/DragonMatriarch/Default/DMDefault_RL4.Default__DMDefault_RL4_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",C034823A4189F2EED2DFEBB7B3005286"
 msgid "Forget the Titan, how about some human?"
-msgstr ""
+msgstr "别管泰坦了，不尝尝看人类的感觉吗?"
 
 #. Key:	C03BBCDD4AACD3CC387AAAB2A4FD00E9
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R01.Default__CamillaDefault01_R01_C.SessionData.Lines(1).Lines
@@ -10364,49 +10366,49 @@ msgstr "总之，一旦你建造好了一个住处，你就可以捕捉任何种
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R01.Default__FaleneDefault01_R01_C.SessionData.Lines(7).Lines
 msgctxt ",C0C2274D435835E82C7558B7D7771463"
 msgid "This is the area most misunderstood and hard to observe."
-msgstr "这是最容易被误解而且难以观察到的区域了。"
+msgstr "这是最容易被误解而且难以观察到的领域了。"
 
 #. Key:	C0DA0B9242845DD678C67991582BCF2B
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraGreeting01.Default__PetraGreeting01_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Petra/Default/PetraGreeting01.Default__PetraGreeting01_C.SessionData.Lines(4).Lines
 msgctxt ",C0DA0B9242845DD678C67991582BCF2B"
 msgid "We made love for hours, and she taught me how to position my body in ways I never thought possible!"
-msgstr ""
+msgstr "我们做了好几个小时，她教会了我从没想到过的姿势！"
 
 #. Key:	C0E8ACF94F6090E346B6B3BFDB6536AF
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.EM_Keystone_Widow.FailMessage
 #: /Game/World/Overworld.Overworld:PersistentLevel.EM_Keystone_Widow.FailMessage
 msgctxt ",C0E8ACF94F6090E346B6B3BFDB6536AF"
 msgid "It's wrapped in webs."
-msgstr ""
+msgstr "它被蛛丝包裹着。"
 
 #. Key:	C1169E76415C88B42A1C1EAA53F38266
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_EnlightenedOne.Default__NeelaDefault01_EnlightenedOne_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_EnlightenedOne.Default__NeelaDefault01_EnlightenedOne_C.SessionData.Lines(2).Lines
 msgctxt ",C1169E76415C88B42A1C1EAA53F38266"
 msgid "We have... uh... met before. Many times."
-msgstr ""
+msgstr "我们有…嗯…以前见过几次面……"
 
 #. Key:	C11A1BE2468282C1EFE3DA9E52978358
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraHadSex01.Default__PetraHadSex01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Petra/Default/PetraHadSex01.Default__PetraHadSex01_C.SessionData.Lines(0).Lines
 msgctxt ",C11A1BE2468282C1EFE3DA9E52978358"
 msgid "Was I a good bunny?"
-msgstr ""
+msgstr "我是只乖兔兔吗?"
 
 #. Key:	C129394C4F9E7B6D0EF3EF87678D5D3B
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeDefault01_RL.Default__BeeDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/QueenBee/Default/BeeDefault01_RL.Default__BeeDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",C129394C4F9E7B6D0EF3EF87678D5D3B"
 msgid "If I must..."
-msgstr ""
+msgstr "如果我必须的话……"
 
 #. Key:	C156402F4738F87B9C9392A5443BE29F
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryGreeting01.Default__EmissaryGreeting01_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryGreeting01.Default__EmissaryGreeting01_C.SessionData.Lines(2).Lines
 msgctxt ",C156402F4738F87B9C9392A5443BE29F"
 msgid "You are unique in this world, for all other living things, myself included, are @MONSTER_RACE@. We are merely half human, crossed with... something else."
-msgstr "汝的存在于这里所有生灵，甚至于吾，诸魔灵们，都是独一无二的。吾等仅是半人，不过是亦融于一些……人外之灵。"
+msgstr "汝的在这个世上是独一无二的，所有生灵，以及吾，都是魔弗灵，我们都是半人……和一些……别的东西。"
 
 #. Key:	C18558714C7A7B697778D68CFD03FAF0
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_AboutKrakens.Default__MirruDefault01_AboutKrakens_C.SessionData.Lines(4).Lines
@@ -10427,21 +10429,21 @@ msgstr "据说，这就是至高女神的阴唇的完美复制品呢！"
 #: /Game/Ranch/Upgrades/FormurianPond.Default__FormurianPond_C.Upgrade.Description
 msgctxt ",C2409B0E43C4FECF37A9A4AEC03EA9E7"
 msgid "This allows you to catch and store all Formurian variants."
-msgstr ""
+msgstr "这能允许你捕捉并饲养深海族。"
 
 #. Key:	C25D4CE34387E86F32C4E28046D053D3
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadFatAssLamia.Default__DryadFatAssLamia_C.SessionData.Lines(6).Lines
 #: /Game/Dialogue/Autumn/Default/DryadFatAssLamia.Default__DryadFatAssLamia_C.SessionData.Lines(6).Lines
 msgctxt ",C25D4CE34387E86F32C4E28046D053D3"
 msgid "Ohhh it felt so good.... as I buried my face into her ass and she thrusted her tongue deep into my pussy."
-msgstr ""
+msgstr "当我把脸埋进她的屁股里她把舌头伸到我的阴道，哦，感觉爽的能翻白眼。"
 
 #. Key:	C29993C74D67F8AE960E44826013B47C
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_AboutKrakens.Default__MirruDefault01_AboutKrakens_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_AboutKrakens.Default__MirruDefault01_AboutKrakens_C.SessionData.Lines(1).Lines
 msgctxt ",C29993C74D67F8AE960E44826013B47C"
 msgid "Krakens founded Formuria, and we have upheld lordship ever since. Our subjects respect us, and we rule over them with mercy and honor."
-msgstr "海妖族扎根于弗玛里亚，自起初就手握权力。治下的臣民敬仰我们，我们自要以仁慈与荣誉统领他们。"
+msgstr "海妖族扎根于弗玛里亚，自起初就手握大全。治下的臣民敬仰我们，我们自要以仁慈与荣誉统领他们。"
 
 #. Key:	C2F976F9463088F39315118741B15D32
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_StartKrakVag.Default__MirruDefault01_StartKrakVag_C.SessionData.Lines(0).Lines
@@ -10455,14 +10457,14 @@ msgstr "噢……相信我人类，你不会后悔的。"
 #: /Game/Dialogue/DragonMatriarch/Default/DMSoBeItT.Default__DMSoBeItT_C.SessionData.Lines(0).Lines
 msgctxt ",C31358424DDC04F9D0E9C2AFEADAFCE4"
 msgid "Ahhh... so be it!"
-msgstr ""
+msgstr "啊噢噢……那么就这么办吧！"
 
 #. Key:	C3445C514F78EFD7116EE28D6898079D
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R02.Default__FaleneDefault01_R02_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R02.Default__FaleneDefault01_R02_C.SessionData.Lines(5).Lines
 msgctxt ",C3445C514F78EFD7116EE28D6898079D"
 msgid "Because of our sentience, it's forbidden to catch us. The temple deems it too much like slavery to captivate those whom are blessed."
-msgstr "因为我们拥有灵智，捕捉我们是被禁止的。圣殿认为捕捉拥有灵性的神佑魔弗灵则太像奴役了。"
+msgstr "因为我们拥有灵智，我们是被禁止捕捉的。圣殿认为捕捉拥有灵性的神佑魔弗灵则太像奴役了。"
 
 #. Key:	C35F97ED47D151CAD06084864F0ED555
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_SpiritForm.Default__LeylannaDefault01_SpiritForm_C.SessionData.Lines(4).Lines
@@ -10476,21 +10478,21 @@ msgstr "这样一来便使得魔弗灵的魂灵在你有所\"作为\"时感受�
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_Forgot_RL.Default__ParvatiDefault01_Forgot_RL_C.ResponseData(7).ResponseData.BreederPrompt
 msgctxt ",C36C759941B23E33ABE38E9C98E4A1E3"
 msgid "Lap Dance!"
-msgstr ""
+msgstr "膝上艳舞式"
 
 #. Key:	C396D17343484B5599E940B3CD9E0AF1
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcHadSex01.Default__OrcHadSex01_C.SessionData.LinesToFemale(2).LinesToFemale
 #: /Game/Dialogue/OrcChief/Default/OrcHadSex01.Default__OrcHadSex01_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",C396D17343484B5599E940B3CD9E0AF1"
 msgid "Grrrrr... chieftain horny again. Human shouldn't stay long, things might happen."
-msgstr ""
+msgstr "咕噜噜，族长我又硬了，人类最好别在这里久留，会被干翻的哦"
 
 #. Key:	C45BFAF14EABF8D1BD3502825C5C1560
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_FloatRhyme.Default__ParvatiDefault01_FloatRhyme_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_FloatRhyme.Default__ParvatiDefault01_FloatRhyme_C.SessionData.Lines(1).Lines
 msgctxt ",C45BFAF14EABF8D1BD3502825C5C1560"
 msgid "And became one with the Goddess who indulged in beastiality."
-msgstr ""
+msgstr "与沉溺于兽性的女神合为一体。"
 
 #. Key:	C462B3344F759413A7C6F28489176C99
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R03_RL.Default__CamillaDefault01_R03_RL_C.ResponseData(1).ResponseData.BreederPrompt
@@ -10511,14 +10513,14 @@ msgstr "嗷！看起来有人的屌想要被吸了哦！"
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_Teach.Default__ParvatiDefault01_Teach_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",C4A89EE6414BE3013E77CA81E8105E53"
 msgid "Remove your garments, for you must be nude."
-msgstr ""
+msgstr "脱下你的衣服，因为你必须赤忱相见。"
 
 #. Key:	C4C596ED4DE277B929ABDDB01255A79B
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDungeon.Default__CassieDungeon_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Cassie/Default/CassieDungeon.Default__CassieDungeon_C.SessionData.Lines(1).Lines
 msgctxt ",C4C596ED4DE277B929ABDDB01255A79B"
 msgid "Meow... no one has been down there for as long as I remember."
-msgstr ""
+msgstr "喵呜……从我记事起就没人下去过了……"
 
 #. Key:	C4F4ECA34FB62457AF54C48B18A75686
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01.Default__EmissaryDefault01_C.SessionData.Lines(2).Lines
@@ -10539,56 +10541,56 @@ msgstr "深海族"
 #: /Game/Dialogue/Romy/Default/RomyHadSex01.Default__RomyHadSex01_C.SessionData.Lines(0).Lines
 msgctxt ",C5113B72490FFD8142C52EBDED0B4656"
 msgid "Oh the songs of pleasure we sang, how good they felt."
-msgstr ""
+msgstr "哦，我们合唱的欢愉之歌，感觉是那么的美好。"
 
 #. Key:	C52FEFD44780735A14B2A78C9F57D862
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiGreeting01.Default__ParvatiGreeting01_C.SessionData.LinesToFemale(6).LinesToFemale
 #: /Game/Dialogue/Parvati/Default/ParvatiGreeting01.Default__ParvatiGreeting01_C.SessionData.LinesToFemale(6).LinesToFemale
 msgctxt ",C52FEFD44780735A14B2A78C9F57D862"
 msgid "Give your body to me, and in ecstasy we will make it conform."
-msgstr ""
+msgstr "把你的身体交给我，在狂喜中我们会合二为一。"
 
 #. Key:	C540E787424068F17DC21E839F8383CC
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiStuck.Default__FesssiStuck_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiStuck.Default__FesssiStuck_C.SessionData.Lines(2).Lines
 msgctxt ",C540E787424068F17DC21E839F8383CC"
 msgid "I blame that dryad, she kept bringing me her sweet fruit, and before I knew it my ass was too big to leave my cave."
-msgstr ""
+msgstr "都怪那个树妖，都是她不停地给我送她那好吃的果子，导致我还没反应过来，屁股就大得不能离开我的洞穴了。"
 
 #. Key:	C544F8824FC4DDC6DBEFE084C3987F32
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon2.Default__AmberMaeLockedDungeon2_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon2.Default__AmberMaeLockedDungeon2_C.SessionData.Lines(4).Lines
 msgctxt ",C544F8824FC4DDC6DBEFE084C3987F32"
 msgid "How I miss the old days."
-msgstr ""
+msgstr "俺多么怀念过去的日子啊。"
 
 #. Key:	C55370A04CAE38FD1D15A9AC46E99FBD
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaHadSex02.Default__CamillaHadSex02_C.SessionData.LinesToFemale(2).LinesToFemale
 #: /Game/Dialogue/Camilla/Default/CamillaHadSex02.Default__CamillaHadSex02_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",C55370A04CAE38FD1D15A9AC46E99FBD"
 msgid "If you... uh... ever get desperate again, you know where to find me!"
-msgstr ""
+msgstr "但是如果你…呃…如果你又很渴望的话，你知道哪里能找到我！"
 
 #. Key:	C5A392E248451A7506C787B6B7724091
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaOldTempleDungeon1.Default__LeylannaOldTempleDungeon1_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Leylanna/Default/LeylannaOldTempleDungeon1.Default__LeylannaOldTempleDungeon1_C.SessionData.Lines(1).Lines
 msgctxt ",C5A392E248451A7506C787B6B7724091"
 msgid "Ahhhh..."
-msgstr ""
+msgstr "哦噢噢……"
 
 #. Key:	C5CEDF194D3B59C00FF3338949A33FDE
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleHaveKeystone2.Default__KybeleHaveKeystone2_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Kybele/Default/KybeleHaveKeystone2.Default__KybeleHaveKeystone2_C.SessionData.Lines(0).Lines
 msgctxt ",C5CEDF194D3B59C00FF3338949A33FDE"
 msgid "A deal is a deal, take it."
-msgstr ""
+msgstr "交易就是交易，拿走吧"
 
 #. Key:	C5E724D9440EB6AC1E01458A6325FC39
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01_R02.Default__FernDefault01_R02_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Fern/Default/FernDefault01_R02.Default__FernDefault01_R02_C.SessionData.Lines(1).Lines
 msgctxt ",C5E724D9440EB6AC1E01458A6325FC39"
 msgid "Me like this name Fern. Hiss!"
-msgstr "我喜欢这个名字，小蕨…嘶嘶…"
+msgstr "我自己喜欢这个名字，小蕨…嘶嘶…"
 
 #. Key:	C5F9CCA94803FF5DA8A42E947B60C68D
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(12).LinesToMale
@@ -10609,63 +10611,63 @@ msgstr "..."
 #: /Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",C64CAA3740345626670050917404491A"
 msgid "You taste so good... ahhhh!"
-msgstr "你可真美味……啊啊啊！！！！"
+msgstr "你可真美味……呃啊啊！！！！"
 
 #. Key:	C65E75D34AC278A104BAD0A7B99C4CA2
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.CBGate_Hivelands.BlockMessage
 #: /Game/World/Overworld.Overworld:PersistentLevel.CBGate_Hivelands.BlockMessage
 msgctxt ",C65E75D34AC278A104BAD0A7B99C4CA2"
 msgid "Honeycomb blocks this gate."
-msgstr ""
+msgstr "蜂巢挡住了这扇门。"
 
 #. Key:	C66928AC49FF8C314FC5339591BF860D
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraGetKeystone.Default__PetraGetKeystone_C.SessionData.Lines(8).Lines
 #: /Game/Dialogue/Petra/Default/PetraGetKeystone.Default__PetraGetKeystone_C.SessionData.Lines(8).Lines
 msgctxt ",C66928AC49FF8C314FC5339591BF860D"
 msgid "You... you must have something to do with it!"
-msgstr ""
+msgstr "你……你一定和这件事有什么关系!"
 
 #. Key:	C6B18EAC4E513704AB264E9A875521FB
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyLockedDungeon.Default__RomyLockedDungeon_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Romy/Default/RomyLockedDungeon.Default__RomyLockedDungeon_C.SessionData.Lines(1).Lines
 msgctxt ",C6B18EAC4E513704AB264E9A875521FB"
 msgid "A very sad song radiates from within..."
-msgstr ""
+msgstr "一首非常悲伤的歌从内心散发出来……"
 
 #. Key:	C6D9B8644431D431610683A58FC57B84
 #. SourceLocation:	/Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToMale(6).LinesToMale
 #: /Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToMale(6).LinesToMale
 msgctxt ",C6D9B8644431D431610683A58FC57B84"
 msgid "Yes! I can feel you're about to cum... I want it all. Mmmm..."
-msgstr "哦！我能感到你快要射了……都给我！呃嗯……"
+msgstr "是的！我能感到你快要射了……都给我！呃嗯……"
 
 #. Key:	C6E5F355439A82543536AA974313674B
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadHaveKeystone2.Default__DryadHaveKeystone2_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Autumn/Default/DryadHaveKeystone2.Default__DryadHaveKeystone2_C.SessionData.Lines(0).Lines
 msgctxt ",C6E5F355439A82543536AA974313674B"
 msgid "It's yours now, I hope it serves you well."
-msgstr ""
+msgstr "现在是你的了，我希望它对你有用。"
 
 #. Key:	C720F2B64D81061E9D1CC7A3ACD4F0BB
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R02.Default__FaleneDefault01_R02_C.SessionData.Lines(12).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R02.Default__FaleneDefault01_R02_C.SessionData.Lines(12).Lines
 msgctxt ",C720F2B64D81061E9D1CC7A3ACD4F0BB"
 msgid "Beware, some blessed ones might succumb to their desires and surprise you if you get close!"
-msgstr "当心，某些受神佑的魔弗灵可能会屈服于他们的欲望然后在你靠近的时候扑倒你！"
+msgstr "当心，某些受神佑的魔弗灵可能会被他们的欲望所支配，然后在你靠近他们的时候顺势扑倒你！"
 
 #. Key:	C73CE27C41A91E73C54B58B65E56049E
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiGreeting01.Default__ParvatiGreeting01_C.SessionData.LinesToFemale(3).LinesToFemale
 #: /Game/Dialogue/Parvati/Default/ParvatiGreeting01.Default__ParvatiGreeting01_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",C73CE27C41A91E73C54B58B65E56049E"
 msgid "You seek to learn a new way to use your pleasure hole."
-msgstr ""
+msgstr "你渴求学习一种新的姿势来满足你那愉悦的小洞。"
 
 #. Key:	C77FA616486308414031F29069272188
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_RL.Default__LeylannaDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
 #: /Game/Dialogue/Leylanna/Default/LeylannaDefault01_RL.Default__LeylannaDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
 msgctxt ",C77FA616486308414031F29069272188"
 msgid "Let's recharge my spirit form."
-msgstr "请您改变我的魂灵形态。"
+msgstr "让我们来给我的魂灵形态充能吧。"
 
 #. Key:	C7BA93A840AB5FA97F357E802955A851
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(1 - Value).TraitIcons.DisplayName
@@ -10679,77 +10681,77 @@ msgstr "趋近兽型"
 #: /Game/Dialogue/Widow/Default/WidowDefault01.Default__WidowDefault01_C.SessionData.Lines(4).Lines
 msgctxt ",C7F43006419AE76ADB041AA7B3BB8DD1"
 msgid "Yes come with me, deeper into my nest of love. You will feel wave after wave of pleasure as I suck on you for every last drop."
-msgstr ""
+msgstr "是的，跟随我，深入我爱的巢穴。当我为了你的每一滴精液而卖力吸吮时，你会感受到一波又一波的快感的。"
 
 #. Key:	C80F35DE492B934FC30FBE82A653139B
 #. SourceLocation:	/Game/Dialogue/Yasmine/Default/YasmineAwake.Default__YasmineAwake_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Yasmine/Default/YasmineAwake.Default__YasmineAwake_C.SessionData.Lines(0).Lines
 msgctxt ",C80F35DE492B934FC30FBE82A653139B"
 msgid "Ah shooooot, my pearl went and rolled away again."
-msgstr ""
+msgstr "噢……妈的，我的珍珠又自己滚远了……"
 
 #. Key:	C831296B46D9E6D1B4ECA181BCD5520B
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_SexPositions.Default__EmissaryDefault01_SexPositions_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_SexPositions.Default__EmissaryDefault01_SexPositions_C.SessionData.Lines(1).Lines
 msgctxt ",C831296B46D9E6D1B4ECA181BCD5520B"
 msgid "She will teach you how to position the body for optimal sexual experience."
-msgstr ""
+msgstr "她会教你如何调整身体姿势以获得最佳的做爱经验。"
 
 #. Key:	C8F56B5143EC7D77BCE3D483F91BD832
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeMasturbate.Default__BeeMasturbate_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/QueenBee/Default/BeeMasturbate.Default__BeeMasturbate_C.SessionData.Lines(4).Lines
 msgctxt ",C8F56B5143EC7D77BCE3D483F91BD832"
 msgid "Of course we do... we must. Ahhh..."
-msgstr ""
+msgstr 我们当然要做……必须的~啊~哦~"
 
 #. Key:	C905E77348FA5208DABFD693A69EEBA4
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiIdiots.Default__FesssiIdiots_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiIdiots.Default__FesssiIdiots_C.SessionData.Lines(5).Lines
 msgctxt ",C905E77348FA5208DABFD693A69EEBA4"
 msgid "Hiss! I've got it."
-msgstr ""
+msgstr "我懂了嘶嘶！"
 
 #. Key:	C90FBEEB4770B7951F9099B01096A1B0
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeMasturbate.Default__BeeMasturbate_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/QueenBee/Default/BeeMasturbate.Default__BeeMasturbate_C.SessionData.Lines(0).Lines
 msgctxt ",C90FBEEB4770B7951F9099B01096A1B0"
 msgid "What... ahhh... a silly thing to ask... ohhh."
-msgstr ""
+msgstr "什么……啊…问这个问题很傻……呵呵。"
 
 #. Key:	C91B08354F7D144D174BCB8A2C8384CF
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMGreeting01.Default__DMGreeting01_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMGreeting01.Default__DMGreeting01_C.SessionData.Lines(5).Lines
 msgctxt ",C91B08354F7D144D174BCB8A2C8384CF"
 msgid "Now if you don't mind, I'd love to get back to my nap."
-msgstr ""
+msgstr "如果你不介意的话，我想打个小盹。"
 
 #. Key:	C933962A4C5DD7F022D428AEE50FE2C0
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeDefault01_RL.Default__MegaSlimeDefault01_RL_C.ResponseData(5).ResponseData.BreederPrompt
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeDefault01_RL.Default__MegaSlimeDefault01_RL_C.ResponseData(5).ResponseData.BreederPrompt
 msgctxt ",C933962A4C5DD7F022D428AEE50FE2C0"
 msgid "I want to play in your slime again!"
-msgstr ""
+msgstr "我还想在你的史莱姆粘液里玩！"
 
 #. Key:	C93F66124DFE84936731BDBDEB0840B9
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_SexPositions.Default__FaleneDefault01_SexPositions_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_SexPositions.Default__FaleneDefault01_SexPositions_C.SessionData.Lines(2).Lines
 msgctxt ",C93F66124DFE84936731BDBDEB0840B9"
 msgid "There is plenty of sex around Hedon to occupy my small attention span."
-msgstr ""
+msgstr "我不经意间注意到大量的做爱都围绕着海顿小镇。"
 
 #. Key:	C94B41FA4308FFD8A8F985BFB7D0411F
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowKeystone.Default__WidowKeystone_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Widow/Default/WidowKeystone.Default__WidowKeystone_C.SessionData.Lines(2).Lines
 msgctxt ",C94B41FA4308FFD8A8F985BFB7D0411F"
 msgid "She landed in my web with a thunderous crash, and ruined the whole thing."
-msgstr ""
+msgstr "她像闪电一样轰隆一声重重地落在我的网里，把一切都毁了。"
 
 #. Key:	C98355D84D2C12D36A73BC8F7D73D2B1
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToFemale(3).LinesToFemale
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",C98355D84D2C12D36A73BC8F7D73D2B1"
 msgid "You might think that's gross, but not at all."
-msgstr ""
+msgstr "你可能会觉得这很恶心，其实也还行吧"
 
 #. Key:	C9B4EBAD46E07D79B09C1DBE7BE0F774
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_UpHere.Default__RomyDefault01_UpHere_C.SessionData.Lines(3).Lines
@@ -10770,14 +10772,14 @@ msgstr "标准体型"
 #: /Game/Dialogue/Autumn/Default/DryadFlowers.Default__DryadFlowers_C.SessionData.Lines(2).Lines
 msgctxt ",CA7A7B57487A850B58D2F18581846801"
 msgid "Lets see. The flowers native to the Hivelands are cuminus-labialata and ejaculum-phallis."
-msgstr ""
+msgstr "让我们看看。原产于蜂巢大地的花有唇丘孜然和龙之泉涌。"
 
 #. Key:	CA7FAE6645EB660782FB59BB2F359378
 #. SourceLocation:	/Game/Ranch/Upgrades/TitanCave.Default__TitanCave_C.Upgrade.TypeDisplay
 #: /Game/Ranch/Upgrades/TitanCave.Default__TitanCave_C.Upgrade.TypeDisplay
 msgctxt ",CA7FAE6645EB660782FB59BB2F359378"
 msgid "Nephelym Barn"
-msgstr ""
+msgstr "魔弗灵农场"
 
 #. Key:	CA8A7F834A44AD0FFD7433BCE63D2DF7
 #. SourceLocation:	/Game/Characters/Procedural/Variants/Starfallen/Harvest/StarfallenHarvest.Default__StarfallenHarvest_C.Harvest.RaceName
@@ -10791,63 +10793,63 @@ msgstr "星陨人"
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",CAB7654B473208B56B23F8857B8CBCA0"
 msgid "Careful human, a Kraken's lust is not to be underestimated."
-msgstr "当心了人类，海妖的欲望可是不能小瞧的"
+msgstr "当心了人类，海妖的欲望可不容小觑！"
 
 #. Key:	CAC37D3345B82EE95615E0BB5C42ED5B
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleTittyPony_T.Default__KybeleTittyPony_T_C.SessionData.LinesToMale(1).LinesToMale
 #: /Game/Dialogue/Kybele/Default/KybeleTittyPony_T.Default__KybeleTittyPony_T_C.SessionData.LinesToMale(1).LinesToMale
 msgctxt ",CAC37D3345B82EE95615E0BB5C42ED5B"
 msgid "It's been sometime since I have been mouted, so I might get rough!"
-msgstr ""
+msgstr "我已经有一段时间没活动活动了，所以我可能会变得粗暴的哟！"
 
 #. Key:	CADDB09246D63E86CBE17C8852675D4B
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01_RL_F.Default__FernDefault01_RL_F_C.ResponseData(4).ResponseData.BreederPrompt
 #: /Game/Dialogue/Fern/Default/FernDefault01_RL_F.Default__FernDefault01_RL_F_C.ResponseData(4).ResponseData.BreederPrompt
 msgctxt ",CADDB09246D63E86CBE17C8852675D4B"
 msgid "The Queen Bee demands flowers."
-msgstr ""
+msgstr "蜂后渴望鲜花的簇拥。"
 
 #. Key:	CADF79DB4BDC5031DE5FA79A12695348
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiCave.Default__FesssiCave_C.SessionData.Lines(7).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiCave.Default__FesssiCave_C.SessionData.Lines(7).Lines
 msgctxt ",CADF79DB4BDC5031DE5FA79A12695348"
 msgid "If you are heading down there, you will no doubt confront Widow. Don't let her frighten you... trust me, she knows how to please. Hiss!"
-msgstr ""
+msgstr "如果你一定要去那里，你无疑会遇到寡妇的。别被她吓到你……相信我，她知道怎么取悦别人。嘶嘶！"
 
 #. Key:	CB48004E4E339F82564495A0A7D0209C
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcDefault02_RL.Default__OrcDefault02_RL_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/OrcChief/Default/OrcDefault02_RL.Default__OrcDefault02_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",CB48004E4E339F82564495A0A7D0209C"
 msgid "I've gone through worse."
-msgstr ""
+msgstr "我经历过更糟的."
 
 #. Key:	CB4B328646049F44CA1AF5B3E7454C29
 #. SourceLocation:	/Game/Ranch/Upgrades/VulwargKennel.Default__VulwargKennel_C.Upgrade.Description
 #: /Game/Ranch/Upgrades/VulwargKennel.Default__VulwargKennel_C.Upgrade.Description
 msgctxt ",CB4B328646049F44CA1AF5B3E7454C29"
 msgid "This allows you to catch and store all variants of Vulwarg."
-msgstr ""
+msgstr "这允许你捕获并饲养全部的狼人族"
 
 #. Key:	CB6197724E6737AA23A5DD991AD65537
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_YourMusic.Default__RomyDefault01_YourMusic_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/Romy/Default/RomyDefault01_YourMusic.Default__RomyDefault01_YourMusic_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",CB6197724E6737AA23A5DD991AD65537"
 msgid "With my delicate fingers, I shall play your vagina like an instrument"
-msgstr ""
+msgstr "我要用我纤细的手指，像演奏乐器一样弹奏你的阴道"
 
 #. Key:	CB65DAA6419D0E0F4ADF968694F481DD
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcDefault01_RL.Default__OrcDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/OrcChief/Default/OrcDefault01_RL.Default__OrcDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",CB65DAA6419D0E0F4ADF968694F481DD"
 msgid "Fix your own gate!"
-msgstr ""
+msgstr "修好属于你们自己的门!"
 
 #. Key:	CB9F33B74B20BE432B5B2D991CAF7A38
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowScary.Default__WidowScary_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Widow/Default/WidowScary.Default__WidowScary_C.SessionData.Lines(3).Lines
 msgctxt ",CB9F33B74B20BE432B5B2D991CAF7A38"
 msgid "My kind are so feared, yet we are the same. I seek only love and companionship here in my web of solitude."
-msgstr ""
+msgstr "他们一直很惧怕我，但是其实我们是一样。我们只想在独处的网中，寻求相爱与长相厮守。"
 
 #. Key:	CBCA7A624672A12A721B83B16D8F5A02
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToMale(4).LinesToMale
@@ -10868,28 +10870,28 @@ msgstr "当然了，她一出现我们就云雨了……很久。我向她昭示
 #: /Game/Dialogue/DragonMatriarch/Default/DMHadSex01.Default__DMHadSex01_C.SessionData.LinesToFuta(3).LinesToFuta
 msgctxt ",CC453F864879B9206AA86C866817E4F7"
 msgid "Do come back... my deep dragon pussy yearns for more."
-msgstr ""
+msgstr "我深深的龙阴不断地渴求着你……一定要回来。"
 
 #. Key:	CC8A60E34A4F302BEBD0CCB8D0F5B282
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiDefault03_RL_T.Default__FesssiDefault03_RL_T_C.ResponseData(3).ResponseData.BreederPrompt
 #: /Game/Dialogue/Fesssi/Default/FesssiDefault03_RL_T.Default__FesssiDefault03_RL_T_C.ResponseData(3).ResponseData.BreederPrompt
 msgctxt ",CC8A60E34A4F302BEBD0CCB8D0F5B282"
 msgid "I want to have fun with your ass!"
-msgstr ""
+msgstr "我想要好好享受一下你的屁股！"
 
 #. Key:	CCBDEE9E4366EC8D550F4DB7D8C546F8
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaFaleneWeek.Default__CamillaFaleneWeek_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaFaleneWeek.Default__CamillaFaleneWeek_C.SessionData.Lines(4).Lines
 msgctxt ",CCBDEE9E4366EC8D550F4DB7D8C546F8"
 msgid "Then I pose seductively in front whatever she brought back, and she records how it reacts."
-msgstr ""
+msgstr "然后我在她带回来的东西前摆出挑逗的姿势，她记录下了它的反应。"
 
 #. Key:	CCFE0CB04C0DD4BC550FE6AF03BFABB3
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R05.Default__FaleneDefault01_R05_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R05.Default__FaleneDefault01_R05_C.SessionData.Lines(1).Lines
 msgctxt ",CCFE0CB04C0DD4BC550FE6AF03BFABB3"
 msgid "Elves are part of the Sylvan race, a large @MONSTER_RACE@ family that spans all sorts! There's lots of different types of elves, but my kind are the cutest I think!"
-msgstr "精灵是Sylvan的一部分，是魔弗灵中最庞大的种族！有许多种精灵，不过我觉得我们异色精灵最可爱！"
+msgstr "精灵是森林住民的一部分，是魔弗灵中最庞大的种族！有许多种精灵，不过我觉得我们异色精灵最可爱！"
 
 #. Key:	CD24CE384C0548CF493A43A0F88CB7A2
 #. SourceLocation:	/Game/Dialogue/Emissary/SexScenes/EmissaryAngelGroinLove.Default__EmissaryAngelGroinLove_C.SessionData.LinesToMale(0).LinesToMale
@@ -10903,28 +10905,28 @@ msgstr "纵享这一切吧，因为吾侍服于汝。"
 #: /Game/Breeding/Positions/Cowgirl.Default__Cowgirl_C.SessionData.Description
 msgctxt ",CD8C53FE4EAFB9508679088ACC31A4CD"
 msgid "The receiver bounces up and down while facing the giver."
-msgstr ""
+msgstr "当被恩赐者面对播种者时，他会上下起伏的运动，仿佛牛仔骑乘一般"
 
 #. Key:	CDE042544846EA4EE23B56B0BA650104
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiDefault01.Default__FesssiDefault01_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiDefault01.Default__FesssiDefault01_C.SessionData.Lines(2).Lines
 msgctxt ",CDE042544846EA4EE23B56B0BA650104"
 msgid "My sister Neela is probably worried by now."
-msgstr ""
+msgstr "我的姐妹妮拉现在可能很担心吧。"
 
 #. Key:	CDEBE2FD40DC775E9639A299E9BF3B83
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeAboutBees.Default__BeeAboutBees_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/QueenBee/Default/BeeAboutBees.Default__BeeAboutBees_C.SessionData.Lines(2).Lines
 msgctxt ",CDEBE2FD40DC775E9639A299E9BF3B83"
 msgid "When consumed by the queen, the mixture will cause her breasts to grow and make honey. Only the queen's breasts can produce honey."
-msgstr ""
+msgstr "当蜂后享用这种混合物后，她乳房就会变大，酿出蜂蜜。只有蜂后的乳房才会产出蜂蜜。"
 
 #. Key:	CDF29C5A40823CB4D1E542912EBC57B8
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcTribeSucks.Default__OrcTribeSucks_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcTribeSucks.Default__OrcTribeSucks_C.SessionData.Lines(0).Lines
 msgctxt ",CDF29C5A40823CB4D1E542912EBC57B8"
 msgid "*Snarl*"
-msgstr ""
+msgstr "*咆哮*"
 
 #. Key:	CE27DDF94397A475B6331E9CAF6EB7C5
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToMale(3).LinesToMale
@@ -10938,21 +10940,21 @@ msgstr "啊哈…没错。我的欲望涌上来了。想用我的肉体放纵一
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFuta(23).LinesToFuta
 msgctxt ",CE3354BC4C98FE63B630758F10560253"
 msgid "Blessed @MONSTER_RACE@ like me have human-level intelligence. Sometimes even greater!"
-msgstr "同我一样受神庇佑而开智的魔弗灵则和人类一般聪明。有些甚至更聪明"
+msgstr "同我一样受神庇佑而开智的魔弗灵则和人类一般聪明。有些甚至比人类更聪明！"
 
 #. Key:	CE3738E344825C4371847CB9F0E4445E
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDefault01_WhatCanBuild.Default__CassieDefault01_WhatCanBuild_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Cassie/Default/CassieDefault01_WhatCanBuild.Default__CassieDefault01_WhatCanBuild_C.SessionData.Lines(0).Lines
 msgctxt ",CE3738E344825C4371847CB9F0E4445E"
 msgid "I can build anything your genitalia desires!"
-msgstr "我可以实现下列你想要的任何愿望！"
+msgstr "我可以做任何你的大鸡鸡想做的事情！"
 
 #. Key:	CE38F80044474A7AE6C3A68384DE4350
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadHaveKeystone.Default__DryadHaveKeystone_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Autumn/Default/DryadHaveKeystone.Default__DryadHaveKeystone_C.SessionData.Lines(1).Lines
 msgctxt ",CE38F80044474A7AE6C3A68384DE4350"
 msgid "You can have it if you help me with a little problem."
-msgstr ""
+msgstr "如果你帮我解决点小问题，就可以送给你。"
 
 #. Key:	CE50C843466352316F4461BC2722C00E
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(18 - Value).TraitIcons.HelpText
@@ -10966,28 +10968,28 @@ msgstr "养育有方：后代的属性值增加20%"
 #: /Game/Dialogue/OrcChief/Default/OrcHaveKeystone.Default__OrcHaveKeystone_C.SessionData.Lines(1).Lines
 msgctxt ",CE59EDA9407017D7F23359822FA77A1D"
 msgid "Serve tribe first, or even better bring my tribe mates!"
-msgstr ""
+msgstr "先为部落服务，或者最好是把我的部落伙伴带来!"
 
 #. Key:	CE6754D34D354921713D50B1F67C0F01
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_RL.Default__ParvatiDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_RL.Default__ParvatiDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
 msgctxt ",CE6754D34D354921713D50B1F67C0F01"
 msgid "I... uh... \"forgot\" a teaching."
-msgstr ""
+msgstr "我……呃……忘……忘记了你的教导……"
 
 #. Key:	CE86D5D34609962D9883CD82312DAC88
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMWantHuman.Default__DMWantHuman_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMWantHuman.Default__DMWantHuman_C.SessionData.Lines(5).Lines
 msgctxt ",CE86D5D34609962D9883CD82312DAC88"
 msgid "Are you sure you can handle this human?"
-msgstr ""
+msgstr "你确定你能搞定这个人类吗?"
 
 #. Key:	CEB5AB8346357320346305B899A9C7BB
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeHaveKeystone.Default__BeeHaveKeystone_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/QueenBee/Default/BeeHaveKeystone.Default__BeeHaveKeystone_C.SessionData.Lines(3).Lines
 msgctxt ",CEB5AB8346357320346305B899A9C7BB"
 msgid "Long ago, large flowers grew here. The nectar they produced was worthy of the Goddess Herself."
-msgstr ""
+msgstr "很久以前，这里生长着巨大的花朵。它们生产的花蜜配得上女神祂本人。"
 
 #. Key:	CEC4092D45D0DBE6546A729EE34F0267
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_AboutMusic.Default__RomyDefault01_AboutMusic_C.SessionData.Lines(3).Lines
@@ -11001,14 +11003,14 @@ msgstr "我们的歌声能达到一种十分美妙的境界，人耳只要听见
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03.Default__FernDefault03_C.SessionData.LinesToFuta(3).LinesToFuta
 msgctxt ",CEC660F240FC0F1941C19ABA02D18068"
 msgid "Let me wrap my lips around that fat cock of yours, my body longs for your warm cum."
-msgstr ""
+msgstr "让我用我的嘴唇包住您的肥鸡鸡，我的身体在索求着您温暖的射精。"
 
 #. Key:	CECD706A47419BAE65A5B3979BEFCA77
 #. SourceLocation:	/Game/Dialogue/Yasmine/Default/YasmineAwake.Default__YasmineAwake_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Yasmine/Default/YasmineAwake.Default__YasmineAwake_C.SessionData.Lines(2).Lines
 msgctxt ",CECD706A47419BAE65A5B3979BEFCA77"
 msgid "Oh well... I suppose you can have it. I'm going to make a better one!"
-msgstr ""
+msgstr "哦……我想你可以拿走了。我会做一个更好的!"
 
 #. Key:	CEE2CED74492461582B4EB8D5D2CB4B6
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R02.Default__FaleneDefault01_R02_C.SessionData.Lines(11).Lines
@@ -11022,7 +11024,7 @@ msgstr "不只是极度的欢愉，还有能够帮助你完成任务的道具。
 #: /Game/Dialogue/OrcChief/Default/OrcHaveKeystone.Default__OrcHaveKeystone_C.SessionData.Lines(3).Lines
 msgctxt ",CF2AA32C438E34A279D2A599B0899492"
 msgid "Breed my tribe a fertile female that we can share. A soft cow, but not lazy one from pastures!"
-msgstr ""
+msgstr "给我的部落生一个我们可以共享的丰满的女人。柔软的母牛，但不是来自牧场的懒牛!"
 
 #. Key:	CF30D7124F42031F52DA0DA6849D4457
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFemale(6).LinesToFemale
@@ -11036,7 +11038,7 @@ msgstr ""
 #: /Game/Dialogue/Monarch/Default/MonarchStartShySex.Default__MonarchStartShySex_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",CF8C923C4436452FD45381813CFCD1F5"
 msgid "So I can, y-y-you know... make you feel good."
-msgstr ""
+msgstr "所以我想，你……你……你懂的，让你感觉爽一下。"
 
 #. Key:	CFA095544A3BB18577988A9489DE24CC
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruGreeting01.Default__MirruGreeting01_C.SessionData.Lines(0).Lines
@@ -11050,77 +11052,77 @@ msgstr "这么说，这一切都是真的。还真是个行走于旱地的人类
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R03.Default__FaleneDefault01_R03_C.SessionData.Lines(3).Lines
 msgctxt ",CFB4BE294E1D3D81CE72719BCB08B1C7"
 msgid "You know, the floating busty winged statues with the sparkles... I will admit I get all tingly inside around them too!"
-msgstr ""
+msgstr "你懂的，，微微颤抖的双乳、长着翅膀的、闪闪发光如同雕像一般。。。我得承认，我在他们周围也会很兴奋！"
 
 #. Key:	CFBBDFD5421C17E7EB1CBBB86EEBD93C
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraAboutPawsmaati.Default__PetraAboutPawsmaati_C.SessionData.Lines(7).Lines
 #: /Game/Dialogue/Petra/Default/PetraAboutPawsmaati.Default__PetraAboutPawsmaati_C.SessionData.Lines(7).Lines
 msgctxt ",CFBBDFD5421C17E7EB1CBBB86EEBD93C"
 msgid "Through orgasm, she can impart a tiny fraction of her knowlege to her partner."
-msgstr ""
+msgstr "通过潮吹，她可以把她的一小部分知识传授给她的做爱对象。"
 
 #. Key:	CFDBD54945D68B87A04B7B9DDE06F521
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R07.Default__CamillaDefault01_R07_C.SessionData.LinesToMale(1).LinesToMale
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R07.Default__CamillaDefault01_R07_C.SessionData.LinesToMale(1).LinesToMale
 msgctxt ",CFDBD54945D68B87A04B7B9DDE06F521"
 msgid "Amber's tits are bigger than me! Why is this world so cruel..."
-msgstr "安布尔的胸部比我大!为什么这个世界如此残酷……"
+msgstr "为什么安布尔的奶子比我的大!这个世界太残酷了……"
 
 #. Key:	D016E93F4A87C5706D65B1A5E101B0C6
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernHadSex02.Default__FernHadSex02_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Fern/DefaultP2/FernHadSex02.Default__FernHadSex02_C.SessionData.Lines(1).Lines
 msgctxt ",D016E93F4A87C5706D65B1A5E101B0C6"
 msgid "More! More!"
-msgstr ""
+msgstr "我还要！再来！"
 
 #. Key:	D039FDFA4AB60D6ABD3384AEF3348588
 #. SourceLocation:	/Game/UI/TaskDescriptions.TaskDescriptions.TextEntries(1).TextEntries
 #: /Game/UI/TaskDescriptions.TaskDescriptions.TextEntries(1).TextEntries
 msgctxt ",D039FDFA4AB60D6ABD3384AEF3348588"
 msgid "It's study time! And by that I mean bring me the most well-endowed Nephelym you can breed. As much as I would like to say this study is about furthering the endless endeavor that is science, no I am horny as hell and want you to fix it! Sure, sex twenty times a day is fun and all, but it's not enough. This one will be for... personal alone time at night. Humans can't possibly understand! The desires don't ever stop!!  -Falene"
-msgstr ""
+msgstr "现在是学习时间!我的意思是给我带来你所能培育的最壮硕的魔弗灵。我想说的是，这项研究是为了进一步推动科学这一永无止境的努力，不，我需要你帮我解决我如同地狱一般的欲火难耐，当然，一天20次的性爱很有趣，但这还不够。这一次是为了……晚上的私人独处时间。人类不可能理解!欲望永远不会停止!!——法莲娜"
 
 #. Key:	D03FE11A4B475C76629C24AF0C738457
 #. SourceLocation:	/Game/Ranch/Upgrades/FormurianPond.Default__FormurianPond_C.Upgrade.DisplayName
 #: /Game/Ranch/Upgrades/FormurianPond.Default__FormurianPond_C.Upgrade.DisplayName
 msgctxt ",D03FE11A4B475C76629C24AF0C738457"
 msgid "Formurian Pond"
-msgstr ""
+msgstr "深海族池塘"
 
 #. Key:	D05595AA4F7337C7E43FD59874E5E624
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleCentaur.Default__KybeleCentaur_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Kybele/Default/KybeleCentaur.Default__KybeleCentaur_C.SessionData.Lines(2).Lines
 msgctxt ",D05595AA4F7337C7E43FD59874E5E624"
 msgid "Centaurs can get aggressive when we haven't released for an extended period of time."
-msgstr ""
+msgstr "当我们很长一段时间没有活动活动时，半人马会变得很有攻击性。"
 
 #. Key:	D066439244AFE855B06F90AB1A4A0829
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TravelShrines(8 - Value).TravelShrines.ShrineName
 #: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TravelShrines(8 - Value).TravelShrines.ShrineName
 msgctxt ",D066439244AFE855B06F90AB1A4A0829"
 msgid "Sultry Plateau"
-msgstr "潮热高地"
+msgstr "潮热高原"
 
 #. Key:	D0AFE2FE43D96C0225B202A9DF9DC0CB
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleHadSex01.Default__KybeleHadSex01_C.SessionData.LinesToFemale(2).LinesToFemale
 #: /Game/Dialogue/Kybele/Default/KybeleHadSex01.Default__KybeleHadSex01_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",D0AFE2FE43D96C0225B202A9DF9DC0CB"
 msgid "You paid the price, now you are filled with a giant load of centaur cum."
-msgstr ""
+msgstr "你付出了代价，现在你身上被射满了半人马的精液。"
 
 #. Key:	D0D371BB447B4CD8A5A17682F596B922
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDungeon.Default__CamillaDungeon_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaDungeon.Default__CamillaDungeon_C.SessionData.Lines(0).Lines
 msgctxt ",D0D371BB447B4CD8A5A17682F596B922"
 msgid "Do I look like a civil engineer?!!"
-msgstr ""
+msgstr "我看起来像土木工程师吗？！！"
 
 #. Key:	D0DE0CF44CDB98087C882AA54375F7BD
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleTittyPony_T.Default__KybeleTittyPony_T_C.SessionData.LinesToFemale(2).LinesToFemale
 #: /Game/Dialogue/Kybele/Default/KybeleTittyPony_T.Default__KybeleTittyPony_T_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",D0DE0CF44CDB98087C882AA54375F7BD"
 msgid "That should teach you to cross this titty po--I mean mighty centaur warmaiden, again!"
-msgstr ""
+msgstr "这再一次教会你如何深入这个大奶驹……——我是说！强大的半人马女战士！"
 
 #. Key:	D0FA90CC4E9378DF7150FB881B18DC60
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(5 - Value).TraitIcons.HelpText
@@ -11148,7 +11150,7 @@ msgstr "您是……嘶这片土地的领主…对吗嘶？"
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeGreeting01.Default__MegaSlimeGreeting01_C.SessionData.Lines(0).Lines
 msgctxt ",D177C30A4E176DA263EBCDB1F6E13158"
 msgid "Wow a visitor!"
-msgstr ""
+msgstr "哇哦，一位访客！"
 
 #. Key:	D18F5F504013858974D982AA49D9035F
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R02.Default__FaleneDefault01_R02_C.SessionData.Lines(13).Lines
@@ -11162,28 +11164,28 @@ msgstr "我现在正在抵抗那种欲望……"
 #: /Game/Dialogue/Autumn/Default/DryadBossomCherries.Default__DryadBossomCherries_C.SessionData.Lines(0).Lines
 msgctxt ",D195ECC34D71382CA65FD091CD7680D5"
 msgid "It's the giant red fruit you see all over the pastures. Everyone was crafted with love by me."
-msgstr ""
+msgstr "那是遍布牧场的巨大的红色水果。每个人都是我用爱精心培养的"
 
 #. Key:	D1984E71418CEF4F3D39AC911B217790
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_Formuria.Default__MirruDefault01_Formuria_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_Formuria.Default__MirruDefault01_Formuria_C.SessionData.Lines(1).Lines
 msgctxt ",D1984E71418CEF4F3D39AC911B217790"
 msgid "Many aquatic @MONSTER_RACE@ inhabit our fair kingdom, but only Krakens have the might and will to rule."
-msgstr "平等居住在我国的水栖魔弗灵为数众多，然而有能力和意愿去治理她的，只有海妖族。"
+msgstr "居住在我们公平的国家里的水栖魔弗灵相当多，但是只有克拉肯一族才有力量和意志去统治。"
 
 #. Key:	D1B21A3544F4242222944E97EA03E1BB
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMHadSex01.Default__DMHadSex01_C.SessionData.LinesToFemale(3).LinesToFemale
 #: /Game/Dialogue/DragonMatriarch/Default/DMHadSex01.Default__DMHadSex01_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",D1B21A3544F4242222944E97EA03E1BB"
 msgid "Do come back... my cock will be waiting."
-msgstr ""
+msgstr "一定要回来啊……我的大鸡巴一直在等着呢。"
 
 #. Key:	D1E7FBF645BBEB29F682D5A4FAB6A2A5
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiWantTongue.Default__FesssiWantTongue_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiWantTongue.Default__FesssiWantTongue_C.SessionData.Lines(0).Lines
 msgctxt ",D1E7FBF645BBEB29F682D5A4FAB6A2A5"
 msgid "How interesting. Hiss!"
-msgstr ""
+msgstr "真有趣啊，嘶！"
 
 #. Key:	D1FC026043E82386A07099A46452AB0F
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R04.Default__FaleneDefault01_R04_C.SessionData.Lines(13).Lines
@@ -11197,63 +11199,63 @@ msgstr "这就是为什么我们如此渴望性——它是如此令人满足，
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03_R04.Default__FernDefault03_R04_C.SessionData.Lines(0).Lines
 msgctxt ",D202E32F436700405E2417A73206A501"
 msgid "Oh Master... I have waited for this."
-msgstr ""
+msgstr "噢主人……我等的就是这个"
 
 #. Key:	D209ED1D49C6A4C6106AC69A3100D415
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01_R02_R01.Default__FernDefault01_R02_R01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Fern/Default/FernDefault01_R02_R01.Default__FernDefault01_R02_R01_C.SessionData.Lines(1).Lines
 msgctxt ",D209ED1D49C6A4C6106AC69A3100D415"
 msgid "When mastah not want harvest... Fern do it."
-msgstr "当主人不想干活时……嘶嘶…小蕨来帮您。"
+msgstr "当主人不想去收获的时候……嘶嘶…小蕨来替您代劳。"
 
 #. Key:	D251615D4084E3BFFB18D4B26806806F
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMWantHuman.Default__DMWantHuman_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMWantHuman.Default__DMWantHuman_C.SessionData.Lines(2).Lines
 msgctxt ",D251615D4084E3BFFB18D4B26806806F"
 msgid "I admit, it is quite tempting. Humans were a myth until I met you."
-msgstr ""
+msgstr 我承认，这很诱人。在我遇见你之前，人类只是个传说。"
 
 #. Key:	D2843C204C6DDAA26611B0B57F67BC41
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcBrashDumb.Default__OrcBrashDumb_C.SessionData.Lines(6).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcBrashDumb.Default__OrcBrashDumb_C.SessionData.Lines(6).Lines
 msgctxt ",D2843C204C6DDAA26611B0B57F67BC41"
 msgid "Grrrrrr! Me human!"
-msgstr ""
+msgstr "咕噜噜噜！我（的）人类！"
 
 #. Key:	D2C5AD664FCA892932A70188B37B1378
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFemale(4).LinesToFemale
 #: /Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFemale(4).LinesToFemale
 msgctxt ",D2C5AD664FCA892932A70188B37B1378"
 msgid "..."
-msgstr ""
+msgstr "……"
 
 #. Key:	D2DF40244F8B96F91F4101A5AD5F08AA
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaGreeting01.Default__CamillaGreeting01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaGreeting01.Default__CamillaGreeting01_C.SessionData.Lines(1).Lines
 msgctxt ",D2DF40244F8B96F91F4101A5AD5F08AA"
 msgid "I'm Camilla! Falene's little goblin assistant! You probably won't need to talk to me much because she's the smart one around here."
-msgstr "我是小小蜜拉！法莲娜的小哥布林助手！你也许不需要和我说太多话，因为法莲娜是这里最聪慧的魔弗灵！"
+msgstr "我是卡米拉！法莲娜的小哥布林助手！你也许不需要和我说太多话，因为法莲娜是这里最博学的魔弗灵！"
 
 #. Key:	D2F9DD5648274637A18B9A8777C5CF03
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeDefault01_RL.Default__MegaSlimeDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeDefault01_RL.Default__MegaSlimeDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",D2F9DD5648274637A18B9A8777C5CF03"
 msgid "About that orb..."
-msgstr ""
+msgstr "关于那个球…"
 
 #. Key:	D3139F1545004EAAF227C0A0C62B74E9
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMDefault_RL2.Default__DMDefault_RL2_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/DragonMatriarch/Default/DMDefault_RL2.Default__DMDefault_RL2_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",D3139F1545004EAAF227C0A0C62B74E9"
 msgid "Tell me about dragons!"
-msgstr ""
+msgstr "跟我讲讲龙族的事情吧！"
 
 #. Key:	D320A28645DC907082F6169F08223AA5
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault02.Default__CamillaDefault02_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaDefault02.Default__CamillaDefault02_C.SessionData.Lines(0).Lines
 msgctxt ",D320A28645DC907082F6169F08223AA5"
 msgid "Oh great Falene is back."
-msgstr ""
+msgstr "噢，伟大的法莲娜又回来了。"
 
 #. Key:	D395A99C4C2FAC4029FBE0A0AACFDE16
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_Leylanna.Default__EmissaryDefault01_Leylanna_C.SessionData.Lines(3).Lines
@@ -11267,14 +11269,14 @@ msgstr "她被神明的笑意笼罩，亦将担任大祭司之职。"
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(18).LinesToFemale
 msgctxt ",D3E9009E43E0327FC24371950104BD21"
 msgid "*Sigh* As you can tell, we @MONSTER_RACE@ have extremely intense sexual desires."
-msgstr "*叹气*如你所见，我们魔弗灵有着异常旺盛的性欲。"
+msgstr "*叹气*如你所见，我们魔弗灵有着异常高昂的性欲。"
 
 #. Key:	D3EBA5FE4F8C935CB40680BE9D7ED27E
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadHaveKeystone2.Default__DryadHaveKeystone2_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Autumn/Default/DryadHaveKeystone2.Default__DryadHaveKeystone2_C.SessionData.Lines(1).Lines
 msgctxt ",D3EBA5FE4F8C935CB40680BE9D7ED27E"
 msgid "I see I've been slacking off and let my roots overtake the gate to the cove."
-msgstr ""
+msgstr "瞧，我一直在懈怠，让我的爬上了海湾的大门。"
 
 #. Key:	D3EBB7904D4648D8930D5B98189AC73D
 #. SourceLocation:	/Game/Characters/Procedural/Variants/Hybrid/Harvest/HybridHarvest.Default__HybridHarvest_C.Harvest.RaceName
@@ -11288,21 +11290,21 @@ msgstr "混血族"
 #: /Game/Breeding/Positions/Waterfall.Default__Waterfall_C.SessionData.Description
 msgctxt ",D43D63CB4B6E7B157FD06E89C537F572"
 msgid "The giver's lower half is elevated while the receiver balances on top."
-msgstr ""
+msgstr "播种者的下半身被抬高，而受恩赐者在上身保持平衡，呈现瀑布式的倒挂。"
 
 #. Key:	D456D54240773E6C7DA921A0B4BDBA16
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_R04.Default__FernDefault02_R04_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02_R04.Default__FernDefault02_R04_C.SessionData.Lines(1).Lines
 msgctxt ",D456D54240773E6C7DA921A0B4BDBA16"
 msgid "I need human milk to grow into my final form. Your soft breasts will be emptied as I suck every drop."
-msgstr ""
+msgstr "我需要人类的乳汁才能成长为我的最终形态。我会吮吸掏空您柔软的乳房。"
 
 #. Key:	D48D138B4D55F9A604E2E0AFFACE1674
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernGreeting02.Default__FernGreeting02_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/Fern/DefaultP2/FernGreeting02.Default__FernGreeting02_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",D48D138B4D55F9A604E2E0AFFACE1674"
 msgid "Look at my beautiful flower, it bloomed! Oh my did it feel weird..."
-msgstr ""
+msgstr "快看看我美丽的花它开放了!哦，天哪，是不是感觉怪怪的……"
 
 #. Key:	D4B876E04002BC56FF720D829DA04785
 #. SourceLocation:	/Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToFemale(6).LinesToFemale
@@ -11323,7 +11325,7 @@ msgstr "马上……啊……粘腻海妖带来的快感会将你吞没……"
 #: /Game/Dialogue/DragonMatriarch/Default/DMClimaxPeak.Default__DMClimaxPeak_C.SessionData.Lines(5).Lines
 msgctxt ",D4E7C4CC40DA7F02F81C91A5CFBF13E8"
 msgid "Bring me Bovaur milk, and lots of it."
-msgstr ""
+msgstr "给我来点奶牛娘的奶吧，不是一点点。"
 
 #. Key:	D4F1F3F04E4BCBC46FFF2E9AC9B301C0
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_RechargeSpiritForm_RL_T.Default__LeylannaDefault01_RechargeSpiritForm_RL_T_C.ResponseData(0).ResponseData.BreederPrompt
@@ -11337,35 +11339,35 @@ msgstr "我们做爱吧！"
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_EnlightenedOne.Default__NeelaDefault01_EnlightenedOne_C.SessionData.Lines(4).Lines
 msgctxt ",D5061B2C431228573CA43DB6C61F5511"
 msgid "Few @MONSTER_RACE@ are older than I, but Pawsmaati is an exception."
-msgstr ""
+msgstr "很少有魔弗灵比我更老，但是帕丝玛媞是个例外。"
 
 #. Key:	D52E88834BD47EFB47BD74839CEEB65D
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadDefault01_RL.Default__DryadDefault01_RL_C.ResponseData(4).ResponseData.BreederPrompt
 #: /Game/Dialogue/Autumn/Default/DryadDefault01_RL.Default__DryadDefault01_RL_C.ResponseData(4).ResponseData.BreederPrompt
 msgctxt ",D52E88834BD47EFB47BD74839CEEB65D"
 msgid "Can I have that keystone?"
-msgstr ""
+msgstr "我可以拿走那个钥石了吗？"
 
 #. Key:	D535E0D84F73A7E07CA72DA2ED4F1B11
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(17 - Value).TraitIcons.HelpText
 #: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(17 - Value).TraitIcons.HelpText
 msgctxt ",D535E0D84F73A7E07CA72DA2ED4F1B11"
 msgid "Meaty: Strength raises the XP granted to mates when breeding as a percentage."
-msgstr "肥硕：自身力量值将按照百分比增加交配对象得到的经验"
+msgstr "肥硕：自身力量值将按照百分比增加交配对象得到的经验。"
 
 #. Key:	D560F92446F9C63CB113458A9A0ED552
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleTaskFulfilled.Default__KybeleTaskFulfilled_C.SessionData.LinesToFemale(3).LinesToFemale
 #: /Game/Dialogue/Kybele/Default/KybeleTaskFulfilled.Default__KybeleTaskFulfilled_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",D560F92446F9C63CB113458A9A0ED552"
 msgid "She will start sucking it when I'm not paying attention, what a nice surprise!"
-msgstr ""
+msgstr "当我不注意的时候她就会偷偷吮吸它们，令我又惊又喜。"
 
 #. Key:	D57D76E842FCC75ECC756BA13E9E8C9B
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToFemale(6).LinesToFemale
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToFemale(6).LinesToFemale
 msgctxt ",D57D76E842FCC75ECC756BA13E9E8C9B"
 msgid "Let me lick that sweet human vagina of yours... yes..."
-msgstr "让我尝尝你的蜜穴，啊……"
+msgstr "让我尝尝你的人类蜜穴，啊……"
 
 #. Key:	D5A1DB2341980090F900379E1AE48051
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R01.Default__CamillaDefault01_R01_C.SessionData.Lines(4).Lines
@@ -11379,7 +11381,7 @@ msgstr "如果你不主动出击，那就等着被找上门吧！"
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_FloatRhyme.Default__ParvatiDefault01_FloatRhyme_C.SessionData.Lines(2).Lines
 msgctxt ",D5C1C3B248D402846D813ABD2800F061"
 msgid "Mentally I have sex with Her every day."
-msgstr ""
+msgstr "某种精神层面上，我天天和她啪在一起。"
 
 #. Key:	D5C1EFC54081F21A6C1F538839E450A2
 #. SourceLocation:	/Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToFuta(3).LinesToFuta
@@ -11400,21 +11402,21 @@ msgstr "你能听见我的嗯……音乐？"
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(11).LinesToMale
 msgctxt ",D5E48FA54813F998B6D165A5B2F04BF7"
 msgid "We love humans because you're special!"
-msgstr "我们简直爱死人类了，因为你们非常特别！"
+msgstr "我们简直爱死人类了，因为你与众不同！"
 
 #. Key:	D5F4BFF649C93B213245C0958C664D40
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_SpiritForm.Default__LeylannaDefault01_SpiritForm_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Leylanna/Default/LeylannaDefault01_SpiritForm.Default__LeylannaDefault01_SpiritForm_C.SessionData.Lines(0).Lines
 msgctxt ",D5F4BFF649C93B213245C0958C664D40"
 msgid "There are an infinite number of @MONSTER_RACE@ souls waiting in the Void to be born into this world."
-msgstr "那是无穷尽的魔弗灵们缱绻于虚空中等待着转生的魂灵"
+msgstr "那是无穷尽的魔弗灵们缱绻于虚空中等待着转生的魂灵。"
 
 #. Key:	D5F8F9DC452D7E14F022B7A4C04B523C
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadHaveKeystone.Default__DryadHaveKeystone_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Autumn/Default/DryadHaveKeystone.Default__DryadHaveKeystone_C.SessionData.Lines(5).Lines
 msgctxt ",D5F8F9DC452D7E14F022B7A4C04B523C"
 msgid "If you can breed me a lovely honey bee, it would be a massive help."
-msgstr ""
+msgstr "如果你能给我养一只可爱的蜜蜂，那就帮了大忙了。"
 
 #. Key:	D60B38ED43ABAC98BCB33FBB4B3477F4
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(4).LinesToFemale
@@ -11428,7 +11430,7 @@ msgstr "而我也是其中之一！准确的来说我是一名收到至高女神
 #: /Game/Dialogue/Petra/Default/PetraAboutPawsmaati.Default__PetraAboutPawsmaati_C.SessionData.Lines(0).Lines
 msgctxt ",D673B2CE4FDE4D50F057C0A033DA8F53"
 msgid "She is amazing!"
-msgstr ""
+msgstr "她棒极了！"
 
 #. Key:	D681E76840B85B19D8C08BBCF50268C8
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToFuta(3).LinesToFuta
@@ -11442,140 +11444,140 @@ msgstr "不可否认那真是令我爽翻天，但是啊…我总觉得我还缺
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_StartWaterfall.Default__ParvatiDefault01_StartWaterfall_C.SessionData.Lines(0).Lines
 msgctxt ",D6BF802E4E5B43F72E7B4F90BD61A387"
 msgid "..."
-msgstr ""
+msgstr "……"
 
 #. Key:	D6D627BB4317AEDB4A049A875CA79F63
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchQueen.Default__MonarchQueen_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Monarch/Default/MonarchQueen.Default__MonarchQueen_C.SessionData.Lines(1).Lines
 msgctxt ",D6D627BB4317AEDB4A049A875CA79F63"
 msgid "We bring her nectar and please her sexually, and in return she let's us eat of her h-h-honey."
-msgstr ""
+msgstr "我们给她花蜜，让她性福。作为回报，她让我们吃她的蜂……蜂……蜂蜜。"
 
 #. Key:	D6E5B72340D672B892908385DF8BC169
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",D6E5B72340D672B892908385DF8BC169"
 msgid "In my case, that Alchemist Guild on the surface constantly dumps fresh semen down here."
-msgstr ""
+msgstr "就我而言，陆地上的炼精术士公会经常把新鲜精液倒在这里。"
 
 #. Key:	D6ECEFA141121C7CDA69A5BAC65087CE
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMClimaxPeak.Default__DMClimaxPeak_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMClimaxPeak.Default__DMClimaxPeak_C.SessionData.Lines(0).Lines
 msgctxt ",D6ECEFA141121C7CDA69A5BAC65087CE"
 msgid "Ah, you wish to have sex with the mighty Titans; I can respect that, for I have done it many times."
-msgstr ""
+msgstr "啊，你想和坚挺的泰坦做爱，我懂你，因为我已经这样做过很多次了"
 
 #. Key:	D720325F44DF14DB1473D0A78512EB8E
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimePlay.Default__MegaSlimePlay_C.SessionData.LinesToFuta(3).LinesToFuta
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePlay.Default__MegaSlimePlay_C.SessionData.LinesToFuta(3).LinesToFuta
 msgctxt ",D720325F44DF14DB1473D0A78512EB8E"
 msgid "Well what are you waiting for? Come on in!"
-msgstr ""
+msgstr "好吧那你还在等什么？快进来吧"
 
 #. Key:	D75F1B6640E7E50789CBE7B4CBEE0FF3
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleTaskFulfilled.Default__KybeleTaskFulfilled_C.SessionData.LinesToFuta(2).LinesToFuta
 #: /Game/Dialogue/Kybele/Default/KybeleTaskFulfilled.Default__KybeleTaskFulfilled_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",D75F1B6640E7E50789CBE7B4CBEE0FF3"
 msgid "The random mounts I get when I'm not paying attention never gets old."
-msgstr ""
+msgstr "在我的胯下，你会有永远的新鲜感。"
 
 #. Key:	D76798CF4DCADF9AF42C6B88C36E27FB
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeAboutOrb_RL.Default__MegaSlimeAboutOrb_RL_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeAboutOrb_RL.Default__MegaSlimeAboutOrb_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",D76798CF4DCADF9AF42C6B88C36E27FB"
 msgid "This won't be easy..."
-msgstr ""
+msgstr "这有点难……"
 
 #. Key:	D79654914AB8CE6E58B5A28BDCFB3EBC
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToMale(5).LinesToMale
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToMale(5).LinesToMale
 msgctxt ",D79654914AB8CE6E58B5A28BDCFB3EBC"
 msgid "It's a nutritious aphrodisiac, a very powerful one so be careful!"
-msgstr ""
+msgstr "这是一种营养丰富的壮阳药，非常强效，所以要十分小心！"
 
 #. Key:	D7A6D67F4C7BFFA071AA8480399A5D41
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMHadSex01.Default__DMHadSex01_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/DragonMatriarch/Default/DMHadSex01.Default__DMHadSex01_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",D7A6D67F4C7BFFA071AA8480399A5D41"
 msgid "I can't believe it!"
-msgstr ""
+msgstr "我无法相信，惊呆了。"
 
 #. Key:	D7B87B2D4E7F9B733C981C804A0914C8
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernGreeting02.Default__FernGreeting02_C.SessionData.LinesToFemale(3).LinesToFemale
 #: /Game/Dialogue/Fern/DefaultP2/FernGreeting02.Default__FernGreeting02_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",D7B87B2D4E7F9B733C981C804A0914C8"
 msgid "My body longs for your delicious breast milk."
-msgstr ""
+msgstr "我的身体渴求着你美味的乳汁。"
 
 #. Key:	D7CBF3A849F90F40A1E899A00B974FBA
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",D7CBF3A849F90F40A1E899A00B974FBA"
 msgid "See, there is nowhere in @WORLD_NAME@ that I haven't slithered."
-msgstr "你知道的，@WORLD_NAME@处处遍布我的脚印……滑痕，如果你非要咬文嚼字的话。"
+msgstr "你知道的，@WORLD_NAME@处处遍布我的脚印……划痕，如果你非要咬文嚼字的话。"
 
 #. Key:	D7CD27D2485A136014BAEDA62F225167
 #. SourceLocation:	/Game/Breeding/Positions/Missionary.Default__Missionary_C.SessionData.Description
 #: /Game/Breeding/Positions/Missionary.Default__Missionary_C.SessionData.Description
 msgctxt ",D7CD27D2485A136014BAEDA62F225167"
 msgid "The giver lays on top of the receiver and thrusts."
-msgstr ""
+msgstr "播种者者躺在被恩赐者的上面并插入，传教士体位。"
 
 #. Key:	D7D031AA47A9423B1EE418BC71725DDA
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimePlay1.Default__MegaSlimePlay1_C.SessionData.LinesToFuta(2).LinesToFuta
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePlay1.Default__MegaSlimePlay1_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",D7D031AA47A9423B1EE418BC71725DDA"
 msgid "*Yawn* Might need a nap after we make love again."
-msgstr ""
+msgstr "我们再次做爱之后可能需要打个小盹。"
 
 #. Key:	D7D29FFE4A41A6DA230B80B0832CBC28
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcWantWrestle.Default__OrcWantWrestle_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcWantWrestle.Default__OrcWantWrestle_C.SessionData.Lines(2).Lines
 msgctxt ",D7D29FFE4A41A6DA230B80B0832CBC28"
 msgid "Chieftain very horny, you will regret this. Come here!"
-msgstr ""
+msgstr "族长浴火焚烧，你会后悔的，过来吧你！"
 
 #. Key:	D7F8B9C2431BFB6ED28ECAAF83BAE062
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03.Default__FernDefault03_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03.Default__FernDefault03_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",D7F8B9C2431BFB6ED28ECAAF83BAE062"
 msgid "Look at my beautiful flower, it bloomed! Oh my did it feel weird..."
-msgstr ""
+msgstr "快看看我美丽的花它开放了!哦，我的天，是不是感觉怪怪的……"
 
 #. Key:	D8048E504EF52CFA3D3F618130F77DB0
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleRideYou_RL.Default__KybeleRideYou_RL_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/Kybele/Default/KybeleRideYou_RL.Default__KybeleRideYou_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",D8048E504EF52CFA3D3F618130F77DB0"
 msgid "Aww what an adorable titty pony."
-msgstr ""
+msgstr "喔！多可爱的小奶驹啊！"
 
 #. Key:	D839985345EFF273DA362C9BB07DA471
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMAboutDragons.Default__DMAboutDragons_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMAboutDragons.Default__DMAboutDragons_C.SessionData.Lines(1).Lines
 msgctxt ",D839985345EFF273DA362C9BB07DA471"
 msgid "Don't be fooled by those Titans. They might seem like they own the place with their massive size and strength."
-msgstr ""
+msgstr "别被那些巨人骗了。它们庞大的体型和力量可能会让人觉得它们拥有这个地方。"
 
 #. Key:	D857E31D47711B85E634029A4E3EB6E7
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.CBGate_Breaks.PlaceMessage
 #: /Game/World/Overworld.Overworld:PersistentLevel.CBGate_Breaks.PlaceMessage
 msgctxt ",D857E31D47711B85E634029A4E3EB6E7"
 msgid "Virgin Breaks is now accessible."
-msgstr ""
+msgstr "现在可以访问落红断崖了。"
 
 #. Key:	D8702B7C4C5E95A9D843A79FCFBFB106
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeVerySad.Default__MegaSlimeVerySad_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeVerySad.Default__MegaSlimeVerySad_C.SessionData.Lines(0).Lines
 msgctxt ",D8702B7C4C5E95A9D843A79FCFBFB106"
 msgid "*Sniff*"
-msgstr ""
+msgstr "*嗅*"
 
 #. Key:	D87AAD604344FB1EAE2D0F9DCC51E7EA
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleHaveKeystone2.Default__KybeleHaveKeystone2_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Kybele/Default/KybeleHaveKeystone2.Default__KybeleHaveKeystone2_C.SessionData.Lines(1).Lines
 msgctxt ",D87AAD604344FB1EAE2D0F9DCC51E7EA"
 msgid "But don't tell the Dragon Matriarch!"
-msgstr ""
+msgstr "可千万不要让女族长知道！"
 
 #. Key:	D8A6098049B17D17442735B4FDBAB323
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_FutaBalls.Default__FaleneDefault01_FutaBalls_C.SessionData.Lines(2).Lines
@@ -11589,21 +11591,21 @@ msgstr "当你思考到进化的下一阶段时，你会发现这真是非常优
 #: /Game/Dialogue/Petra/Default/PetraGetKeystone.Default__PetraGetKeystone_C.SessionData.Lines(2).Lines
 msgctxt ",D8ADF7FF4D4119D1628F44BF0E97521A"
 msgid "Pawsmaati tasked me with practicing my recent lesson with a succubus."
-msgstr ""
+msgstr "帕丝玛媞让我和一个魅魔一起复习我最近的课程。"
 
 #. Key:	D8D64A6444112501D1C4728A0BB65EB7
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_R02.Default__FernDefault02_R02_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02_R02.Default__FernDefault02_R02_C.SessionData.Lines(1).Lines
 msgctxt ",D8D64A6444112501D1C4728A0BB65EB7"
 msgid "I grow more voluptuous and beautiful everyday, and it feels so good..."
-msgstr ""
+msgstr "我变得越来越性感和美丽，这感觉太美妙了……"
 
 #. Key:	D8F0F94A480E7784CAF965A42BDDDC9A
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeDefault01_RL.Default__MegaSlimeDefault01_RL_C.ResponseData(3).ResponseData.BreederPrompt
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeDefault01_RL.Default__MegaSlimeDefault01_RL_C.ResponseData(3).ResponseData.BreederPrompt
 msgctxt ",D8F0F94A480E7784CAF965A42BDDDC9A"
 msgid "How are slimes made?"
-msgstr ""
+msgstr "史莱姆的粘液是怎么产生的？"
 
 #. Key:	D8F23CE1423B47137E2603AC9C522535
 #. SourceLocation:	/Game/Dialogue/Cassie/SexScenes/CassieSplintersT.Default__CassieSplintersT_C.SessionData.Lines(4).Lines
@@ -11617,49 +11619,49 @@ msgstr "*咕噜咕噜声*"
 #: /Game/Dialogue/AmberMae/Default/AmberMaeHadSex01.Default__AmberMaeHadSex01_C.SessionData.Lines(2).Lines
 msgctxt ",D9124E55481B91E85A0884AA58197D19"
 msgid "'Mai milk was tasty aye? Plenty more where that came from!"
-msgstr ""
+msgstr "俺的奶很好喝，是嘛？俺的乳房里还有很多！"
 
 #. Key:	D913C6254D30AA08E8B01787AE3D1B68
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TravelShrines(4 - Value).TravelShrines.ShrineName
 #: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TravelShrines(4 - Value).TravelShrines.ShrineName
 msgctxt ",D913C6254D30AA08E8B01787AE3D1B68"
 msgid "Hivelands"
-msgstr "蜂巢大陆"
+msgstr "蜂巢大地"
 
 #. Key:	D942BF8C4B6164B1D4F7569E55FC349E
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03_R03.Default__FernDefault03_R03_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03_R03.Default__FernDefault03_R03_C.SessionData.Lines(0).Lines
 msgctxt ",D942BF8C4B6164B1D4F7569E55FC349E"
 msgid "Oh Master... you are too good to me."
-msgstr ""
+msgstr "噢，主人……您对我太好了"
 
 #. Key:	D946784E4574F80408FA7D82B80E4EAC
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadCherryHelp.Default__DryadCherryHelp_C.SessionData.LinesToMale(2).LinesToMale
 #: /Game/Dialogue/Autumn/Default/DryadCherryHelp.Default__DryadCherryHelp_C.SessionData.LinesToMale(2).LinesToMale
 msgctxt ",D946784E4574F80408FA7D82B80E4EAC"
 msgid "I'm getting wet just thinking about your thick cock seeding me."
-msgstr ""
+msgstr "一想到你那粗壮的老二在我身体里播种，我就湿的不能自已。"
 
 #. Key:	D970772D478546EA5EFEA68C821EAC60
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcHadSex01.Default__OrcHadSex01_C.SessionData.LinesToFuta(2).LinesToFuta
 #: /Game/Dialogue/OrcChief/Default/OrcHadSex01.Default__OrcHadSex01_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",D970772D478546EA5EFEA68C821EAC60"
 msgid "For one so weak, human did give mighty load!"
-msgstr ""
+msgstr "这么弱小的人类，居然有那么多的子弹！"
 
 #. Key:	D98B804D4BEB2904234F77AB902776CD
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadAboutDryads.Default__DryadAboutDryads_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Autumn/Default/DryadAboutDryads.Default__DryadAboutDryads_C.SessionData.Lines(2).Lines
 msgctxt ",D98B804D4BEB2904234F77AB902776CD"
 msgid "Every dryad is blessed by the Goddess, there are no wild dryads."
-msgstr ""
+msgstr "每一个树妖都已经被女神所祝福了，所以已经没有野生的树妖了。"
 
 #. Key:	D9AEE5314A7E8A6D9F57F6B9A6116A55
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleTaskFulfilled.Default__KybeleTaskFulfilled_C.SessionData.LinesToFemale(2).LinesToFemale
 #: /Game/Dialogue/Kybele/Default/KybeleTaskFulfilled.Default__KybeleTaskFulfilled_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",D9AEE5314A7E8A6D9F57F6B9A6116A55"
 msgid "Each time she moans a little louder, I think she's starting to get addicted to my cock."
-msgstr ""
+msgstr "她呻吟的声音一次比一次大，我想她已经开始对我的鸡巴上瘾了。"
 
 #. Key:	D9AEE8B346F04D85CD643FA456C20645
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R05.Default__CamillaDefault01_R05_C.SessionData.Lines(1).Lines
@@ -11673,7 +11675,7 @@ msgstr "你一定非这么说不可吗？"
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeVerySad.Default__MegaSlimeVerySad_C.SessionData.Lines(5).Lines
 msgctxt ",D9E588CA4CF77A887584A3B57617B58C"
 msgid "*Sobbing*"
-msgstr ""
+msgstr "*啜泣*"
 
 #. Key:	D9E7689541319CEB860F4A99964E97FE
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R03.Default__FaleneDefault01_R03_C.SessionData.Lines(5).Lines
@@ -11687,7 +11689,7 @@ msgstr "野生魔弗灵也许会很木讷，但他们也需要爱！"
 #: /Game/Dialogue/Kybele/Default/KybeleHaveKeystone.Default__KybeleHaveKeystone_C.SessionData.Lines(0).Lines
 msgctxt ",D9F1E15344E0F55C0BF0C2BD7FA7EB63"
 msgid "Hmm... I suppose you were a good mate."
-msgstr ""
+msgstr "嗯…我觉得你是个好伴侣。"
 
 #. Key:	D9F77A0E43A8B000912D6AB5C30FD924
 #. SourceLocation:	/Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToFuta(7).LinesToFuta
@@ -11701,21 +11703,21 @@ msgstr "*吮吸* *吮吸*"
 #: /Game/Dialogue/OrcChief/Default/OrcAkabekoCheck.Default__OrcAkabekoCheck_C.SessionData.Lines(2).Lines
 msgctxt ",D9FB570C43AD0DD02FC1EA8FBF6685E7"
 msgid "Akabeko not found in the wild, her pussy felt unique! Grrrrr!!"
-msgstr ""
+msgstr "红牛（原型：Akabeko,日本福岛会津地方对红毛的牛的一种称呼，可以给孩子们辟邪，最早出现在日本平安时代）在野外根本找不到，而且她的私处感觉很特别!咕噜噜噜噜! !"
 
 #. Key:	DA05F5A447D7B5F1C5C75E8A35B95C21
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01_RL_M.Default__FernDefault01_RL_M_C.ResponseData(4).ResponseData.BreederPrompt
 #: /Game/Dialogue/Fern/Default/FernDefault01_RL_M.Default__FernDefault01_RL_M_C.ResponseData(4).ResponseData.BreederPrompt
 msgctxt ",DA05F5A447D7B5F1C5C75E8A35B95C21"
 msgid "The Queen Bee demands flowers."
-msgstr ""
+msgstr "蜂后渴望被鲜花簇拥"
 
 #. Key:	DA1107CD4D4DED76EFB5A3BAE5A1C4D0
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_StartLoveMakingF.Default__LeylannaDefault01_StartLoveMakingF_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Leylanna/Default/LeylannaDefault01_StartLoveMakingF.Default__LeylannaDefault01_StartLoveMakingF_C.SessionData.Lines(0).Lines
 msgctxt ",DA1107CD4D4DED76EFB5A3BAE5A1C4D0"
 msgid "Come to my embrace."
-msgstr "投入我的怀抱吧。"
+msgstr "投入我的温暖乡吧。"
 
 #. Key:	DA2AFA94407EDEA10F42C4A25864E68E
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R01.Default__CamillaDefault01_R01_C.SessionData.Lines(6).Lines
@@ -11736,49 +11738,49 @@ msgstr "我从这片土地诞生嘶……我还是株幼苗……需要主人的
 #: /Game/Dialogue/Fern/Default/FernDefault01_RL_T.Default__FernDefault01_RL_T_C.ResponseData(3).ResponseData.BreederPrompt
 msgctxt ",DA9BB43342773BD3A51CEC9C5A48CA82"
 msgid "You may have my cum!"
-msgstr "你可以用我的精液滋润自己了！"
+msgstr "你可以用我的射精来滋润自己了"
 
 #. Key:	DAA21E23412F638CF86C45BDFEF403A9
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcDefault03_RL.Default__OrcDefault03_RL_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/OrcChief/Default/OrcDefault03_RL.Default__OrcDefault03_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",DAA21E23412F638CF86C45BDFEF403A9"
 msgid "Uh... so... want to wrestle?"
-msgstr ""
+msgstr "呃…所以…想一起摔跤吗?"
 
 #. Key:	DAC926244203A48C0547B89807D93FA8
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R01.Default__FaleneDefault01_R01_C.SessionData.Lines(6).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R01.Default__FaleneDefault01_R01_C.SessionData.Lines(6).Lines
 msgctxt ",DAC926244203A48C0547B89807D93FA8"
 msgid "@MONSTER_RACE@ on the other hand reproduce almost instantly."
-msgstr "然而魔弗灵几乎能立刻恢复。"
+msgstr "然而魔弗灵几乎能立刻恢复能够繁殖的状态。"
 
 #. Key:	DADDEBF642EA8FAF8F912C830249D0E6
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(9).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(9).Lines
 msgctxt ",DADDEBF642EA8FAF8F912C830249D0E6"
 msgid "@WORLD_NAME@ is my world."
-msgstr ""
+msgstr "@WORLD_NAME@是我的世界。"
 
 #. Key:	DAF3ABC54412C70DC128659F2DB1098C
 #. SourceLocation:	/Game/Dialogue/Yasmine/Default/YasmineHadSex01.Default__YasmineHadSex01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Yasmine/Default/YasmineHadSex01.Default__YasmineHadSex01_C.SessionData.Lines(0).Lines
 msgctxt ",DAF3ABC54412C70DC128659F2DB1098C"
 msgid "Oh the songs of pleasure we sang, how good they felt."
-msgstr ""
+msgstr "我们刚才一起唱的愉悦的歌，美妙至极。"
 
 #. Key:	DB00D91D4420A5D9D4F3FBB7DD1AC099
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_R02_R01.Default__FernDefault02_R02_R01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02_R02_R01.Default__FernDefault02_R02_R01_C.SessionData.Lines(0).Lines
 msgctxt ",DB00D91D4420A5D9D4F3FBB7DD1AC099"
 msgid "I can help you harvest fluids from wild @MONSTER_RACE@."
-msgstr ""
+msgstr "我可以帮您收获您捕获的野生魔弗灵的体液。"
 
 #. Key:	DB0CF562471898C2200245955791C3B9
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchGreeting01.Default__MonarchGreeting01_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Monarch/Default/MonarchGreeting01.Default__MonarchGreeting01_C.SessionData.Lines(2).Lines
 msgctxt ",DB0CF562471898C2200245955791C3B9"
 msgid "What brings you here?"
-msgstr ""
+msgstr "什么风把你吹来了？"
 
 #. Key:	DB15AC1342DDCD7D060351944CB369E4
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDefault01.Default__CassieDefault01_C.SessionData.Lines(2).Lines
@@ -11792,7 +11794,7 @@ msgstr "喵喵喵呜！"
 #: /Game/Dialogue/Kybele/Default/KybeleAnyMeans.Default__KybeleAnyMeans_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",DB1DF3C343E55ED6022897831EFCA30B"
 msgid "Haha! Humans do have a one-track mind... you aren't so different from us after all."
-msgstr ""
+msgstr "哈哈!一个人的确是一根筋……毕竟和我们没多大区别。"
 
 #. Key:	DB4129DC426B367CD877BE889495E940
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_RL.Default__CamillaDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
@@ -11806,7 +11808,7 @@ msgstr " 来交换精液吧！"
 #: /Game/Dialogue/Kybele/Default/KybeleAnyMeans_RL_T.Default__KybeleAnyMeans_RL_T_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",DB44149945F62048F1EF0D9C2BF75EFB"
 msgid "Pfff I can handle a titty pony."
-msgstr ""
+msgstr "好吧，我可以搞定小奶驹的"
 
 #. Key:	DB49BD62447CAE7EAA40869818522E59
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R03_RL.Default__CamillaDefault01_R03_RL_C.ResponseData(0).ResponseData.BreederPrompt
@@ -11827,21 +11829,21 @@ msgstr "嘶嘶嘶……"
 #: /Game/Dialogue/Cassie/Default/CassieDungeon2.Default__CassieDungeon2_C.SessionData.Lines(3).Lines
 msgctxt ",DB700CCB477FAB622C9638923D9D31D6"
 msgid "That old rusty set of gears above the town entrance controls a pulley system."
-msgstr ""
+msgstr "城镇入口上方那套生锈的齿轮控制着一个滑轮系统"
 
 #. Key:	DB7D31B143C7D61531D61790BE87667B
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03_R01.Default__FernDefault03_R01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03_R01.Default__FernDefault03_R01_C.SessionData.Lines(1).Lines
 msgctxt ",DB7D31B143C7D61531D61790BE87667B"
 msgid "I grew in your soil, and now it is my permanent home. Hopefully you like your new decoration!"
-msgstr ""
+msgstr "我在您的土地上成长，现在这里是我永久的家了。希望您喜欢您的新装饰!"
 
 #. Key:	DC0025004492CEEAE0F8D1A26E169F34
 #. SourceLocation:	/Game/Dialogue/Blossom/Default/BlossomDefault01_R02.Default__BlossomDefault01_R02_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Blossom/Default/BlossomDefault01_R02.Default__BlossomDefault01_R02_C.SessionData.Lines(1).Lines
 msgctxt ",DC0025004492CEEAE0F8D1A26E169F34"
 msgid "Me like this name Blossom. Hiss!"
-msgstr ""
+msgstr "我喜欢这个花花名字。嘶嘶"
 
 #. Key:	DC23BE8C475FA9FCC7F22596C3D47F3F
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01_R02.Default__FernDefault01_R02_C.SessionData.Lines(2).Lines
@@ -11855,42 +11857,42 @@ msgstr "小蕨需要您的滋润嘶嘶~~~"
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeAboutOrb.Default__MegaSlimeAboutOrb_C.SessionData.Lines(3).Lines
 msgctxt ",DC33A237422E2C40903834AF3706B8E4"
 msgid "Then just a few days ago, this orb floated down the drain and got stuck in me."
-msgstr ""
+msgstr "就在几天前，这个球漂进了下水道，卡在了我的身体里。"
 
 #. Key:	DC3F654D485B4A5558C482B697A01B3C
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiDefault01_RL.Default__FesssiDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/Fesssi/Default/FesssiDefault01_RL.Default__FesssiDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",DC3F654D485B4A5558C482B697A01B3C"
 msgid "Are you ok?"
-msgstr ""
+msgstr "你还好吗？"
 
 #. Key:	DC3FF6AD41D27D03E1D980BAD76F4897
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleHadSex01.Default__KybeleHadSex01_C.SessionData.LinesToFuta(2).LinesToFuta
 #: /Game/Dialogue/Kybele/Default/KybeleHadSex01.Default__KybeleHadSex01_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",DC3FF6AD41D27D03E1D980BAD76F4897"
 msgid "Still... you pleased me like a stallion. That's amazing for one of your size!"
-msgstr ""
+msgstr "啊……你依然像一匹种马一样讨我的欢心。你的尺寸对我来说太棒了!"
 
 #. Key:	DC59A07E4D2FC78409E32EA7A64B7007
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFemale(7).LinesToFemale
 #: /Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFemale(7).LinesToFemale
 msgctxt ",DC59A07E4D2FC78409E32EA7A64B7007"
 msgid "That creepy golden seraphim, the one in the temple. She appeared only a few days ago, constantly asking to speak with \"the human\"."
-msgstr ""
+msgstr "那个可怕的金色六翼天使，寺庙里的那个。她几天前才出现，不断地要求和'人类'说话"
 
 #. Key:	DC843E8A4828B0881624D494C080BC2B
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeDefault01_SuckJugs.Default__AmberMaeDefault01_SuckJugs_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeDefault01_SuckJugs.Default__AmberMaeDefault01_SuckJugs_C.SessionData.Lines(1).Lines
 msgctxt ",DC843E8A4828B0881624D494C080BC2B"
 msgid "Awww... I'm blushing something heavy."
-msgstr "嗷~~俺现在好害羞脸好红~"
+msgstr "嗷~~俺现在羞射的要死~"
 
 #. Key:	DC85F26F423721D07495E3AB892F86CC
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R01.Default__FaleneDefault01_R01_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R01.Default__FaleneDefault01_R01_C.SessionData.Lines(4).Lines
 msgctxt ",DC85F26F423721D07495E3AB892F86CC"
 msgid "They are very unlike your human counterparts."
-msgstr "它们的发展过程跟你们人类的大不相同。"
+msgstr "他们和人类非常不同。"
 
 #. Key:	DC880E904973CDED818EF58F9949FB40
 #. SourceLocation:	/Game/Dialogue/Mirru/SexScenes/MirruSnatchF.Default__MirruSnatchF_C.SessionData.Lines(0).Lines
@@ -11911,7 +11913,7 @@ msgstr "丰乳"
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePlay.Default__MegaSlimePlay_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",DCA3C7F14DDEBDAEB595FB95AA6A4F3C"
 msgid "Really?! These truly are the best days of my life!"
-msgstr ""
+msgstr "真的吗? !这些真的是我一生中最美好的日子!"
 
 #. Key:	DCBFA42D4FD9520CA7F586A84DCF3921
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01.Default__LeylannaDefault01_C.SessionData.Lines(0).Lines
@@ -11932,7 +11934,7 @@ msgstr "如果野生魔弗灵对你失去了性趣，他们会失魂落魄的慢
 #: /Game/Dialogue/Monarch/Default/MonarchGreeting01.Default__MonarchGreeting01_C.SessionData.Lines(1).Lines
 msgctxt ",DD27BA4F486D3C23B0BAE6ABF193831E"
 msgid "A human... t-t-that's not something you see everyday."
-msgstr ""
+msgstr "一个人类……这……这……这可不是每天都能看到的！"
 
 #. Key:	DD3959194243B910FF07BC8D7CA651AB
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_Emissary.Default__LeylannaDefault01_Emissary_C.SessionData.Lines(0).Lines
@@ -11946,21 +11948,21 @@ msgstr "就在几天前，这位美艳的金色天使来到了这里。"
 #: /Game/Dialogue/Widow/Default/WidowKeystone.Default__WidowKeystone_C.SessionData.Lines(6).Lines
 msgctxt ",DD71570B40252FFC58EE9CAB7B9A3230"
 msgid "Breed this lonely spider a juicy elf, and the rock will be yours."
-msgstr ""
+msgstr "给这个寂寞的蜘蛛一个多汁的精灵吧，石头就是你的了。"
 
 #. Key:	DD7ECB9E437DDF8975868AA3934E909D
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernGreeting02.Default__FernGreeting02_C.SessionData.LinesToFuta(1).LinesToFuta
 #: /Game/Dialogue/Fern/DefaultP2/FernGreeting02.Default__FernGreeting02_C.SessionData.LinesToFuta(1).LinesToFuta
 msgctxt ",DD7ECB9E437DDF8975868AA3934E909D"
 msgid "Look at my beautiful flower, it bloomed! Oh my did it feel weird..."
-msgstr ""
+msgstr "快看看我美丽的花，它开放了!哦，我的天，是不是感觉怪怪的……"
 
 #. Key:	DD90913F4C544CDB2D79CDAE67287C68
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01.Default__ParvatiDefault01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01.Default__ParvatiDefault01_C.SessionData.Lines(0).Lines
 msgctxt ",DD90913F4C544CDB2D79CDAE67287C68"
 msgid "Returning to me with that familiar glint in your eye."
-msgstr ""
+msgstr "带着你眼中熟悉的光芒回到我身边。"
 
 #. Key:	DDC7B99042CEA89C790895990EB876BE
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R02.Default__FaleneDefault01_R02_C.SessionData.Lines(1).Lines
@@ -11974,21 +11976,21 @@ msgstr "大部分魔弗灵是野生的，他们像动物一样依靠本能游荡
 #: /Game/Dialogue/Cassie/Default/CassieGreeting01.Default__CassieGreeting01_C.SessionData.Lines(3).Lines
 msgctxt ",DDC88AD7412D1B9E7696ED8213C21E27"
 msgid "Though, whoever drew up your fence line is a lunatic!"
-msgstr "不过，无论是谁设计了你牧场的栅栏他一定是个疯子！"
+msgstr "不过，无论是谁设计了你牧场的栅栏，那他一定是个疯子！"
 
 #. Key:	DDEC9C474F3624331E30EEB35B19842A
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadHaveKeystone2.Default__DryadHaveKeystone2_C.SessionData.Message
 #: /Game/Dialogue/Autumn/Default/DryadHaveKeystone2.Default__DryadHaveKeystone2_C.SessionData.Message
 msgctxt ",DDEC9C474F3624331E30EEB35B19842A"
 msgid "Autumn is satisfied."
-msgstr ""
+msgstr "欧特满意了"
 
 #. Key:	DE21C1784F767D32E852689C8D264665
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeHadSex01.Default__MegaSlimeHadSex01_C.SessionData.LinesToFemale(2).LinesToFemale
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeHadSex01.Default__MegaSlimeHadSex01_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",DE21C1784F767D32E852689C8D264665"
 msgid "It's been so long since I have given slime."
-msgstr ""
+msgstr "我已经很久没有分泌史莱姆粘液了。"
 
 #. Key:	DE7B484C4224680737F160881A189942
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_Emissary.Default__LeylannaDefault01_Emissary_C.SessionData.Lines(2).Lines
@@ -12016,7 +12018,7 @@ msgstr "弗玛里亚是深居海中的国度，也是我的家乡。"
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_StartForgotten.Default__ParvatiDefault01_StartForgotten_C.SessionData.Lines(0).Lines
 msgctxt ",DF6BBB7E43776E94C988FCA9C4AD5110"
 msgid "Once you learn a new position, we can practice it anytime."
-msgstr ""
+msgstr "一旦你学会了一个新姿势，我们便可以随时练习"
 
 #. Key:	DF7ACA4545FC48FBC7FBD9816CFDE6DA
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_HowToSpiritForm_RL_T.Default__LeylannaDefault01_HowToSpiritForm_RL_T_C.ResponseData(0).ResponseData.BreederPrompt
@@ -12030,28 +12032,28 @@ msgstr "我抓到了你所要求的魔弗灵."
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R06.Default__FaleneDefault01_R06_C.SessionData.Lines(0).Lines
 msgctxt ",DF82C5BA4FA233DFB96C8A9B6BBE86E2"
 msgid "It's from the ancient mythology of the Goddess, which has become the modern day religion."
-msgstr "这是一个古老的关于至高女神的神话，并已变成了当代社会的传说。"
+msgstr "它源于古代神话中的女神，现在已成为现代的宗教。"
 
 #. Key:	DFB5CC1D474B332C39BEB6B951A88142
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeDefault01_RL.Default__AmberMaeDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/AmberMae/Default/AmberMaeDefault01_RL.Default__AmberMaeDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",DFB5CC1D474B332C39BEB6B951A88142"
 msgid "What's with your accent?"
-msgstr "你的口音是怎么回事？"
+msgstr "你的口音是怎么肥事？"
 
 #. Key:	DFC4AEBB489C5D9B74E6F79CC91F1DB0
 #. SourceLocation:	/Game/Ranch/Upgrades/FoxenHouse.Default__FoxenHouse_C.Upgrade.TypeDisplay
 #: /Game/Ranch/Upgrades/FoxenHouse.Default__FoxenHouse_C.Upgrade.TypeDisplay
 msgctxt ",DFC4AEBB489C5D9B74E6F79CC91F1DB0"
 msgid "Nephelym Barn"
-msgstr ""
+msgstr "魔弗灵牧场"
 
 #. Key:	E01ADC7A41DCC8C65CA87E9C9561359D
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03_R02.Default__FernDefault03_R02_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03_R02.Default__FernDefault03_R02_C.SessionData.Lines(0).Lines
 msgctxt ",E01ADC7A41DCC8C65CA87E9C9561359D"
 msgid "Indeed! Your delicious fluid has done wonders."
-msgstr ""
+msgstr "没错!您美味的体液创造了奇迹。"
 
 #. Key:	E043108D41291B6169E3579CE41F44B3
 #. SourceLocation:	/Game/Dialogue/Emissary/SexScenes/EmissaryAngelGroinLove.Default__EmissaryAngelGroinLove_C.SessionData.LinesToFemale(2).LinesToFemale
@@ -12065,7 +12067,7 @@ msgstr "吾散发着柔和金色光晕的皮肤可令汝欢愉？@BREEDER_NAME@"
 #: /Game/Dialogue/Autumn/Default/DryadAboutDryads.Default__DryadAboutDryads_C.SessionData.Lines(1).Lines
 msgctxt ",E04E71634CD5DA9067A43C8F3AE1A4F3"
 msgid "After decades of growth, the fruit will fall off and a dryad will emerge."
-msgstr ""
+msgstr "再过几十年的生长，果实就会掉落，树妖就会出现。"
 
 #. Key:	E0699FC749A0DDDF3E385CA8D6F3E80E
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R07.Default__FaleneDefault01_R07_C.SessionData.LinesToMale(1).LinesToMale
@@ -12086,21 +12088,21 @@ msgstr "于吾大天使而言，这虽然是徒然无功，但是她对于至高
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02_RL_T.Default__FernDefault02_RL_T_C.ResponseData(4).ResponseData.BreederPrompt
 msgctxt ",E0B9E9894DD5921A03759097168DF006"
 msgid "You may have my breast milk!"
-msgstr ""
+msgstr "你可以喝我的乳汁！"
 
 #. Key:	E0C87F904575D628A6EAEFAD7A1DD491
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchPrettyButterfly.Default__MonarchPrettyButterfly_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Monarch/Default/MonarchPrettyButterfly.Default__MonarchPrettyButterfly_C.SessionData.Lines(2).Lines
 msgctxt ",E0C87F904575D628A6EAEFAD7A1DD491"
 msgid "As such, we frequently find ourselves on the receiving end of sex..."
-msgstr ""
+msgstr "嘛，我们意识到自己总是被别人压在身下只能娇喘。"
 
 #. Key:	E0CB0262419C2D4379873799FB2844BC
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadAboutDryads.Default__DryadAboutDryads_C.SessionData.Lines(6).Lines
 #: /Game/Dialogue/Autumn/Default/DryadAboutDryads.Default__DryadAboutDryads_C.SessionData.Lines(6).Lines
 msgctxt ",E0CB0262419C2D4379873799FB2844BC"
 msgid "I guess I do spoil them..."
-msgstr ""
+msgstr "我想我确实宠坏了她们……"
 
 #. Key:	E0E93AA54E36B2C3F876CEBE1F52C2FC
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_Emissary.Default__LeylannaDefault01_Emissary_C.SessionData.Lines(4).Lines
@@ -12121,42 +12123,42 @@ msgstr "不可否认那真是令我爽翻天，但是啊…我总觉得我还缺
 #: /Game/Dialogue/Blossom/Default/BlossomGreeting01.Default__BlossomGreeting01_C.SessionData.Lines(3).Lines
 msgctxt ",E1682EC8470332A4284BBB8EEDB147A2"
 msgid "..."
-msgstr ""
+msgstr "……"
 
 #. Key:	E17B89624E06BB5038FB7A90A70FFD12
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon.Default__AmberMaeLockedDungeon_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon.Default__AmberMaeLockedDungeon_C.SessionData.Lines(1).Lines
 msgctxt ",E17B89624E06BB5038FB7A90A70FFD12"
 msgid "As Hedon's oldest citizen, I remember trying to fit in there ages ago."
-msgstr ""
+msgstr "作为海顿小镇最早的住民，俺很多年前就努力试着融入了这样的生活。"
 
 #. Key:	E1AA64794D412D85279E1C928CB75EFF
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_RL.Default__FaleneDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_RL.Default__FaleneDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",E1AA64794D412D85279E1C928CB75EFF"
 msgid "What are wild @MONSTER_RACE@?"
-msgstr "什么是野生魔弗灵？"
+msgstr "什么是野生的魔弗灵？"
 
 #. Key:	E1E308E24203BE20934F4FBC8BEC61C7
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_YourMusic.Default__RomyDefault01_YourMusic_C.SessionData.LinesToFuta(1).LinesToFuta
 #: /Game/Dialogue/Romy/Default/RomyDefault01_YourMusic.Default__RomyDefault01_YourMusic_C.SessionData.LinesToFuta(1).LinesToFuta
 msgctxt ",E1E308E24203BE20934F4FBC8BEC61C7"
 msgid "With my voluptuous mermaid body, I shall play your dick like an instrument"
-msgstr ""
+msgstr "用我性感的美人鱼的身体，我会像演奏乐器一样弹奏你的鸡巴"
 
 #. Key:	E1E5995441F81E5B6E79E8A5481789F0
 #. SourceLocation:	/Game/Dialogue/Mirru/SexScenes/MirruSnatchF.Default__MirruSnatchF_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Mirru/SexScenes/MirruSnatchF.Default__MirruSnatchF_C.SessionData.Lines(1).Lines
 msgctxt ",E1E5995441F81E5B6E79E8A5481789F0"
 msgid "Ahh... ohhhh... yes! Please both of my tentacle heads..."
-msgstr "啊……对……我的两条触手、全部……"
+msgstr "啊……噢哦哦……是的！两根触手的头都取悦……"
 
 #. Key:	E1FD0C3A455475E0E474A0A50646DBA8
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon.Default__AmberMaeLockedDungeon_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon.Default__AmberMaeLockedDungeon_C.SessionData.Lines(3).Lines
 msgctxt ",E1FD0C3A455475E0E474A0A50646DBA8"
 msgid "Once they built that new temple, the door was sealed... golly 'twas well over 1000 years ago now."
-msgstr ""
+msgstr "新的圣殿一建好，那道大门就被封住了……天哪噜，这是1000多年前的事了。"
 
 #. Key:	E20511A746C7BFEF4C46D5A2F2586CD0
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(28 - Value).TraitIcons.HelpText
@@ -12177,14 +12179,14 @@ msgstr "让我们做爱吧！！"
 #: /Game/Dialogue/Fesssi/Default/FesssiIdiots.Default__FesssiIdiots_C.SessionData.Lines(6).Lines
 msgctxt ",E255306C4E1CCD9DDB61B0AAC4AFBF04"
 msgid "A titan with plenty of muscle should work, use those breeding skillsssss."
-msgstr ""
+msgstr "一个肌肉发达的泰坦应该会帮上忙，来使用这些繁殖技巧。"
 
 #. Key:	E264C5AA4DFA58630DD1B5AF551D5C38
 #. SourceLocation:	/Game/Dialogue/Blossom/Default/BlossomGreeting01.Default__BlossomGreeting01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Blossom/Default/BlossomGreeting01.Default__BlossomGreeting01_C.SessionData.Lines(1).Lines
 msgctxt ",E264C5AA4DFA58630DD1B5AF551D5C38"
 msgid "..."
-msgstr ""
+msgstr "……"
 
 #. Key:	E267B04149B1C5C63B246BB9B347927F
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R01.Default__CamillaDefault01_R01_C.SessionData.Lines(0).Lines
@@ -12198,14 +12200,14 @@ msgstr "哦她这么说了，是吗？唔，好吧。首先你需要做的是找
 #: /Game/Dialogue/Blossom/Default/BlossomGreeting01.Default__BlossomGreeting01_C.SessionData.Lines(0).Lines
 msgctxt ",E27A479A496E7D5504357E85E45466FC"
 msgid "Hiss..."
-msgstr ""
+msgstr "嘶……"
 
 #. Key:	E28456C04008409976B97DAD9E483D99
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleTittyPony_T.Default__KybeleTittyPony_T_C.SessionData.LinesToFuta(2).LinesToFuta
 #: /Game/Dialogue/Kybele/Default/KybeleTittyPony_T.Default__KybeleTittyPony_T_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",E28456C04008409976B97DAD9E483D99"
 msgid "That should teach you to cross this titty po--I mean mighty centaur warmaiden, again!"
-msgstr ""
+msgstr "这再一次教会你如何深入这个大奶驹……——我是说！强大的半人马女战士！"
 
 #. Key:	E29F5BAA40F6C8758245C58555D4F73E
 #. SourceLocation:	/Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToFemale(2).LinesToFemale
@@ -12219,21 +12221,21 @@ msgstr "啊，你的手指简直和魔法一样灵巧！再深一点，再深一
 #: /Game/Dialogue/AmberMae/SexScenes/AmberMilkyF.Default__AmberMilkyF_C.SessionData.Lines(1).Lines
 msgctxt ",E2D78DC6488712103CF0A59E6DE95E47"
 msgid "Oh yer hand feels so good. Don't stop strok'n me box!"
-msgstr "噢你的手摸的俺好爽，狠狠挤俺的奶…挤干他们 不要停！"
+msgstr "噢，尼的手摸的俺好爽，狠狠挤俺的奶…挤干她们 不要停！"
 
 #. Key:	E2F13B714EEE6046C9069A8F6F71DA0B
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMAboutDragons.Default__DMAboutDragons_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMAboutDragons.Default__DMAboutDragons_C.SessionData.Lines(5).Lines
 msgctxt ",E2F13B714EEE6046C9069A8F6F71DA0B"
 msgid "Why I remember when this area was just grasslands and trees!"
-msgstr ""
+msgstr "为什么我还记得那时这里只有草地和大树！"
 
 #. Key:	E32B21044CA4F23C751CD4AC2F814FC7
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcFixOwnGate.Default__OrcFixOwnGate_C.SessionData.LinesToFuta(4).LinesToFuta
 #: /Game/Dialogue/OrcChief/Default/OrcFixOwnGate.Default__OrcFixOwnGate_C.SessionData.LinesToFuta(4).LinesToFuta
 msgctxt ",E32B21044CA4F23C751CD4AC2F814FC7"
 msgid "You get crushed under muscles and ass until chieftain satisfied!"
-msgstr ""
+msgstr "直到酋长满意为止，你都将会被肌肉和屁股压在下面娇喘连连。"
 
 #. Key:	E34457BA4EEA184519C5E4AAD2E0B122
 #. SourceLocation:	/Game/Dialogue/Fern/SexScenes/FernCum_01.Default__FernCum_01_C.SessionData.Lines(7).Lines
@@ -12247,35 +12249,35 @@ msgstr "*吮吸* *吮吸*"
 #: /Game/Dialogue/Kybele/Default/KybeleTaskFulfilled.Default__KybeleTaskFulfilled_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",E3AE7B054DC0BBA83F3A75BBB8565010"
 msgid "I've taken advantage of her fat ass many times, and pumped her full of my seed."
-msgstr ""
+msgstr "我曾多次用她的肥臀好好的射了几次，给她灌满了我的种子。"
 
 #. Key:	E3E470CD447870D4FC3D96BD5BD10264
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimePlay_RL.Default__MegaSlimePlay_RL_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePlay_RL.Default__MegaSlimePlay_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",E3E470CD447870D4FC3D96BD5BD10264"
 msgid "Whoa... that's more than I bargained for!"
-msgstr ""
+msgstr "哇…这超出了我的预料，爽翻了！"
 
 #. Key:	E41A1FB14C3203DC5709BD9DDA4C90B4
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMClimaxPeak.Default__DMClimaxPeak_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMClimaxPeak.Default__DMClimaxPeak_C.SessionData.Lines(1).Lines
 msgctxt ",E41A1FB14C3203DC5709BD9DDA4C90B4"
 msgid "Perhaps we can strike a bargain."
-msgstr ""
+msgstr "也许我们可以达成一笔交易。"
 
 #. Key:	E44DC681421F83D23915B6BCE7AF12EF
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeAboutOrb.Default__MegaSlimeAboutOrb_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeAboutOrb.Default__MegaSlimeAboutOrb_C.SessionData.Lines(0).Lines
 msgctxt ",E44DC681421F83D23915B6BCE7AF12EF"
 msgid "I love it... it makes me so happy!"
-msgstr ""
+msgstr "我爱死了，这简直让我欲罢不能！"
 
 #. Key:	E456792841D9433268D3C186837C9B2F
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleTaskFulfilled.Default__KybeleTaskFulfilled_C.SessionData.LinesToFuta(4).LinesToFuta
 #: /Game/Dialogue/Kybele/Default/KybeleTaskFulfilled.Default__KybeleTaskFulfilled_C.SessionData.LinesToFuta(4).LinesToFuta
 msgctxt ",E456792841D9433268D3C186837C9B2F"
 msgid "The perfect toy for such a boring task. You have my thanks."
-msgstr ""
+msgstr "对于这样无聊的工作来说，这是个完美的打发时间的泄欲玩具。谢谢你"
 
 #. Key:	E45685834D7AE2795D9FA29F5CCF8B18
 #. SourceLocation:	/Game/Dialogue/Mirru/SexScenes/MirruSnatchT.Default__MirruSnatchT_C.SessionData.Lines(1).Lines
@@ -12289,63 +12291,63 @@ msgstr "啊……噢……就是这样！"
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03.Default__FernDefault03_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",E460226A4FF1B186BCA5DE85158B49AF"
 msgid "I am a growing Alraune, perhaps you have fluids to spare?"
-msgstr ""
+msgstr "我是正在成长的曼陀罗，也许您可以分我一点您的体液吗？"
 
 #. Key:	E48F12854CF0D281AA9E52B611BEFF61
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryHadSex01.Default__EmissaryHadSex01_C.SessionData.LinesToMale(2).LinesToMale
 #: /Game/Dialogue/Emissary/Default/EmissaryHadSex01.Default__EmissaryHadSex01_C.SessionData.LinesToMale(2).LinesToMale
 msgctxt ",E48F12854CF0D281AA9E52B611BEFF61"
 msgid "Is that a comforting feeling?"
-msgstr ""
+msgstr "那是一种令人倍感安慰的感觉吗？"
 
 #. Key:	E499F0E4452FBC3AAE82E18BCF77B28B
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryBlessedInquiry01_R01.Default__EmissaryBlessedInquiry01_R01_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryBlessedInquiry01_R01.Default__EmissaryBlessedInquiry01_R01_C.SessionData.Lines(2).Lines
 msgctxt ",E499F0E4452FBC3AAE82E18BCF77B28B"
 msgid "My senses detect your desires @BREEDER_NAME@. You see my exposed body before you, and you wish to please yourself with it."
-msgstr "吾之感官感测到了汝之欲求，@BREEDER_NAME@。诚汝所见吾裸露的肉体，而汝想以吾肉体成全自己。"
+msgstr "吾之感官感测到了汝之欲求，@BREEDER_NAME@。诚汝所见吾裸露的肉体，而汝想以吾肉体成全汝。"
 
 #. Key:	E4AA6F334E8152CCB55879A1FD73219D
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaFaleneWeek.Default__CamillaFaleneWeek_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaFaleneWeek.Default__CamillaFaleneWeek_C.SessionData.Lines(0).Lines
 msgctxt ",E4AA6F334E8152CCB55879A1FD73219D"
 msgid "Every week she embarks on a \"field study\"."
-msgstr ""
+msgstr "每周她都要进行一次'实地考察'。"
 
 #. Key:	E4B026D641AF98C38A86DC827DC789C9
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeHowLong.Default__MegaSlimeHowLong_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeHowLong.Default__MegaSlimeHowLong_C.SessionData.Lines(0).Lines
 msgctxt ",E4B026D641AF98C38A86DC827DC789C9"
 msgid "For nearly 1000 years I have been growing... all alone..."
-msgstr ""
+msgstr "近1000年来，我一直在成长……独自一人……"
 
 #. Key:	E4BB37CF496E2ECB97F60B861C42188F
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeDefault02_RL.Default__BeeDefault02_RL_C.ResponseData(2).ResponseData.BreederPrompt
 #: /Game/Dialogue/QueenBee/Default/BeeDefault02_RL.Default__BeeDefault02_RL_C.ResponseData(2).ResponseData.BreederPrompt
 msgctxt ",E4BB37CF496E2ECB97F60B861C42188F"
 msgid "Tell me about bees."
-msgstr ""
+msgstr "跟我说说蜜蜂的事情吧。"
 
 #. Key:	E4C07523420122C952973D869A7F228C
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMDefault_RL2.Default__DMDefault_RL2_C.ResponseData(2).ResponseData.BreederPrompt
 #: /Game/Dialogue/DragonMatriarch/Default/DMDefault_RL2.Default__DMDefault_RL2_C.ResponseData(2).ResponseData.BreederPrompt
 msgctxt ",E4C07523420122C952973D869A7F228C"
 msgid "Now that you have so much energy..."
-msgstr ""
+msgstr "现在你的精力如此的充沛。"
 
 #. Key:	E4D00AF649A1E7AC5659FFA04BB04427
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault02.Default__EmissaryDefault02_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault02.Default__EmissaryDefault02_C.SessionData.Lines(0).Lines
 msgctxt ",E4D00AF649A1E7AC5659FFA04BB04427"
 msgid "Well done @BREEDER_NAME@, thou hast restored my world's link to the Void."
-msgstr ""
+msgstr "干得好 @BREEDER_NAME@，你恢复了我的世界与虚空的连接。"
 
 #. Key:	E4F530D54D663ADF27773EB024081B52
 #. SourceLocation:	/Game/World/Events/EM_Pearl.EM_Pearl_C:ExecuteUbergraph_EM_Pearl [Script Bytecode]
 #: /Game/World/Events/EM_Pearl.EM_Pearl_C:ExecuteUbergraph_EM_Pearl [Script Bytecode]
 msgctxt ",E4F530D54D663ADF27773EB024081B52"
 msgid "Beautiful Pearl acquired."
-msgstr ""
+msgstr "获得了美丽的大珍珠。"
 
 #. Key:	E5058E9246E1827F928D6681023A71A0
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(10).LinesToFemale
@@ -12359,49 +12361,49 @@ msgstr "不过魔弗灵们都非常想和你交配。"
 #: /Game/Dialogue/Fesssi/Default/FesssiHowLong.Default__FesssiHowLong_C.SessionData.Lines(0).Lines
 msgctxt ",E52DB615469C458EDFDE9380BA351713"
 msgid "No idea, a year or two perhaps."
-msgstr ""
+msgstr "不知道，也许一两年吧"
 
 #. Key:	E535E57A4387D4FB6EB39EA5A3988B61
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(17).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(17).Lines
 msgctxt ",E535E57A4387D4FB6EB39EA5A3988B61"
 msgid "Their offspring were restored to strong immortal forms, and the Goddess called all of Her creations the @MONSTER_RACE@."
-msgstr ""
+msgstr "他们的后代恢复了强大的不朽形态，女神称她的所有作品为魔弗灵。"
 
 #. Key:	E5582CD145475FD1FDA1C88BC2821A2A
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleHaveKeystone.Default__KybeleHaveKeystone_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Kybele/Default/KybeleHaveKeystone.Default__KybeleHaveKeystone_C.SessionData.Lines(2).Lines
 msgctxt ",E5582CD145475FD1FDA1C88BC2821A2A"
 msgid "The Dragon Matriarch probably wouldn't mind if I let you BORROW it for awhile."
-msgstr ""
+msgstr "女族长大概不会介意我把它借给你用一段时间"
 
 #. Key:	E594716B40413B6747D21BA87B26EE43
 #. SourceLocation:	/Game/Breeding/Positions/Test4.Default__Test4_C.SessionData.PositionName
 #: /Game/Breeding/Positions/Test4.Default__Test4_C.SessionData.PositionName
 msgctxt ",E594716B40413B6747D21BA87B26EE43"
 msgid "Test4"
-msgstr ""
+msgstr "测试4"
 
 #. Key:	E5B424C34D393C3602C0EA8AF2AB1F9E
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadTaskFulfilled.Default__DryadTaskFulfilled_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Autumn/Default/DryadTaskFulfilled.Default__DryadTaskFulfilled_C.SessionData.Lines(0).Lines
 msgctxt ",E5B424C34D393C3602C0EA8AF2AB1F9E"
 msgid "What a sweet little honey bee."
-msgstr ""
+msgstr "多么可爱的小蜜蜂啊"
 
 #. Key:	E5B7F2E2469864C41253FC892250ED92
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_YourMusic_Start.Default__RomyDefault01_YourMusic_Start_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Romy/Default/RomyDefault01_YourMusic_Start.Default__RomyDefault01_YourMusic_Start_C.SessionData.Lines(0).Lines
 msgctxt ",E5B7F2E2469864C41253FC892250ED92"
 msgid "Yes! Sing with me human."
-msgstr ""
+msgstr "是的!和我一起歌唱吧，人类。"
 
 #. Key:	E5ED1DF6437395916BD42CBCD355E384
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruHadSex01.Default__MirruHadSex01_C.SessionData.LinesToFemale(2).LinesToFemale
 #: /Game/Dialogue/Mirru/Default/MirruHadSex01.Default__MirruHadSex01_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",E5ED1DF6437395916BD42CBCD355E384"
 msgid "I hope my tentacles were not too much for you... yes they can deliver quite the load."
-msgstr ""
+msgstr "我希望我的触手对你来说不是太多……是的，他们可以运送相当多的子弹。"
 
 #. Key:	E5F734734AC1001F041105949672E015
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R04.Default__FaleneDefault01_R04_C.SessionData.Lines(11).Lines
@@ -12422,21 +12424,21 @@ msgstr "只有同我共赴情爱，你方能知晓至高女神所降下的恩典
 #: /Game/Dialogue/OrcChief/Default/OrcHaveKeystone.Default__OrcHaveKeystone_C.SessionData.Lines(0).Lines
 msgctxt ",E616C96848EB54386E6532BF634CD0EA"
 msgid "No! *snarl*"
-msgstr ""
+msgstr "不！*咆哮*"
 
 #. Key:	E6284AF048B97D804F6434804C0A6D5C
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowTaskFulfilled.Default__WidowTaskFulfilled_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Widow/Default/WidowTaskFulfilled.Default__WidowTaskFulfilled_C.SessionData.Lines(2).Lines
 msgctxt ",E6284AF048B97D804F6434804C0A6D5C"
 msgid "Elves taste just as I dreamed they would... and this little one is all mine."
-msgstr ""
+msgstr "精灵们的味道和我所梦想的一模一样……这个小家伙只属于我。"
 
 #. Key:	E63E125C4A07D646D1BFD48E816B5B37
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryRaiseTraitLvl_Accept.Default__EmissaryRaiseTraitLvl_Accept_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryRaiseTraitLvl_Accept.Default__EmissaryRaiseTraitLvl_Accept_C.SessionData.Lines(0).Lines
 msgctxt ",E63E125C4A07D646D1BFD48E816B5B37"
 msgid "A wise choice human, for the Goddess has further endowed wild @MONSTER_RACE@."
-msgstr "多么明智的人啊。于至高女神则会为野生魔弗灵赋予更多。."
+msgstr "多么明智的选择啊人类。至高女神则会为野生魔弗灵进一步赋予更多的能力."
 
 #. Key:	E663A2A8494081C671EA74A317740FAD
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(31 - Value).TraitIcons.DisplayName
@@ -12450,14 +12452,14 @@ msgstr "反常体型"
 #: /Game/Dialogue/QueenBee/Default/BeeMoreHoney.Default__BeeMoreHoney_C.SessionData.Lines(0).Lines
 msgctxt ",E6729AE74984F181641135921F97D449"
 msgid "Ahhh yes... I knew you wouldn't be able to resist."
-msgstr ""
+msgstr "啊哈，看吧……我就知道你抵抗不了。"
 
 #. Key:	E69826E04F46B36F08DF61ADC6BE1350
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchHaveKeystone.Default__MonarchHaveKeystone_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Monarch/Default/MonarchHaveKeystone.Default__MonarchHaveKeystone_C.SessionData.Lines(0).Lines
 msgctxt ",E69826E04F46B36F08DF61ADC6BE1350"
 msgid "You were nice to me... I can part with it."
-msgstr ""
+msgstr "你对我太好了，我想我可以舍弃它给你。"
 
 #. Key:	E6AE999D442B37DD898ED3B14ADA261A
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R05.Default__FaleneDefault01_R05_C.SessionData.Lines(2).Lines
@@ -12471,70 +12473,70 @@ msgstr "野生精灵不像其他魔弗灵那样常见，彩绘精灵就更加稀
 #: /Game/Ranch/Upgrades/DragonHoard.Default__DragonHoard_C.Upgrade.DisplayName
 msgctxt ",E6EFAF84489D0FE3730843AEC3483A12"
 msgid "Dragon Hoard"
-msgstr ""
+msgstr "龙之秘宝"
 
 #. Key:	E71D6B9A4400127440C060AAD55FB07B
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiWantAss.Default__FesssiWantAss_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiWantAss.Default__FesssiWantAss_C.SessionData.Lines(0).Lines
 msgctxt ",E71D6B9A4400127440C060AAD55FB07B"
 msgid "Hiss! I knew you wanted it. Don't think I haven't noticed you gazing upon my girthy glory."
-msgstr ""
+msgstr "嘶！我早就知道你想要了，你以为我没看到你在偷瞟我引以为傲的腰吗？"
 
 #. Key:	E771BFFB4897C621A00726862D211233
 #. SourceLocation:	/Game/Breeding/Positions/ReverseCowgirl.Default__ReverseCowgirl_C.SessionData.Description
 #: /Game/Breeding/Positions/ReverseCowgirl.Default__ReverseCowgirl_C.SessionData.Description
 msgctxt ",E771BFFB4897C621A00726862D211233"
 msgid "The receiver bounces up and down while facing away from the giver."
-msgstr ""
+msgstr "被恩赐者背对着坐在播种者的身上，被恩赐者的方向和骑乘位刚好相反，翻转牛仔式。"
 
 #. Key:	E785DF8A4F91C040EC352CA7D80C247E
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyHadSex01.Default__RomyHadSex01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Romy/Default/RomyHadSex01.Default__RomyHadSex01_C.SessionData.Lines(1).Lines
 msgctxt ",E785DF8A4F91C040EC352CA7D80C247E"
 msgid "Waves of ecstasy still course through my body."
-msgstr ""
+msgstr "一波又一波的狂喜在我的身体里不断涌动。"
 
 #. Key:	E786C6B44314BBD71D79DA9FE5AF0C96
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDungeon.Default__CassieDungeon_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Cassie/Default/CassieDungeon.Default__CassieDungeon_C.SessionData.Lines(3).Lines
 msgctxt ",E786C6B44314BBD71D79DA9FE5AF0C96"
 msgid "Cassie thinks there is a way to open it!"
-msgstr ""
+msgstr "凯茜认为有办法打开它!"
 
 #. Key:	E79C52514246BC9F37D1229336510455
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeHadSex01.Default__MegaSlimeHadSex01_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeHadSex01.Default__MegaSlimeHadSex01_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",E79C52514246BC9F37D1229336510455"
 msgid "*Yawn*"
-msgstr ""
+msgstr "*打哈欠*"
 
 #. Key:	E7BA70CA4CDE49CD26EE3A92475B70E2
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(12).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(12).Lines
 msgctxt ",E7BA70CA4CDE49CD26EE3A92475B70E2"
 msgid "They began creating lifeforms of their own, but lacked the power and wisdom of the Goddess."
-msgstr ""
+msgstr "他们开始创造自己的生命形式，但缺乏女神的力量和智慧"
 
 #. Key:	E82ABEEB4DFDC274912B3E9EA8ECF8F2
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeAboutBees.Default__BeeAboutBees_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/QueenBee/Default/BeeAboutBees.Default__BeeAboutBees_C.SessionData.Lines(3).Lines
 msgctxt ",E82ABEEB4DFDC274912B3E9EA8ECF8F2"
 msgid "At the end of each day, the worker bees will milk the queen and store the honey in jars and combs."
-msgstr ""
+msgstr "每天傍晚，工蜂都会给蜂后挤奶，并把蜂蜜储存在罐子和蜂巢里。"
 
 #. Key:	E82D05B04D7461ACFB177EBE4ED8C772
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.EM_OrcSwitch.Message
 #: /Game/World/Overworld.Overworld:PersistentLevel.EM_OrcSwitch.Message
 msgctxt ",E82D05B04D7461ACFB177EBE4ED8C772"
 msgid "A gate was opened."
-msgstr ""
+msgstr "打开了这扇大门"
 
 #. Key:	E869210B499044B8227AF0B4F982A564
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.CBGate_Cavern.PlaceMessage
 #: /Game/World/Overworld.Overworld:PersistentLevel.CBGate_Cavern.PlaceMessage
 msgctxt ",E869210B499044B8227AF0B4F982A564"
 msgid "Amorous Hallows is now accessible."
-msgstr ""
+msgstr "现在可以访问性欲圣地了。"
 
 #. Key:	E8789C0E4CCC57BB8A98178902DA8110
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(1 - Value).TraitIcons.HelpText
@@ -12548,14 +12550,14 @@ msgstr "趋近兽型：继承了更多动物的特征"
 #: /Game/Dialogue/Kybele/Default/KybeleDefault01.Default__KybeleDefault01_C.SessionData.Lines(0).Lines
 msgctxt ",E884B8E5410C3C8C00BFC3AFDA4097F9"
 msgid "By any means necessary, I will not let you pass human."
-msgstr ""
+msgstr "无论如何，我都不会让你通过的，人类。"
 
 #. Key:	E887131048CFFB8EF5A2E0A1DA1194FE
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraTaskFulfilled.Default__PetraTaskFulfilled_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Petra/Default/PetraTaskFulfilled.Default__PetraTaskFulfilled_C.SessionData.Lines(2).Lines
 msgctxt ",E887131048CFFB8EF5A2E0A1DA1194FE"
 msgid "I got the keystone for you as promised, take it. Don't be a stranger though!"
-msgstr ""
+msgstr "我答应过你把钥石给你的，拿着吧。可别见外!"
 
 #. Key:	E89A6BB74D15111C98632A99F45745CC
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(17 - Value).TraitIcons.DisplayName
@@ -12569,28 +12571,28 @@ msgstr "肥硕"
 #: /Game/Dialogue/Fern/Default/FernDefault01_R02_R01.Default__FernDefault01_R02_R01_C.SessionData.Lines(2).Lines
 msgctxt ",E89B660E4DCD6EDBFE7FBDB73A354FD0"
 msgid "If mastah let Fern drink mastah's fluids, Fern give shiny. Hiss!"
-msgstr "如果主人用体液滋润滋润小蕨，小蕨会给您一些亮晶晶！嘶嘶……！"
+msgstr "如果主人用体液滋润滋润小蕨，小蕨会给您一些小蕨收集的亮片！嘶嘶……！"
 
 #. Key:	E8E336B64B994547FA9BF2A5CFD5F9EE
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault02.Default__CamillaDefault02_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaDefault02.Default__CamillaDefault02_C.SessionData.Lines(3).Lines
 msgctxt ",E8E336B64B994547FA9BF2A5CFD5F9EE"
 msgid "Yeah... one time she brought a leech in here and it swallowed me whole."
-msgstr ""
+msgstr "是的…有一次她带了一只水蛭来这里，它把我直接丸吞了。"
 
 #. Key:	E90C40EC48C37A3A560F8083C83692A7
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMTaskFulfilled.Default__DMTaskFulfilled_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMTaskFulfilled.Default__DMTaskFulfilled_C.SessionData.Lines(2).Lines
 msgctxt ",E90C40EC48C37A3A560F8083C83692A7"
 msgid "Perhaps I should do this from now on instead of wasting days slumbering."
-msgstr ""
+msgstr "也许从现在开始我应该这样做，而不是浪费时间在睡觉上。"
 
 #. Key:	E91EF4164FCD12832A52B095A8557B4A
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.DragonHoard.ManageActionMessage
 #: /Game/World/Overworld.Overworld:PersistentLevel.DragonHoard.ManageActionMessage
 msgctxt ",E91EF4164FCD12832A52B095A8557B4A"
 msgid "Manage your Dragons"
-msgstr "管理你的龙人"
+msgstr "管理你的龙人族"
 
 #. Key:	E9306878425673698C22F9AA8CD2A8CC
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(9).LinesToFemale
@@ -12611,21 +12613,21 @@ msgstr "性欲圣地"
 #: /Game/Dialogue/Autumn/Default/DryadFatAssLamia.Default__DryadFatAssLamia_C.SessionData.Lines(3).Lines
 msgctxt ",E999DFEA4E92B84DC1426192191A75AA"
 msgid "As she turned to face me, her massive ass jiggled and settled into place."
-msgstr ""
+msgstr "当他她转过身来看着我的时候，她那肥硕的屁股微微一摇，稳稳地坐了下来。"
 
 #. Key:	E9A374BB46F94E4B206A549D48B4D6FD
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMNap_RL.Default__DMNap_RL_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/DragonMatriarch/Default/DMNap_RL.Default__DMNap_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",E9A374BB46F94E4B206A549D48B4D6FD"
 msgid "But I must go to Climax Peak."
-msgstr ""
+msgstr "但是我必须要去极乐之巅。"
 
 #. Key:	E9AB731F47E3F6759C9BEA90AA3E32CB
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchPrettyButterfly.Default__MonarchPrettyButterfly_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Monarch/Default/MonarchPrettyButterfly.Default__MonarchPrettyButterfly_C.SessionData.Lines(0).Lines
 msgctxt ",E9AB731F47E3F6759C9BEA90AA3E32CB"
 msgid "W-w-whoa easy human... I'm fragile."
-msgstr ""
+msgstr "呜哇哇哇，轻点，人类……我很脆弱的"
 
 #. Key:	E9B8B1C5455710ECF7299ABDF56BBA47
 #. SourceLocation:	/Game/Characters/Procedural/Variants/Neko/Harvest/NekoHarvest.Default__NekoHarvest_C.Harvest.Description
@@ -12639,14 +12641,14 @@ msgstr "猫娘体液"
 #: /Game/Dialogue/Kybele/Default/KybeleAnyMeans.Default__KybeleAnyMeans_C.SessionData.LinesToFemale(4).LinesToFemale
 msgctxt ",EA2B04154B0261A512D72EBBD877304B"
 msgid "Well... my back legs. You can't miss it, nor handle it for that matter."
-msgstr ""
+msgstr "恩……在我的后腿那边，你不会错过的，好好的让我爽一下。"
 
 #. Key:	EA5E734B4238AB7601156A936E5E99DF
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchStartShySex.Default__MonarchStartShySex_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/Monarch/Default/MonarchStartShySex.Default__MonarchStartShySex_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",EA5E734B4238AB7601156A936E5E99DF"
 msgid "Oh... m-m-my... uh."
-msgstr ""
+msgstr "噢……我……我……我的……天哪……"
 
 #. Key:	EA5FEF4E48F8E04291135AA9D42A6CE4
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_Formuria.Default__MirruDefault01_Formuria_C.SessionData.Lines(2).Lines
@@ -12660,21 +12662,21 @@ msgstr "而本公主，米露，就是即将继位的女王。所有兄弟姐妹
 #: /Game/Dialogue/Kybele/Default/KybeleHadSex01.Default__KybeleHadSex01_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",EAB6EBE14AAB0E16FF7079998969A562"
 msgid "What a massive release, it's been far too many days."
-msgstr ""
+msgstr "你究竟囤积了多少天了啊，射了那么多……"
 
 #. Key:	EAC5867744C78DCB09760896409A7850
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcTribeSucks.Default__OrcTribeSucks_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcTribeSucks.Default__OrcTribeSucks_C.SessionData.Lines(5).Lines
 msgctxt ",EAC5867744C78DCB09760896409A7850"
 msgid "Take my tribe sisters back to Homestead... breed them well!"
-msgstr ""
+msgstr "带我的部落姐妹们回到你的家园…好好繁育她们!"
 
 #. Key:	EAE306A64EE7F2719CB1719962D3F107
 #. SourceLocation:	/Game/Ranch/Upgrades/DemonPool.Default__DemonPool_C.Upgrade.Description
 #: /Game/Ranch/Upgrades/DemonPool.Default__DemonPool_C.Upgrade.Description
 msgctxt ",EAE306A64EE7F2719CB1719962D3F107"
 msgid "This allows you to catch and store all variants of Demon."
-msgstr ""
+msgstr "这允许你捕获和饲养野生的恶魔族。"
 
 #. Key:	EB2D583D443FA7DB15278C95780CBC37
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDefault01_Meow.Default__CassieDefault01_Meow_C.SessionData.LinesToFemale(0).LinesToFemale
@@ -12688,28 +12690,28 @@ msgstr "喵呜！嘿嘿嘿，别给人家起这个头！"
 #: /Game/Breeding/Positions/Test1.Default__Test1_C.SessionData.PositionName
 msgctxt ",EB54AD484FADC0D1DA6A95B5B6780E36"
 msgid "Surprise"
-msgstr ""
+msgstr "突鸡式"
 
 #. Key:	EB6E4330432136A859E45AAF024E2DC0
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowScary.Default__WidowScary_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Widow/Default/WidowScary.Default__WidowScary_C.SessionData.Lines(5).Lines
 msgctxt ",EB6E4330432136A859E45AAF024E2DC0"
 msgid "And perhaps to suck my companion dry when the hunger arises... but I always strive to make it feel good."
-msgstr ""
+msgstr "也许饥饿来临的时候也可以吸干我的伴侣，但是我总是温柔的让她感觉很好。"
 
 #. Key:	EB717BA44A439427B1DE6CA60FA650A2
 #. SourceLocation:	/Game/Dialogue/Mirru/SexScenes/MirruKrakVag.Default__MirruKrakVag_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Mirru/SexScenes/MirruKrakVag.Default__MirruKrakVag_C.SessionData.Lines(2).Lines
 msgctxt ",EB717BA44A439427B1DE6CA60FA650A2"
 msgid "Do you like my thick deep vagina? Ahh... penetrate it with all your might..."
-msgstr "喜欢我又肥又厚的小穴吗？对、用你的所有力量操穿它……"
+msgstr "喜欢我又肥又厚的小穴吗？对、用你的所有力量冲击它……"
 
 #. Key:	EB8281BE4BDC307B5C0B208F2E5CDCED
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R02.Default__CamillaDefault01_R02_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R02.Default__CamillaDefault01_R02_C.SessionData.Lines(5).Lines
 msgctxt ",EB8281BE4BDC307B5C0B208F2E5CDCED"
 msgid "Titans like the mountain caves of the Climax Peak."
-msgstr "泰坦喜欢住在高潮之峰的洞穴里。"
+msgstr "泰坦喜欢住在极乐之巅的洞穴里。"
 
 #. Key:	EB9CEE7C492834A71E0684923E36AB86
 #. SourceLocation:	/Game/Dialogue/Fern/SexScenes/FernCum_01.Default__FernCum_01_C.SessionData.Lines(5).Lines
@@ -12737,35 +12739,35 @@ msgstr "擎天柱：继承了更大的下体"
 #: /Game/Dialogue/Autumn/Default/DryadDefault01.Default__DryadDefault01_C.SessionData.Lines(0).Lines
 msgctxt ",EC505AF645F08A603F4BDF98F4F09BAC"
 msgid "So many bosom cherries to make, the cows are always ready to eat them."
-msgstr ""
+msgstr "许多胸部樱桃要做，牛儿们吃的一刻也不停。"
 
 #. Key:	EC6BFF394580DB5B2B148096C2994439
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_RL_M.Default__FernDefault02_RL_M_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02_RL_M.Default__FernDefault02_RL_M_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",EC6BFF394580DB5B2B148096C2994439"
 msgid "Why did you call me master?"
-msgstr ""
+msgstr "你为什么要叫我主人呢？"
 
 #. Key:	EC7903464D18A00937FD1CB94B22B7B8
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMDefault_RL.Default__DMDefault_RL_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/DragonMatriarch/Default/DMDefault_RL.Default__DMDefault_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",EC7903464D18A00937FD1CB94B22B7B8"
 msgid "Lame. I thought the Dragon Matriarch would be better!"
-msgstr ""
+msgstr "站不稳啊……我还以为巨龙女族长会更好呢!"
 
 #. Key:	EC7D97C640A2B4A5E3BFACACD27F84F8
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDungeon2.Default__CassieDungeon2_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Cassie/Default/CassieDungeon2.Default__CassieDungeon2_C.SessionData.Lines(2).Lines
 msgctxt ",EC7D97C640A2B4A5E3BFACACD27F84F8"
 msgid "It was locked for many years."
-msgstr ""
+msgstr "它被锁了很多年了。"
 
 #. Key:	EC82D74441832F387397BE94F0621215
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeGreeting02.Default__BeeGreeting02_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/QueenBee/Default/BeeGreeting02.Default__BeeGreeting02_C.SessionData.Lines(0).Lines
 msgctxt ",EC82D74441832F387397BE94F0621215"
 msgid "Kneel before your queen... ahhh.... ohhh..."
-msgstr ""
+msgstr "在你的女王面前跪下……啊…噢…"
 
 #. Key:	EC9757E141CD427BCC7326B974A16B82
 #. SourceLocation:	/Game/Dialogue/Neela/SexScenes/NeelaSnakeCuddleF.Default__NeelaSnakeCuddleF_C.SessionData.Lines(4).Lines
@@ -12786,28 +12788,28 @@ msgstr "感受我的小舌在你的阴唇中滑动吧人类。噢……"
 #: /Game/UI/TaskDescriptions.TaskDescriptions.TextEntries(0).TextEntries
 msgctxt ",ECE1ACB84FCF8F8A06C64385D7909E98"
 msgid "We need another wild one to extract fluids from! You may think such a thing would be easy, but Falene and I go through... many fluids. Don't ask! Besides, I'm too small to do any real fluid harvesting remember?! That's what big human breeders are for. AND YES IN CASE YOU WERE WONDERING, I PINNED THIS ON THE BOARD MYSELF... using a box. I don't need any help from tall folk!!  -Camilla"
-msgstr ""
+msgstr "我们需要另一个野生魔弗灵来提取体液!你可能会认为这样的事是很简单的事,但法莲娜和我被射了很多精液……。不要问!再说了，我太小了，根本没法收集液体记得吗!这就是大型人类繁殖者的作用。还有！如果你想知道！我把这个钉在了布告栏上！垫了一个盒子！！我不需要高个子的帮助!!——卡米拉"
 
 #. Key:	ECE912E146D6A887F2F7C39091185320
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadHaveKeystone.Default__DryadHaveKeystone_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Autumn/Default/DryadHaveKeystone.Default__DryadHaveKeystone_C.SessionData.Lines(0).Lines
 msgctxt ",ECE912E146D6A887F2F7C39091185320"
 msgid "Oh that old thing stuck in my roots?"
-msgstr ""
+msgstr "哦，那个旧东西卡在我的根里了?"
 
 #. Key:	ECF633104DBC2948B9EE9FB8C499DCA5
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcHadSex01.Default__OrcHadSex01_C.SessionData.LinesToFuta(1).LinesToFuta
 #: /Game/Dialogue/OrcChief/Default/OrcHadSex01.Default__OrcHadSex01_C.SessionData.LinesToFuta(1).LinesToFuta
 msgctxt ",ECF633104DBC2948B9EE9FB8C499DCA5"
 msgid "Human feel good. Lucky chieftain let you squirt weak seed in her."
-msgstr ""
+msgstr "人类让我感觉爽飞了。幸运的酋长允许你在她的体内射出你那柔弱的种子。"
 
 #. Key:	ED31F33C43B35F55174029803CC7A311
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernGreeting03.Default__FernGreeting03_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/Fern/DefaultP3/FernGreeting03.Default__FernGreeting03_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",ED31F33C43B35F55174029803CC7A311"
 msgid "I am a full grown Alraune now!"
-msgstr ""
+msgstr "我现在是一个完全成熟的曼陀罗了！"
 
 #. Key:	ED550A2148D3A000A85A3888AF7B31B1
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_AboutLamias.Default__NeelaDefault01_AboutLamias_C.SessionData.Lines(3).Lines
@@ -12821,21 +12823,21 @@ msgstr "..."
 #: /Game/Dialogue/Parvati/Default/ParvatiGreeting01.Default__ParvatiGreeting01_C.SessionData.LinesToFemale(8).LinesToFemale
 msgctxt ",EDA3DF9D4C1774AA8DDFC69C0EFD0035"
 msgid "Favor from the Goddess will you require."
-msgstr ""
+msgstr "需吾屈尊助汝一臂之力"
 
 #. Key:	EDB37C414F34D2DB942D46BC07E82687
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraGetKeystone.Default__PetraGetKeystone_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Petra/Default/PetraGetKeystone.Default__PetraGetKeystone_C.SessionData.Lines(3).Lines
 msgctxt ",EDB37C414F34D2DB942D46BC07E82687"
 msgid "I've been sitting here every night waiting for one to visit me."
-msgstr ""
+msgstr "我每天晚上都坐在这里等人来拜访我。"
 
 #. Key:	EDC3705644F1B11509FCD4A1CD88991D
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault02.Default__FaleneDefault02_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault02.Default__FaleneDefault02_C.SessionData.Lines(0).Lines
 msgctxt ",EDC3705644F1B11509FCD4A1CD88991D"
 msgid "This is the Alchemist Guild! YAY!!!"
-msgstr ""
+msgstr "这里是炼精术士公会!耶！！！"
 
 #. Key:	EDFEC0864067F06F1A5A1C9F3501DE00
 #. SourceLocation:	/Game/Dialogue/Fern/SexScenes/FernCum_01.Default__FernCum_01_C.SessionData.Lines(2).Lines
@@ -12849,28 +12851,28 @@ msgstr "小蕨的嘴太……唔呃……小了嘶嘶。"
 #: /Game/UI/TaskDescriptions.TaskDescriptions.TextEntries(10).TextEntries
 msgctxt ",EDFF0F6F4588A69F5A1D5EA8DB0A78AA"
 msgid "Falene and I are attempting to extract the magical essense from wild Nephelym, so that we might better understand what makes some of us blessed. We can't remember being born, so this is an ancient puzzle that you can help with. Whatever you can make, we can take!  -Camilla"
-msgstr ""
+msgstr "法琳和我正在尝试从野生魔弗灵中提取魔法精华，这样我们就可以更好地理解是什么让我们中的一些人得到祝福。我们不记得自己出生了，所以这是一个古老的谜题，你也许可以帮忙解答。所以不管你能做什么，我们都能接受!——卡米拉"
 
 #. Key:	EE11DC6C4F3DE85807004E93DB73A0B2
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToFuta(5).LinesToFuta
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToFuta(5).LinesToFuta
 msgctxt ",EE11DC6C4F3DE85807004E93DB73A0B2"
 msgid "Ohhh... would you please this old warden? It is a lonely life..."
-msgstr "噢，你就满足我这个可怜的老守卫吧……我的命途真是太过漫长而孤独了……"
+msgstr "噢，你就满足我这个可怜的老守卫吧……我的命途真是太过漫长而寂寞了……"
 
 #. Key:	EE4B752847129E59EA2F61BC21D14B8D
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_RL.Default__NeelaDefault01_RL_C.ResponseData(3).ResponseData.BreederPrompt
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_RL.Default__NeelaDefault01_RL_C.ResponseData(3).ResponseData.BreederPrompt
 msgctxt ",EE4B752847129E59EA2F61BC21D14B8D"
 msgid "Who is the Enlightened One?"
-msgstr ""
+msgstr "谁是开悟之人？"
 
 #. Key:	EE8FDFD64822DC7BFDD6C9A70419163D
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02.Default__FernDefault02_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02.Default__FernDefault02_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",EE8FDFD64822DC7BFDD6C9A70419163D"
 msgid "Oh Master, you have fed me well."
-msgstr ""
+msgstr "噢，主人，您把我照顾的太好了。"
 
 #. Key:	EEBA2B7C475E9710DEB122887C14BEE9
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(8 - Value).TraitIcons.HelpText
@@ -12884,70 +12886,70 @@ msgstr "迷人的：配种行为得到的经验值获得相当于自身魅力属
 #: /Game/Dialogue/Emissary/Default/EmissaryHadSex01.Default__EmissaryHadSex01_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",EF1AB21445DDAE7CA5453BB814817514"
 msgid "It has been thousands of years since this holy vessel was touched in such a way, and it felt nothing."
-msgstr ""
+msgstr "几千年来，人们以这样的方式触摸这个神圣的容器，但它什么变化也没有。"
 
 #. Key:	EF23DE3948A14D6E8E26C397EFF2D243
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMNapSomewhereElse.Default__DMNapSomewhereElse_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMNapSomewhereElse.Default__DMNapSomewhereElse_C.SessionData.Lines(3).Lines
 msgctxt ",EF23DE3948A14D6E8E26C397EFF2D243"
 msgid "You're just jealous and want it for yourself!"
-msgstr ""
+msgstr "你只是嫉妒，想要自己得到它!"
 
 #. Key:	EF7904964EA5BDAA8F91D29F54021C40
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowSpiders.Default__WidowSpiders_C.SessionData.Lines(8).Lines
 #: /Game/Dialogue/Widow/Default/WidowSpiders.Default__WidowSpiders_C.SessionData.Lines(8).Lines
 msgctxt ",EF7904964EA5BDAA8F91D29F54021C40"
 msgid "Oh don't give me that look, we love our catches and never harm them."
-msgstr ""
+msgstr "别用那种眼神看我，我们爱我们的猎物，也从来不伤害她们。"
 
 #. Key:	EF902B4F424735BE83B622865F58AED8
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadStartMakeCherry.Default__DryadStartMakeCherry_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Autumn/Default/DryadStartMakeCherry.Default__DryadStartMakeCherry_C.SessionData.Lines(0).Lines
 msgctxt ",EF902B4F424735BE83B622865F58AED8"
 msgid "Climb up here with me..."
-msgstr ""
+msgstr "爬到我这儿来"
 
 #. Key:	EFEE39A441DF6F79110B608104881B11
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeAboutOrb.Default__MegaSlimeAboutOrb_C.SessionData.Lines(7).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeAboutOrb.Default__MegaSlimeAboutOrb_C.SessionData.Lines(7).Lines
 msgctxt ",EFEE39A441DF6F79110B608104881B11"
 msgid "But I love it down here, it's perfect for a slime... if only I had more company."
-msgstr ""
+msgstr "但我喜欢这里，这里对史莱姆来说很适合…要是我有更多的同伴就好了。"
 
 #. Key:	EFF175ED431E22A2893E90913974E354
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchTaskFulfilled.Default__MonarchTaskFulfilled_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Monarch/Default/MonarchTaskFulfilled.Default__MonarchTaskFulfilled_C.SessionData.Lines(0).Lines
 msgctxt ",EFF175ED431E22A2893E90913974E354"
 msgid "Whoa... this Foxen is f-f-fast!"
-msgstr ""
+msgstr "哇……这只狐狸真的……太……太…太迅速了!"
 
 #. Key:	EFFEEA9A4CC82094FD20CABC0AF432BB
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMDefault_RL5_T.Default__DMDefault_RL5_T_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/DragonMatriarch/Default/DMDefault_RL5_T.Default__DMDefault_RL5_T_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",EFFEEA9A4CC82094FD20CABC0AF432BB"
 msgid "Eeek... big genitals!"
-msgstr ""
+msgstr "嘿……大鸡鸡!"
 
 #. Key:	F010E1B74164FC7DBBA07E8F73124FEF
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_RL.Default__EmissaryDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_RL.Default__EmissaryDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
 msgctxt ",F010E1B74164FC7DBBA07E8F73124FEF"
 msgid "What does the Goddess do with my @MONSTER_RACE@?"
-msgstr "至高女神会对我所提供的魔弗灵做什么？"
+msgstr "至高女神会对我提供的魔弗灵做什么？"
 
 #. Key:	F018F7BF46C60F9708C3828E74D271BD
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R04.Default__FaleneDefault01_R04_C.SessionData.Lines(10).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R04.Default__FaleneDefault01_R04_C.SessionData.Lines(10).Lines
 msgctxt ",F018F7BF46C60F9708C3828E74D271BD"
 msgid "We have a hard time setting our desires aside, but we manage somehow."
-msgstr "我们曾经历了一段艰难的放置欲望于一旁的时期，但是不知怎么我们居然做到了。"
+msgstr "我们为了克制自己的欲望有着一段痛苦不堪的回忆，但我们很努力地做到了。"
 
 #. Key:	F02F8B45410D1DAB710358A53AE119D7
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiIdiots.Default__FesssiIdiots_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiIdiots.Default__FesssiIdiots_C.SessionData.Lines(2).Lines
 msgctxt ",F02F8B45410D1DAB710358A53AE119D7"
 msgid "Hiss... hmm... perhaps a centaur. No no, she will want money."
-msgstr ""
+msgstr "嘶嘶……嗯…也许是半人马。不，不，她会要钱的。”"
 
 #. Key:	F042509A4B58E96016C6A38E05689C66
 #. SourceLocation:	/Game/Dialogue/Fern/SexScenes/FernMilk_01.Default__FernMilk_01_C.SessionData.Lines(1).Lines
@@ -12961,21 +12963,21 @@ msgstr "*吮吸 舔舐*"
 #: /Game/Dialogue/Autumn/Default/DryadBossomCherries.Default__DryadBossomCherries_C.SessionData.Lines(4).Lines
 msgctxt ",F04A18AC479B4181D244928A4D159C06"
 msgid "Most of the time they fall, and then immediately sleep from over exertion."
-msgstr ""
+msgstr "大多数她们摔倒的时候，都会感觉很累然后呼呼睡去。"
 
 #. Key:	F05FD1324ABB81C7141ED7A41A996723
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R02.Default__CamillaDefault01_R02_C.SessionData.Lines(7).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R02.Default__CamillaDefault01_R02_C.SessionData.Lines(7).Lines
 msgctxt ",F05FD1324ABB81C7141ED7A41A996723"
 msgid "Last but by no means least, you can find the Seraphim in their temporary home Esoteric Glade."
-msgstr "最后一点，四翼天使把神秘沼泽当作一个临时的住处，你可以在那里找到她们"
+msgstr "最后一点，六翼天使把密荫之地当作一个临时的住处，你可以在那里找到她们"
 
 #. Key:	F06D080B472FAC8F39770EB5B3818956
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(15).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(15).Lines
 msgctxt ",F06D080B472FAC8F39770EB5B3818956"
 msgid "Outraged, the Goddess Herself descended and cursed the demons for their sins."
-msgstr ""
+msgstr "女神勃然大怒，于是给恶魔所犯下的罪恶降下了诅咒。"
 
 #. Key:	F091EDAA4504CD138BB740BD4D4EBCB6
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(14).LinesToMale
@@ -12989,28 +12991,28 @@ msgstr "哦~我现在已经湿了..."
 #: /Game/Dialogue/DragonMatriarch/Default/DMGreeting01.Default__DMGreeting01_C.SessionData.Lines(4).Lines
 msgctxt ",F0A3AEEB4B43B9230E0996961D788CD4"
 msgid "I am the Dragon Matriarch of Virgin Breaks, and you have awoken me from my slumber."
-msgstr ""
+msgstr "吾乃落红断崖巨龙族之女族长，汝将吾从长眠中唤醒。"
 
 #. Key:	F0AE51CA47FD221A60043B81E2DB05FB
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaHadSex01.Default__CamillaHadSex01_C.SessionData.LinesToFuta(2).LinesToFuta
 #: /Game/Dialogue/Camilla/Default/CamillaHadSex01.Default__CamillaHadSex01_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",F0AE51CA47FD221A60043B81E2DB05FB"
 msgid "Ohhh but I did!"
-msgstr ""
+msgstr "噢哦哦，我做到了！"
 
 #. Key:	F0B9252A42792A03062E66B1D8354922
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchHaveKeystone.Default__MonarchHaveKeystone_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Monarch/Default/MonarchHaveKeystone.Default__MonarchHaveKeystone_C.SessionData.Lines(5).Lines
 msgctxt ",F0B9252A42792A03062E66B1D8354922"
 msgid "Can you please breed me a swift helper?"
-msgstr ""
+msgstr "你能不能为我养个动作敏捷的小帮手？"
 
 #. Key:	F12F82174560F4F28E10D3A06B282D0A
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R02.Default__CamillaDefault01_R02_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R02.Default__CamillaDefault01_R02_C.SessionData.Lines(0).Lines
 msgctxt ",F12F82174560F4F28E10D3A06B282D0A"
 msgid "Different @MONSTER_RACE@ can be found in various places but they're generally around the Avatars of the Goddess. That's what those statues floating in the sky are called."
-msgstr "在不同的地区可以找到不同的魔弗灵，不过他们通常都在至高女神的化身附近。我们一般都这样称呼那些漂浮在空中的雕像。"
+msgstr "不同的魔弗灵可以在不同的地方找到，但他们通常围绕着女神的化身生活。也就是那些漂浮在天空中的雕像。"
 
 #. Key:	F13E7CAC4E86FD0C4B9F639D0F536883
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R07.Default__CamillaDefault01_R07_C.SessionData.LinesToMale(0).LinesToMale
@@ -13024,21 +13026,21 @@ msgstr "不要把你的美味精液浪费在我身上。等着法莲娜回来，
 #: /Game/Dialogue/Mirru/SexScenes/MirruKrakVag.Default__MirruKrakVag_C.SessionData.Lines(4).Lines
 msgctxt ",F15CA5AC442824FB00747A8771A80403"
 msgid "Yes, ohh... give me all of your seed. Ahhhhh..."
-msgstr "对……把你的种子全部射给我！"
+msgstr "对……把你的种子全部射给我！噢…哦哦…"
 
 #. Key:	F177E2D543CD7E7EEE8D7D8675341E30
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchQueen.Default__MonarchQueen_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Monarch/Default/MonarchQueen.Default__MonarchQueen_C.SessionData.Lines(4).Lines
 msgctxt ",F177E2D543CD7E7EEE8D7D8675341E30"
 msgid "I miss my little sister! She's s-s-stil a caterpillar."
-msgstr ""
+msgstr "我想念我的妹妹了!她……她……她还是一只毛毛虫。"
 
 #. Key:	F1C0D9374BF1D4EC73102080D4855555
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadFlowers.Default__DryadFlowers_C.SessionData.Lines(7).Lines
 #: /Game/Dialogue/Autumn/Default/DryadFlowers.Default__DryadFlowers_C.SessionData.Lines(7).Lines
 msgctxt ",F1C0D9374BF1D4EC73102080D4855555"
 msgid "Ejaculum-phallis is the product of dragon semen. If you bring me a large amount of it, I can use it to heal the Hivelands."
-msgstr ""
+msgstr "龙之泉涌 是龙的精液的产物。如果你给我很多很多的话，我可以用它来恢复蜂巢大地的生机。"
 
 #. Key:	F1D3A2E044E22D62A15FD2A3C291C751
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(6 - Value).TraitIcons.HelpText
@@ -13052,14 +13054,14 @@ msgstr "小型体型：身高约5英尺（1.52米）"
 #: /Game/Dialogue/DragonMatriarch/Default/DMGreeting01.Default__DMGreeting01_C.SessionData.Lines(0).Lines
 msgctxt ",F1DF0EFD4196365D249B2EBDA93F7F85"
 msgid "*Yawn*"
-msgstr ""
+msgstr "*打哈欠*"
 
 #. Key:	F1E5410345C530DA657424BD124E30D9
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernHadSex03.Default__FernHadSex03_C.SessionData.LinesToFemale(2).LinesToFemale
 #: /Game/Dialogue/Fern/DefaultP3/FernHadSex03.Default__FernHadSex03_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",F1E5410345C530DA657424BD124E30D9"
 msgid "You squirted a ton in here, how fun!"
-msgstr ""
+msgstr "您在我这里射了太多了，这太美妙了。"
 
 #. Key:	F1EF1BEA4E4AF008C65539ADC6740F61
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01_RL_M.Default__FernDefault01_RL_M_C.ResponseData(0).ResponseData.BreederPrompt
@@ -13073,7 +13075,7 @@ msgstr "你为什么称呼我为主人？"
 #: /Game/Dialogue/Kybele/Default/KybeleCentaur.Default__KybeleCentaur_C.SessionData.Lines(0).Lines
 msgctxt ",F20D52F44B97970311709CBA65ACF998"
 msgid "The feared centaur warmaiden Kybele!"
-msgstr ""
+msgstr "可怕的半人马女战神凯布莉!"
 
 #. Key:	F20F724C47A982D41C8EE29F4756992A
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_RL.Default__FaleneDefault01_RL_C.ResponseData(4).ResponseData.BreederPrompt
@@ -13087,14 +13089,14 @@ msgstr "所以魔弗灵都很饥渴吗……"
 #: /Game/Dialogue/AmberMae/Default/AmberMaeHadSex01.Default__AmberMaeHadSex01_C.SessionData.Lines(1).Lines
 msgctxt ",F2106FBD47C33358DD8CBE9C4F4ABE40"
 msgid "Ahhh... I sure do appreciate tak'n yer time to please this old milkmaid."
-msgstr ""
+msgstr "啊…谢谢尼抽粗时间来取悦这位我这位老挤奶工。"
 
 #. Key:	F21C5AFA463E6FCE44980EAAEE23498C
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchDefault01_RL.Default__MonarchDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/Monarch/Default/MonarchDefault01_RL.Default__MonarchDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",F21C5AFA463E6FCE44980EAAEE23498C"
 msgid "Pretty butterfly!"
-msgstr ""
+msgstr "好漂亮的蝴蝶！"
 
 #. Key:	F267FA90451165F036048A9D768C4718
 #. SourceLocation:	/Game/Dialogue/Fern/SexScenes/FernCum_01.Default__FernCum_01_C.SessionData.Lines(8).Lines
@@ -13108,42 +13110,42 @@ msgstr "请把您的每一滴精液都给小蕨吧。小蕨吃的越多长得越
 #: /Game/Dialogue/OrcChief/Default/OrcGreeting01.Default__OrcGreeting01_C.SessionData.Lines(0).Lines
 msgctxt ",F2F1647F46528F5AE94959AFFBE62500"
 msgid "Human! *snarl*"
-msgstr ""
+msgstr "人类!*咆哮*"
 
 #. Key:	F320BEE04338B72C9D0242A03C05EBBD
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleTaskFulfilled.Default__KybeleTaskFulfilled_C.SessionData.LinesToFuta(3).LinesToFuta
 #: /Game/Dialogue/Kybele/Default/KybeleTaskFulfilled.Default__KybeleTaskFulfilled_C.SessionData.LinesToFuta(3).LinesToFuta
 msgctxt ",F320BEE04338B72C9D0242A03C05EBBD"
 msgid "Such a large dick penetrating my deep vagina... ahhh!"
-msgstr ""
+msgstr "这么大的鸡巴在我深深的阴道里摩擦…啊……爽翻了"
 
 #. Key:	F37DF7694328A3895D54B3BC4DB0147D
 #. SourceLocation:	/Game/Dialogue/Blossom/Default/BlossomDefault01_R03.Default__BlossomDefault01_R03_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Blossom/Default/BlossomDefault01_R03.Default__BlossomDefault01_R03_C.SessionData.Lines(0).Lines
 msgctxt ",F37DF7694328A3895D54B3BC4DB0147D"
 msgid "Blossom help mastah! Blossom harvest fluidssss for you!"
-msgstr ""
+msgstr "花花能帮助主银！花花可以帮您收获体液！"
 
 #. Key:	F39F0EAF49B80BDC208978900604CC74
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R03.Default__FaleneDefault01_R03_C.SessionData.Lines(10).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R03.Default__FaleneDefault01_R03_C.SessionData.Lines(10).Lines
 msgctxt ",F39F0EAF49B80BDC208978900604CC74"
 msgid "But be warned, wild @MONSTER_RACE@ have no control over their desires and will surprise you with sex!"
-msgstr "不过我得警告你，野生魔弗灵不会控制他们的欲望，可能会对你进行性爱袭击！"
+msgstr "不过我得警告你，野生魔弗灵不会控制他们的欲望，可能会对你性爱突击！"
 
 #. Key:	F3CA61414720C714BBD4FB98C38684ED
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_RL.Default__EmissaryDefault01_RL_C.ResponseData(4).ResponseData.BreederPrompt
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_RL.Default__EmissaryDefault01_RL_C.ResponseData(4).ResponseData.BreederPrompt
 msgctxt ",F3CA61414720C714BBD4FB98C38684ED"
 msgid "How do I learn sex positions?"
-msgstr ""
+msgstr "我要怎么学习更多的体位呢？"
 
 #. Key:	F3E1DD1B4ED3DA2D29DB4CA040F01A59
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraGetKeystone.Default__PetraGetKeystone_C.SessionData.Lines(6).Lines
 #: /Game/Dialogue/Petra/Default/PetraGetKeystone.Default__PetraGetKeystone_C.SessionData.Lines(6).Lines
 msgctxt ",F3E1DD1B4ED3DA2D29DB4CA040F01A59"
 msgid "Am I to undertake a journey down to Moaning Crag and find one... no, she said to remain in the jungle."
-msgstr ""
+msgstr "我要去娇喘峭壁找她……哦不对，她说她隐居在丛林里。"
 
 #. Key:	F3F4124041D97034B836478BD7FE0BF9
 #. SourceLocation:	/Game/Characters/Procedural/Variants/Demon/Harvest/DemonHarvest.Default__DemonHarvest_C.Harvest.Description
@@ -13157,7 +13159,7 @@ msgstr "恶魔体液"
 #: /Game/Characters/Procedural/Variants/Thriae/Harvest/ThriaeHarvest.Default__ThriaeHarvest_C.Harvest.RaceName
 msgctxt ",F3FBCA874294C689B32721B1C210D74A"
 msgid "Thriae"
-msgstr "蜂人"
+msgstr "蜂娘"
 
 #. Key:	F44AC0034E9517A0581F3EA383C623F9
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_NoSpiritVariant.Default__LeylannaDefault01_NoSpiritVariant_C.SessionData.LinesToMale(0).LinesToMale
@@ -13171,35 +13173,35 @@ msgstr "等你抓住一只雄性狼灵再回来找我吧"
 #: /Game/Dialogue/Leylanna/Default/LeylannaDefault01_SmokeRL.Default__LeylannaDefault01_SmokeRL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",F4CADE7A441CE6B749B76B9F7EC26371"
 msgid "So it makes you high?"
-msgstr ""
+msgstr "恩~这让你爽上天了吧"
 
 #. Key:	F5276F72433DAADC3348C9937061AB06
 #. SourceLocation:	/Game/Ranch/Upgrades/StarfallenMonolith.Default__StarfallenMonolith_C.Upgrade.Description
 #: /Game/Ranch/Upgrades/StarfallenMonolith.Default__StarfallenMonolith_C.Upgrade.Description
 msgctxt ",F5276F72433DAADC3348C9937061AB06"
 msgid "This allows you to catch and store all variants of Starfallen."
-msgstr ""
+msgstr "这允许你捕获并饲养星陨人。"
 
 #. Key:	F539C90E493265602920739266B04C87
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimePearl.Default__MegaSlimePearl_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePearl.Default__MegaSlimePearl_C.SessionData.Lines(1).Lines
 msgctxt ",F539C90E493265602920739266B04C87"
 msgid "Are you sure you want to give this to me? Oh... I don't know what to say."
-msgstr ""
+msgstr "你确定要把这个给我吗?哦……我激动地不知道该说什么了。"
 
 #. Key:	F5C8C3C7475F573785E31C934B9F38B9
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleRideYou.Default__KybeleRideYou_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Kybele/Default/KybeleRideYou.Default__KybeleRideYou_C.SessionData.Lines(1).Lines
 msgctxt ",F5C8C3C7475F573785E31C934B9F38B9"
 msgid "Just for asking that, you are going to be my sex toy for the rest of the day!"
-msgstr ""
+msgstr "只因你提及，今天一整天你都要做我发泄欲望的性爱玩具了！"
 
 #. Key:	F5D89EF24DD4E97F5789B4AF367D8E47
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R04.Default__FaleneDefault01_R04_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R04.Default__FaleneDefault01_R04_C.SessionData.Lines(4).Lines
 msgctxt ",F5D89EF24DD4E97F5789B4AF367D8E47"
 msgid "It's our genitalia and hormones. They are extremely robust and powerful compared to humans."
-msgstr "我们的生殖器和荷尔蒙。它们比人类的性能更加稳定且强大。"
+msgstr "我们的生殖器和荷尔蒙比人类的更加充满活性且强大。"
 
 #. Key:	F5ED58D749F2CCE9DC0F23BD22E35C2D
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_RechargeSpiritForm.Default__LeylannaDefault01_RechargeSpiritForm_C.SessionData.Lines(1).Lines
@@ -13213,35 +13215,35 @@ msgstr "魂灵已经向我昭示，我们从此往后耳鬓厮磨的机会将绵
 #: /Game/Dialogue/Fern/DefaultP3/FernGreeting03.Default__FernGreeting03_C.SessionData.LinesToFuta(3).LinesToFuta
 msgctxt ",F685E190400D71BAA030AE8630162626"
 msgid "I suppose there is no need to feed me anymore, but there is another place your fluids can go!"
-msgstr ""
+msgstr "我想没必要再喂我了，但是您可以在新的地方释放您的体液了!"
 
 #. Key:	F6969BA84DEC3DFDB3D93F9DDA026D6A
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeDefault01_RL.Default__MegaSlimeDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeDefault01_RL.Default__MegaSlimeDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
 msgctxt ",F6969BA84DEC3DFDB3D93F9DDA026D6A"
 msgid "How long have you been down here?"
-msgstr ""
+msgstr "你在这下面生活多久了?"
 
 #. Key:	F69BD2354184895C493EA985FE74F5CC
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault02.Default__EmissaryDefault02_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault02.Default__EmissaryDefault02_C.SessionData.Lines(1).Lines
 msgctxt ",F69BD2354184895C493EA985FE74F5CC"
 msgid "To think your vessel made love with a pathetic blob to achieve this."
-msgstr ""
+msgstr "试着想象用你的性器和一个可怜的家伙做爱来激活。"
 
 #. Key:	F6A2BD8D4CBE73666D030B83D56908E8
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_RaiseTraitLvl.Default__EmissaryDefault01_RaiseTraitLvl_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_RaiseTraitLvl.Default__EmissaryDefault01_RaiseTraitLvl_C.SessionData.Lines(2).Lines
 msgctxt ",F6A2BD8D4CBE73666D030B83D56908E8"
 msgid "@TRAIT_LVL_COST@ shall suffice."
-msgstr "魔晶便足矣"
+msgstr "一点魔晶便足矣"
 
 #. Key:	F74061254D2D2A0904956FA983C624F3
 #. SourceLocation:	/Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToMale(0).LinesToMale
 #: /Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToMale(0).LinesToMale
 msgctxt ",F74061254D2D2A0904956FA983C624F3"
 msgid "Ohhh how I have waited to wrap my soft lips around a human dick! Ahhh..."
-msgstr "噢~你不知道我是多么迫不及待想用我的嘴唇缠住你的人类肉棒！啊啊啊……"
+msgstr "噢~你不知道我是多么迫不及待想用我的嘴唇与你的肉棒相交融！唔噢噢……"
 
 #. Key:	F743D4EB4B4F3333AEE950BA4458ECE8
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01.Default__RomyDefault01_C.SessionData.LinesGrungy(0).LinesGrungy
@@ -13262,21 +13264,21 @@ msgstr "*呻吟*"
 #: /Game/Dialogue/Cassie/Default/CassieDungeon.Default__CassieDungeon_C.SessionData.Lines(2).Lines
 msgctxt ",F7525328451BBC6ED4F59587DBE6C854"
 msgid "It has been locked for many years."
-msgstr ""
+msgstr "它已经尘封了很多年了"
 
 #. Key:	F75595714B06DF676D20B5B79FB8C222
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(20).LinesToMale
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(20).LinesToMale
 msgctxt ",F75595714B06DF676D20B5B79FB8C222"
 msgid "Since you're a breeder, it's your job to catch and mate as many @MONSTER_RACE@ as possible!"
-msgstr "自你正式成为一名饲魔者，你的工作就是尽可能去抓你所能抓到的魔弗灵并与每一个交配！"
+msgstr "自你正式成为一名饲魔者起，你的工作就是尽可能去抓你所能抓到的魔弗灵并与每一个交配！"
 
 #. Key:	F790EDFC4B6DF5886C322687396F4E9C
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleDragonMatriarch.Default__KybeleDragonMatriarch_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Kybele/Default/KybeleDragonMatriarch.Default__KybeleDragonMatriarch_C.SessionData.Lines(0).Lines
 msgctxt ",F790EDFC4B6DF5886C322687396F4E9C"
 msgid "She has charged me with guarding her offspring."
-msgstr ""
+msgstr "她嘱咐我守护她的后代。"
 
 #. Key:	F79308E4449E12AB211CF78CC8200DA9
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(21).LinesToMale
@@ -13290,91 +13292,91 @@ msgstr "而你所要抓的魔弗灵却并非像我这样受到神佑！"
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToFuta(0).LinesToFuta
 msgctxt ",F7A6401147093A75B20588870BFA39C7"
 msgid "Careful human, a Kraken's lust is not to be underestimated."
-msgstr "当心了人类，海妖的欲望可是不能小瞧的。"
+msgstr "当心了人类，克拉肯一族的淫欲可是不能小瞧的。"
 
 #. Key:	F7B920EC4CAAD4CD4E61C8915489F45C
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiIdiots.Default__FesssiIdiots_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiIdiots.Default__FesssiIdiots_C.SessionData.Lines(3).Lines
 msgctxt ",F7B920EC4CAAD4CD4E61C8915489F45C"
 msgid "Those damn centaurs only care about money and sticking their spears in places."
-msgstr ""
+msgstr "那些该死的半人马只在乎钱和把他们的长矛插在哪儿。"
 
 #. Key:	F7C4336C4CE85A985EE8819488AD2853
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMYourChildren.Default__DMYourChildren_C.SessionData.LinesToFuta(1).LinesToFuta
 #: /Game/Dialogue/DragonMatriarch/Default/DMYourChildren.Default__DMYourChildren_C.SessionData.LinesToFuta(1).LinesToFuta
 msgctxt ",F7C4336C4CE85A985EE8819488AD2853"
 msgid "Who knows which of them are mine, and I don't care. This matriarch will continue reproducing until the end of time."
-msgstr ""
+msgstr "谁知道他们哪些是我的后代,而且我也不在乎。女族长将继续繁衍直到时间的尽头。"
 
 #. Key:	F80CC71F49A124229467EC98902D86F9
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleCentaur.Default__KybeleCentaur_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Kybele/Default/KybeleCentaur.Default__KybeleCentaur_C.SessionData.Lines(4).Lines
 msgctxt ",F80CC71F49A124229467EC98902D86F9"
 msgid "Count yourself fortunate, in case you haven't noticed the challenge present for a centuar to please herself."
-msgstr ""
+msgstr "算你走运，半人马还没有因为私欲而向你发起挑战。"
 
 #. Key:	F84550BD45785F99DC5ACC9F2C125EDF
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleDefault01_RL.Default__KybeleDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/Kybele/Default/KybeleDefault01_RL.Default__KybeleDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",F84550BD45785F99DC5ACC9F2C125EDF"
 msgid "Dragon Matriarch?"
-msgstr ""
+msgstr "龙族女族长？"
 
 #. Key:	F88AA516424D4DB3A67953803B2F3000
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_Formuria.Default__MirruDefault01_Formuria_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_Formuria.Default__MirruDefault01_Formuria_C.SessionData.Lines(3).Lines
 msgctxt ",F88AA516424D4DB3A67953803B2F3000"
 msgid "*Sigh* I hold them dear, but pity them for not being born Kraken."
-msgstr "*叹气*我很爱他们，可也为他们可惜。毕竟，他们生来就不是海妖。"
+msgstr "*叹气*我珍视他们，但可惜的是他们非克拉肯一族所生。"
 
 #. Key:	F890DAF744D2EC5F55BEE5AFC5CA772A
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowHadSex01.Default__WidowHadSex01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Widow/Default/WidowHadSex01.Default__WidowHadSex01_C.SessionData.Lines(0).Lines
 msgctxt ",F890DAF744D2EC5F55BEE5AFC5CA772A"
 msgid "Sweet succulent human, you were delicious..."
-msgstr ""
+msgstr "甜蜜多汁的人类，你太美味了…"
 
 #. Key:	F8A579884E09A8EAFE39C78D6B221425
 #. SourceLocation:	/Game/Dialogue/AmberMae/SexScenes/AmberMilkyF.Default__AmberMilkyF_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/AmberMae/SexScenes/AmberMilkyF.Default__AmberMilkyF_C.SessionData.Lines(2).Lines
 msgctxt ",F8A579884E09A8EAFE39C78D6B221425"
 msgid "Drink it, ahhhh... ohhh..."
-msgstr "快喝…啊噢噢"
+msgstr "快喝…啊噢噢…喔噢噢……"
 
 #. Key:	F8B7E4C84269C81CD36B5CB136D0AA4F
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcHaveKeystone.Default__OrcHaveKeystone_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcHaveKeystone.Default__OrcHaveKeystone_C.SessionData.Lines(2).Lines
 msgctxt ",F8B7E4C84269C81CD36B5CB136D0AA4F"
 msgid "Mates... yes. Human is breeder!"
-msgstr ""
+msgstr "配偶……对哦，人类是繁殖对象！"
 
 #. Key:	F8E2DB524A01D500B2ED3BB19853D247
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToMale(5).LinesToMale
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToMale(5).LinesToMale
 msgctxt ",F8E2DB524A01D500B2ED3BB19853D247"
 msgid "Ohhh... would you please this old warden? It is a lonely life..."
-msgstr "噢，你就满足我这个可怜的老守卫吧……我的命途真是太过漫长而孤独了……"
+msgstr "噢，你就满足我这个可怜的老守卫吧……我的命途真是太过漫长而寂寞了……"
 
 #. Key:	F8E720D345661A45019656BB02DC9809
 #. SourceLocation:	/Game/Dialogue/Blossom/Default/BlossomGreeting01.Default__BlossomGreeting01_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Blossom/Default/BlossomGreeting01.Default__BlossomGreeting01_C.SessionData.Lines(2).Lines
 msgctxt ",F8E720D345661A45019656BB02DC9809"
 msgid "Mastah?"
-msgstr ""
+msgstr "主银？"
 
 #. Key:	F91CB0D5406C6A0CEF265AACB268DDE0
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernGreeting01.Default__FernGreeting01_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Fern/Default/FernGreeting01.Default__FernGreeting01_C.SessionData.Lines(2).Lines
 msgctxt ",F91CB0D5406C6A0CEF265AACB268DDE0"
 msgid "Mastah?"
-msgstr "主……嘶人？"
+msgstr "主银？"
 
 #. Key:	F98CD43545B39F2F962E56AF0DC2ADAA
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraAboutPawsmaati.Default__PetraAboutPawsmaati_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Petra/Default/PetraAboutPawsmaati.Default__PetraAboutPawsmaati_C.SessionData.Lines(5).Lines
 msgctxt ",F98CD43545B39F2F962E56AF0DC2ADAA"
 msgid "I never wanted it to end! She was in complete control the entire time, not releasing until I came ten times."
-msgstr ""
+msgstr "我从不希望停下来!她完全主宰了整场做爱，直到我去了十次她才高潮。"
 
 #. Key:	F9C66FA74BAA102FE1238A952823D3D9
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R01.Default__FaleneDefault01_R01_C.SessionData.Lines(17).Lines
@@ -13388,7 +13390,7 @@ msgstr "我多希望我能记得我的出生与童年，那会使我的研究容
 #: /Game/Dialogue/Cassie/Default/CassieDefault01_Meow_StartButterButt.Default__CassieDefault01_Meow_StartButterButt_C.SessionData.Lines(0).Lines
 msgctxt ",F9EF68BC4CE831DD669546BF6213C846"
 msgid "MEOW!!! Cassie is going to fill you with kitty seed!"
-msgstr "喵呜！！！凯希要在你体内播种啦！"
+msgstr "喵呜！！！凯茜要在你体内播种啦！"
 
 #. Key:	FA099D00490628CE02692F98F8341539
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(34 - Value).TraitIcons.DisplayName
@@ -13409,7 +13411,7 @@ msgstr "脏乱不堪：配种对象有20%的几率变脏，降低50%的魅力属
 #: /Game/Dialogue/Monarch/Default/MonarchPrettyButterfly.Default__MonarchPrettyButterfly_C.SessionData.Lines(3).Lines
 msgctxt ",FA28913344F5F91202D288867FDD4829"
 msgid "If y-y-you know what I mean."
-msgstr ""
+msgstr "如……如果……你……你懂我指的是什么"
 
 #. Key:	FA2C70284FBA2B074235FD87FF6B8D64
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDefault01.Default__CassieDefault01_C.SessionData.Lines(1).Lines
@@ -13423,21 +13425,21 @@ msgstr "*咕噜咕噜声*"
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_AboutKrakens.Default__MirruDefault01_AboutKrakens_C.SessionData.Lines(9).Lines
 msgctxt ",FA4364AD420E7246DD976FA55489258C"
 msgid "At least, I can promise a Kraken's body will provide our mates with enormous pleasure."
-msgstr "所幸，至少我敢保证克拉肯的肉体能给予同胞们压倒性的快感。"
+msgstr "至少，我可以保证海怪的身体会给我们的伴侣带来极大的欢愉。"
 
 #. Key:	FA986E53459F35B9F05FE5909E9153CE
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMDefault01.Default__DMDefault01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMDefault01.Default__DMDefault01_C.SessionData.Lines(0).Lines
 msgctxt ",FA986E53459F35B9F05FE5909E9153CE"
 msgid "*Yawn*"
-msgstr ""
+msgstr "*打哈欠*"
 
 #. Key:	FAA596EC4B5291C8FF02FC9966C3C4B6
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeDefault01.Default__MegaSlimeDefault01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeDefault01.Default__MegaSlimeDefault01_C.SessionData.Lines(1).Lines
 msgctxt ",FAA596EC4B5291C8FF02FC9966C3C4B6"
 msgid "AND I have!! For nearly 1000 years, down here all by myself..."
-msgstr ""
+msgstr "我想! !将近1000年了，就我独自在这里……"
 
 #. Key:	FAA5B41940157F8963E69CB4ACE814A4
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeDefault01_MilkyProducts.Default__AmberMaeDefault01_MilkyProducts_C.SessionData.Lines(0).Lines
@@ -13451,175 +13453,175 @@ msgstr "请尽情挑选俺的奶！"
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03_RL_F.Default__FernDefault03_RL_F_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",FAA922F744CCD015043333AD26B1B5AF"
 msgid "You've changed!"
-msgstr ""
+msgstr "你变了！"
 
 #. Key:	FAB1F6F548473C3126B60F9981FBA341
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",FAB1F6F548473C3126B60F9981FBA341"
 msgid "Ohhh @BREEDER_NAME@... you were amazing."
-msgstr ""
+msgstr "唔喔@BREEDER_NAME@……你棒的惊人。"
 
 #. Key:	FAC3B1AA48B55AC22C81BABA4025A329
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_TheVoid.Default__NeelaDefault01_TheVoid_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_TheVoid.Default__NeelaDefault01_TheVoid_C.SessionData.Lines(3).Lines
 msgctxt ",FAC3B1AA48B55AC22C81BABA4025A329"
 msgid "However, by stepping into a sacred pussy portal one can enter the Void from this plane."
-msgstr "不过，从这儿踏入这道神圣的蜜穴之门可以帮助你从这个次元到达虚空。"
+msgstr "不过，从这儿踏入这道神圣的蜜穴之门可以帮助你从这个次元步入虚空。"
 
 #. Key:	FAD4B31949B0D1AC3DE5B3A79B8048C6
 #. SourceLocation:	/Game/Dialogue/Mirru/SexScenes/MirruSnatchF.Default__MirruSnatchF_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Mirru/SexScenes/MirruSnatchF.Default__MirruSnatchF_C.SessionData.Lines(5).Lines
 msgctxt ",FAD4B31949B0D1AC3DE5B3A79B8048C6"
 msgid "Ohhh yes... ahhh..."
-msgstr "噢……就是这样！"
+msgstr "噢……是的~就是这样！喔……"
 
 #. Key:	FAF0FA2D4B10AE21D5D8D2A27EAE488D
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruHadSex01.Default__MirruHadSex01_C.SessionData.LinesToFemale(5).LinesToFemale
 #: /Game/Dialogue/Mirru/Default/MirruHadSex01.Default__MirruHadSex01_C.SessionData.LinesToFemale(5).LinesToFemale
 msgctxt ",FAF0FA2D4B10AE21D5D8D2A27EAE488D"
 msgid "Perhaps next time I will indulge myself and not go so easy on you..."
-msgstr ""
+msgstr "也许下次吾会放纵自己本来的野性，不会对汝那么温柔了……"
 
 #. Key:	FAF57AE645B3D2B5A5373CA6FA1C5EA6
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadFlowers.Default__DryadFlowers_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Autumn/Default/DryadFlowers.Default__DryadFlowers_C.SessionData.Lines(1).Lines
 msgctxt ",FAF57AE645B3D2B5A5373CA6FA1C5EA6"
 msgid "However I am going to require a lot of... seed."
-msgstr ""
+msgstr "无论如何我都需要很多…很多的种子。"
 
 #. Key:	FB09A1964EDEBFF9F5E3839307040AEB
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchDefault01.Default__MonarchDefault01_C.SessionData.LinesToFemale(4).LinesToFemale
 #: /Game/Dialogue/Monarch/Default/MonarchDefault01.Default__MonarchDefault01_C.SessionData.LinesToFemale(4).LinesToFemale
 msgctxt ",FB09A1964EDEBFF9F5E3839307040AEB"
 msgid "Is t-t-there something... you want human?"
-msgstr ""
+msgstr "你……你需……你需要什么吗？人类。"
 
 #. Key:	FB2BB3B44297DAF2860982BAD6C1819A
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToMale(0).LinesToMale
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToMale(0).LinesToMale
 msgctxt ",FB2BB3B44297DAF2860982BAD6C1819A"
 msgid "Careful human, a Kraken's lust is not to be underestimated."
-msgstr "当心了人类，海妖的欲望可是不能小瞧的。"
+msgstr "当心了人类，克拉肯一族的淫欲可是不能小瞧的。"
 
 #. Key:	FB4D6F564D28EE26BC34658F3C9B1F73
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimePlay.Default__MegaSlimePlay_C.SessionData.LinesToFemale(2).LinesToFemale
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePlay.Default__MegaSlimePlay_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",FB4D6F564D28EE26BC34658F3C9B1F73"
 msgid "Well what are you waiting for? Come on in!"
-msgstr ""
+msgstr "那你还在等什么呢？快进来吧！"
 
 #. Key:	FB6284F34E0BBFD934651EAD6C3DC5D8
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchGreeting01.Default__MonarchGreeting01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Monarch/Default/MonarchGreeting01.Default__MonarchGreeting01_C.SessionData.Lines(0).Lines
 msgctxt ",FB6284F34E0BBFD934651EAD6C3DC5D8"
 msgid "Oh, hello!"
-msgstr ""
+msgstr "噢，你好呀！"
 
 #. Key:	FB857A0E425DC310680C179A127076D3
 #. SourceLocation:	/Game/Dialogue/Mirru/SexScenes/MirruSnatchF.Default__MirruSnatchF_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Mirru/SexScenes/MirruSnatchF.Default__MirruSnatchF_C.SessionData.Lines(3).Lines
 msgctxt ",FB857A0E425DC310680C179A127076D3"
 msgid "Ahh... it feels so good! I am going to cum."
-msgstr "啊……太爽了！我要高潮了！"
+msgstr "啊……太爽了！我……我要去了！"
 
 #. Key:	FB8D2D144CB9249F47237B94F66E71F1
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(6).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(6).Lines
 msgctxt ",FB8D2D144CB9249F47237B94F66E71F1"
 msgid "Why I drink it and use it to make magic treats of course! I ain't a wee lass mind you--I drink lots o' the stuff! Also, me treats are famous world wide!"
-msgstr ""
+msgstr "俺喝了它就可以用她们来款待尼!俺不会像个小姑娘一样提醒你'哦~我喝得太多了!'哦，俺的款待可有名了!"
 
 #. Key:	FBA6175C45D9F4E3E3CD7F85021561C6
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_Pregnancy.Default__FaleneDefault01_Pregnancy_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_Pregnancy.Default__FaleneDefault01_Pregnancy_C.SessionData.Lines(0).Lines
 msgctxt ",FBA6175C45D9F4E3E3CD7F85021561C6"
 msgid "Pregnancy isn't what you think!"
-msgstr "怀孕不是你想的那样！"
+msgstr "怀孕才不是你想的那样！"
 
 #. Key:	FBB64BA447C689B390DF64875A9061E9
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_TheVoid.Default__NeelaDefault01_TheVoid_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_TheVoid.Default__NeelaDefault01_TheVoid_C.SessionData.Lines(5).Lines
 msgctxt ",FBB64BA447C689B390DF64875A9061E9"
 msgid "Despite over 4,000 years traversing the Void, I have yet to find our fabled birthplace."
-msgstr "尽管我已经在虚空里穿梭了超过四千年，还是没有找到我们传说中的起源之地。"
+msgstr "尽管我已经在虚空里穿梭了超过四千年，还是没有找到我们传说中的发源之地。"
 
 #. Key:	FBC59E69493451F2A30A66818584F9BC
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadCherryHelp.Default__DryadCherryHelp_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/Autumn/Default/DryadCherryHelp.Default__DryadCherryHelp_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",FBC59E69493451F2A30A66818584F9BC"
 msgid "Ohhh how I've waited for this."
-msgstr ""
+msgstr "哦，我等这一刻等的太久了。"
 
 #. Key:	FBDDB80F480F00F6DF7E1BA03EC927F6
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowTaskFullfilled2.Default__WidowTaskFullfilled2_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Widow/Default/WidowTaskFullfilled2.Default__WidowTaskFullfilled2_C.SessionData.Lines(2).Lines
 msgctxt ",FBDDB80F480F00F6DF7E1BA03EC927F6"
 msgid "Always she crawls to me, begging me to suck her juicy nethers and breasts... and I gladly oblige."
-msgstr ""
+msgstr "她总是爬到我身边，求我吮吸她多汁的阴道和乳房……当然我也很乐意帮她这个忙。"
 
 #. Key:	FBE363A241E1A6C5172380A2F5CAFD27
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleGreeting01.Default__KybeleGreeting01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Kybele/Default/KybeleGreeting01.Default__KybeleGreeting01_C.SessionData.Lines(1).Lines
 msgctxt ",FBE363A241E1A6C5172380A2F5CAFD27"
 msgid "I see that look in your eye, you wish to use the denizens of Virgin Breaks for your own pleasure."
-msgstr ""
+msgstr "我懂你眼神里的意思，你想利用落红断崖的圣灵来找些乐子。"
 
 #. Key:	FBF536C949746784E2045981A88739F6
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaHadSex02.Default__CamillaHadSex02_C.SessionData.LinesToMale(0).LinesToMale
 #: /Game/Dialogue/Camilla/Default/CamillaHadSex02.Default__CamillaHadSex02_C.SessionData.LinesToMale(0).LinesToMale
 msgctxt ",FBF536C949746784E2045981A88739F6"
 msgid "Wow human, you must have been desperate to give this nugget your love."
-msgstr ""
+msgstr "哇人类！你一定很想把你的爱给这个小东西。"
 
 #. Key:	FC2E4BC244CE7A4471B402A207DCB5C4
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03.Default__FernDefault03_C.SessionData.LinesToFuta(0).LinesToFuta
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03.Default__FernDefault03_C.SessionData.LinesToFuta(0).LinesToFuta
 msgctxt ",FC2E4BC244CE7A4471B402A207DCB5C4"
 msgid "Oh Master, you have fed me well."
-msgstr ""
+msgstr "喔主人，您把我照顾的很好。"
 
 #. Key:	FC6A48C641C7797ED1492DB62B0AC386
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R07_RL.Default__CamillaDefault01_R07_RL_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R07_RL.Default__CamillaDefault01_R07_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",FC6A48C641C7797ED1492DB62B0AC386"
 msgid "Mmm Amber's tits..."
-msgstr "嗯~ 安铂的胸……"
+msgstr "嗯~ 安贝尔的乳头……"
 
 #. Key:	FCA66F654F21F79586D7899A9C2CADC5
 #. SourceLocation:	/Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToFemale(3).LinesToFemale
 #: /Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",FCA66F654F21F79586D7899A9C2CADC5"
 msgid "*Slurp* *Lick*"
-msgstr "*啧啧水声*...*舔*"
+msgstr "*嘶嘶啜食*...*舔*"
 
 #. Key:	FCD1F71F4D144F31FDAB9F89767AC8E7
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyGreeting01.Default__RomyGreeting01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Romy/Default/RomyGreeting01.Default__RomyGreeting01_C.SessionData.Lines(1).Lines
 msgctxt ",FCD1F71F4D144F31FDAB9F89767AC8E7"
 msgid "Yes it sounds so sweet, it is the sound of human desire. Ahhh... it grows louder as your gaze turns upon my breasts."
-msgstr "是的，听起来十分诱人，这是人类欲望的歌声。啊... 随着你的目光转向我的乳房，欲望的声音变得越来越大了。"
+msgstr "是的听起来如此甜美,它是人类欲望的声音。啊…当你的停留在我的乳房上时，欲望的歌声变得更加响亮……"
 
 #. Key:	FCEBBA094930884E07B0A38C1FC062B8
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchHadSex01.Default__MonarchHadSex01_C.SessionData.LinesToFemale(2).LinesToFemale
 #: /Game/Dialogue/Monarch/Default/MonarchHadSex01.Default__MonarchHadSex01_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",FCEBBA094930884E07B0A38C1FC062B8"
 msgid "I hope my toy made you feel good. Maybe... w-w-we can do it again?"
-msgstr ""
+msgstr "希望我的玩具能让你感觉好点。也许……我……我们可以再来一次?"
 
 #. Key:	FCFE3B3D4F76E0D8BBC19BBF1F504CC6
 #. SourceLocation:	/Game/Dialogue/Yasmine/Default/YasmineAwake.Default__YasmineAwake_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Yasmine/Default/YasmineAwake.Default__YasmineAwake_C.SessionData.Lines(1).Lines
 msgctxt ",FCFE3B3D4F76E0D8BBC19BBF1F504CC6"
 msgid "It happens every time I open, you think I would have learned by now."
-msgstr ""
+msgstr "当我每次打开贝壳的时候都会这样，你想我应该已经意识到这个问题了对吧。"
 
 #. Key:	FD102648460B4847C187CA85C454705B
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeMoreHoney.Default__BeeMoreHoney_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/QueenBee/Default/BeeMoreHoney.Default__BeeMoreHoney_C.SessionData.Lines(1).Lines
 msgctxt ",FD102648460B4847C187CA85C454705B"
 msgid "Kneel and suck human. Engorge yourself on my honey, for it pleases me greatly."
-msgstr ""
+msgstr "跪下来吸吧人类。尽情享用我的蜜吧，因为这非常让我感觉骄傲"
 
 #. Key:	FD257CB04C6B3AB420244298D2C33047
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(14 - Value).TraitIcons.DisplayName
@@ -13633,14 +13635,14 @@ msgstr "欲壑难填"
 #: /Game/Dialogue/Autumn/Default/DryadHaveKeystone2.Default__DryadHaveKeystone2_C.SessionData.Lines(2).Lines
 msgctxt ",FD45A2EF441A8E608939FF9788710118"
 msgid "There, they will no longer block your path."
-msgstr ""
+msgstr "好了，我的根不会再挡住你前进的脚步了。"
 
 #. Key:	FD4609F340081E569544E6914EAA6434
 #. SourceLocation:	/Game/Dialogue/Yasmine/Default/YasmineDefault02.Default__YasmineDefault02_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Yasmine/Default/YasmineDefault02.Default__YasmineDefault02_C.SessionData.Lines(0).Lines
 msgctxt ",FD4609F340081E569544E6914EAA6434"
 msgid "..."
-msgstr ""
+msgstr "……"
 
 #. Key:	FD467EAE4829745CF23D4BA9D511E423
 #. SourceLocation:	/Game/Dialogue/Mirru/SexScenes/MirruSnatchF.Default__MirruSnatchF_C.SessionData.Lines(2).Lines
@@ -13661,42 +13663,42 @@ msgstr "腹部的肿胀程度代表了新生儿成长的过程！"
 #: /Game/Dialogue/Fesssi/Default/FesssiHowLong.Default__FesssiHowLong_C.SessionData.Lines(9).Lines
 msgctxt ",FD60314C4ADEEDC7A454ECA6AA29E42A"
 msgid "A lamia's body is very sensitive in certain places, and if massaged correctly can induce a nice orgasm."
-msgstr ""
+msgstr "拉米娅的身体在某些地方非常敏感，如果你按摩到位的话，就能引发一次棒极了的性高潮。"
 
 #. Key:	FD6F8B5B4B3A96B1EC5B4D838FCA8599
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToFemale(7).LinesToFemale
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToFemale(7).LinesToFemale
 msgctxt ",FD6F8B5B4B3A96B1EC5B4D838FCA8599"
 msgid "Believe it or not, I used to be bigger, but I lost a large chunk of myself and it floated away..."
-msgstr ""
+msgstr "信不信由你，我以前块头更大，后来我失去了我自己的一大块，它就这么漂走了…………"
 
 #. Key:	FD8011CC4C321FCEC4C41F88F97FDCD1
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TravelShrines(3 - Value).TravelShrines.ShrineName
 #: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TravelShrines(3 - Value).TravelShrines.ShrineName
 msgctxt ",FD8011CC4C321FCEC4C41F88F97FDCD1"
 msgid "Moaning Crag"
-msgstr "呻吟峭壁"
+msgstr "娇喘峭壁"
 
 #. Key:	FD905EC14D8B8AC5E3D8D28AB7280C39
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid_RL.Default__NeelaDefault01_YourVoid_RL_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid_RL.Default__NeelaDefault01_YourVoid_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",FD905EC14D8B8AC5E3D8D28AB7280C39"
 msgid "Experience this human!"
-msgstr ""
+msgstr "尝尝这个！人类！"
 
 #. Key:	FD996BF544296A6A4A54CE82ABF12183
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernGreeting02.Default__FernGreeting02_C.SessionData.LinesToFuta(2).LinesToFuta
 #: /Game/Dialogue/Fern/DefaultP2/FernGreeting02.Default__FernGreeting02_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",FD996BF544296A6A4A54CE82ABF12183"
 msgid "I am a growing Alraune, perhaps you have fluids to spare?"
-msgstr ""
+msgstr "我是一只正在成长的曼陀罗，您可以分一些体液给我吗？"
 
 #. Key:	FDB79BD24E2E79AD2A532E8378563FD0
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault02.Default__CamillaDefault02_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaDefault02.Default__CamillaDefault02_C.SessionData.Lines(4).Lines
 msgctxt ",FDB79BD24E2E79AD2A532E8378563FD0"
 msgid "Not to eat me, it did other things to my little body... it felt amazing actually."
-msgstr ""
+msgstr "并不是想吃我，它对我的小身体做了其他的事情……实际上感觉美妙极了。"
 
 #. Key:	FDBDE7714A97FE255B38A0BACEC479DB
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(7 - Value).TraitIcons.DisplayName
@@ -13710,14 +13712,14 @@ msgstr "微小体型"
 #: /Game/Dialogue/Monarch/Default/MonarchQueen.Default__MonarchQueen_C.SessionData.Lines(6).Lines
 msgctxt ",FDF3D1784F3939583D52ADB0231DF337"
 msgid "Legends say beautiful angels fly around its spires."
-msgstr ""
+msgstr "神话中说美丽的天使们萦绕着塔尖翩翩起舞。"
 
 #. Key:	FDF4297C47FFAC2C90A1C8A5AC503A21
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadTaskFulfilled.Default__DryadTaskFulfilled_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Autumn/Default/DryadTaskFulfilled.Default__DryadTaskFulfilled_C.SessionData.Lines(1).Lines
 msgctxt ",FDF4297C47FFAC2C90A1C8A5AC503A21"
 msgid "She knows how to please, and her delicious honey has increased my fruit production."
-msgstr ""
+msgstr "她知道如何取悦别人，她美味的蜂蜜甚至增加了我的水果产量。"
 
 #. Key:	FE11832245764B482A5550B347EB143E
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(25).LinesToMale
@@ -13731,7 +13733,7 @@ msgstr "不过，有些魔弗灵可是极其精于此道并能让你体会到超
 #: /Game/Dialogue/Yasmine/Default/YasmineHadSex01.Default__YasmineHadSex01_C.SessionData.Lines(2).Lines
 msgctxt ",FE30CC0F4EC31063CA576A8A6CF941F5"
 msgid "Let us spend the day together, for here in the warmth of this water we can sing again for hours."
-msgstr ""
+msgstr "让吾等一起度过这一天吧，因为在这温暖的泉水里，我们可以再唱上几个小时、"
 
 #. Key:	FE908E8B4214DDCF1709D284DCA9D0E1
 #. SourceLocation:	/Game/Dialogue/Cassie/SexScenes/CassieButterButtF.Default__CassieButterButtF_C.SessionData.Lines(1).Lines
@@ -13745,35 +13747,35 @@ msgstr "*咕噜咕噜声*"
 #: /Game/Dialogue/OrcChief/Default/OrcGreeting01.Default__OrcGreeting01_C.SessionData.Lines(2).Lines
 msgctxt ",FE9D2CEF44200883BEC34F94279CA502"
 msgid "My tribe very horny, need elves for breeding."
-msgstr ""
+msgstr "我的部落十分的饥渴，需要精灵们来繁衍后代。"
 
 #. Key:	FEB03B36414C543E3D3737B9AB198545
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimePlay1.Default__MegaSlimePlay1_C.SessionData.LinesToFemale(2).LinesToFemale
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePlay1.Default__MegaSlimePlay1_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",FEB03B36414C543E3D3737B9AB198545"
 msgid "*Yawn* Might need a nap after we make love again."
-msgstr ""
+msgstr "*打哈欠*我想在我们再爱一次前需要小小的打个盹"
 
 #. Key:	FEB3BE874AC81C2B63FD03953371A656
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeVerySad.Default__MegaSlimeVerySad_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeVerySad.Default__MegaSlimeVerySad_C.SessionData.Lines(2).Lines
 msgctxt ",FEB3BE874AC81C2B63FD03953371A656"
 msgid "Who would... after years of loneliness... *sniff*"
-msgstr ""
+msgstr "谁会…在多年的孤独之后来……*啜泣*"
 
 #. Key:	FEE6416B44C40270EC8167ADD51EA060
 #. SourceLocation:	/Game/Dialogue/Mirru/SexScenes/MirruKrakVag.Default__MirruKrakVag_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Mirru/SexScenes/MirruKrakVag.Default__MirruKrakVag_C.SessionData.Lines(0).Lines
 msgctxt ",FEE6416B44C40270EC8167ADD51EA060"
 msgid "Ohhh human yes... my soft fleshy groin awaits you."
-msgstr "噢……人类……我柔软的小穴已经急不可耐了！"
+msgstr "噢……人类…喔噢噢……我柔软的蜜穴已经等不及了！"
 
 #. Key:	FEEAD6AA4B91EE463E366FBDCB397167
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_AboutKrakens.Default__MirruDefault01_AboutKrakens_C.SessionData.Lines(8).Lines
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_AboutKrakens.Default__MirruDefault01_AboutKrakens_C.SessionData.Lines(8).Lines
 msgctxt ",FEEAD6AA4B91EE463E366FBDCB397167"
 msgid "Even a drylander such as yourself can probably guess what purpose my two front tentacles serve."
-msgstr "即使是你这样的旱地人也猜得到我这两条触手的作用吧。"
+msgstr "即使是汝这样的旱地人也猜得到吾这两条触手的作用吧。"
 
 #. Key:	FF0D5A0E4AD29A5B9CCF59942CB94FFA
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_RaiseTraitLvl.Default__EmissaryDefault01_RaiseTraitLvl_C.SessionData.Lines(0).Lines
@@ -13787,21 +13789,21 @@ msgstr "吾感到汝在寻找汝认为质量更上乘的种族。"
 #: /Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFuta(8).LinesToFuta
 msgctxt ",FF2AAC0145D999DF7D9EE5BBF54B6B50"
 msgid "That must have been you, perhaps you should go and talk to her."
-msgstr ""
+msgstr "那一定是和你有关，也许你应该去和她谈谈"
 
 #. Key:	FF350C0E49A57126AB07218CBF432744
 #. SourceLocation:	/Game/UI/TaskDescriptions.TaskDescriptions.TextEntries(9).TextEntries
 #: /Game/UI/TaskDescriptions.TaskDescriptions.TextEntries(9).TextEntries
 msgctxt ",FF350C0E49A57126AB07218CBF432744"
 msgid "The Void gets dull when you have wandered it for countless millennia, and it's been awhile since I wrapped my body around a helpless mate. Could you make me a new toy to squeeze?  -Neela"
-msgstr ""
+msgstr "当你在虚空中徘徊了无数个千年之后，虚空就变得枯燥无味。而我缠上了一个无助的伴侣已经很久了，你能给我做一个新玩具来让我榨精吗？——妮拉"
 
 #. Key:	FF56CAFF482C5F43FF4C419DCB359C8A
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R06.Default__CamillaDefault01_R06_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R06.Default__CamillaDefault01_R06_C.SessionData.Lines(0).Lines
 msgctxt ",FF56CAFF482C5F43FF4C419DCB359C8A"
 msgid "Mean human! Girthy little lumps have feelings too!"
-msgstr "粗鲁的人类!矮肥圆也有感情!"
+msgstr "粗鲁的人类!矮肥圆也是有感情的!"
 
 #. Key:	FF5A245B4A28E802C1A30CAC4B4DE4E5
 #. SourceLocation:	/Game/Characters/Procedural/Variants/Seraphim/Harvest/SeraphimHarvest.Default__SeraphimHarvest_C.Harvest.Description
@@ -13815,7 +13817,7 @@ msgstr "天使体液"
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(5).LinesToMale
 msgctxt ",FFA17F124A05F93244CA07860B63DEA2"
 msgid "Oh silly me, I never introduced myself."
-msgstr "哦我真傻，我还没有做过自我介绍。"
+msgstr "哦我可真傻，我还没有做过自我介绍呀。"
 
 #. Key:	FFEB9256402DB5ADDFEED38770F40285
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(24 - Value).TraitIcons.HelpText
@@ -13829,448 +13831,448 @@ msgstr "丰乳：继承了一对非常大的乳房"
 #: /Game/Dialogue/Fesssi/Default/FesssiAreYouOk.Default__FesssiAreYouOk_C.SessionData.Lines(1).Lines
 msgctxt ",FFF6AE0C41E39194F413A28DAC8CD9F5"
 msgid "Give into your desires human. I know you want to mate with all of thisss."
-msgstr ""
+msgstr "得了吧，屈服于你的欲望吧人类。我知道你想和这些东西做爱。"
 
 #. Key:	SpiritFormActivate
 #. SourceLocation:	Source/Radiant/Public/Characters/SexyBreederCharacter.cpp:230
 #: Source/Radiant/Public/Characters/SexyBreederCharacter.cpp:230
 msgctxt "ASexyBreederCharacter,SpiritFormActivate"
 msgid "A Nephelym spirit has merged with {0}."
-msgstr ""
+msgstr "一个魔弗灵的灵魂与{0}结合了。"
 
 #. Key:	SpiritFormDeactivate
 #. SourceLocation:	Source/Radiant/Public/Characters/SexyBreederCharacter.cpp:236
 #: Source/Radiant/Public/Characters/SexyBreederCharacter.cpp:236
 msgctxt "ASexyBreederCharacter,SpiritFormDeactivate"
 msgid "The spirit has departed."
-msgstr ""
+msgstr "魔弗灵的魂灵离开了你的躯体。"
 
 #. Key:	SpiritFormNotEnough
 #. SourceLocation:	Source/Radiant/Public/Characters/SexyBreederCharacter.cpp:225
 #: Source/Radiant/Public/Characters/SexyBreederCharacter.cpp:225
 msgctxt "ASexyBreederCharacter,SpiritFormNotEnough"
 msgid "Not enough spirit."
-msgstr ""
+msgstr "魂灵不够"
 
 #. Key:	NoKeystones
 #. SourceLocation:	Source/Radiant/Public/Characters/Breeder/SexyBreederController.cpp:666
 #: Source/Radiant/Public/Characters/Breeder/SexyBreederController.cpp:666
 msgctxt "ASexyBreederController,NoKeystones"
 msgid "A keystone is required."
-msgstr ""
+msgstr "需要一颗钥石。"
 
 #. Key:	IncestMessage
 #. SourceLocation:	Source/Radiant/Public/Game/Monsters/SexyBreedingSystem.cpp:328
 #: Source/Radiant/Public/Game/Monsters/SexyBreedingSystem.cpp:328
 msgctxt "ASexyBreedingSystem,IncestMessage"
 msgid "This might not turn out well..."
-msgstr ""
+msgstr "这可能不会有好结果……"
 
 #. Key:	ReleasedOffspring
 #. SourceLocation:	Source/Radiant/Public/Game/Monsters/SexyBreedingSystem.cpp:447
 #: Source/Radiant/Public/Game/Monsters/SexyBreedingSystem.cpp:447
 msgctxt "ASexyBreedingSystem,ReleasedOffspring"
 msgid "Released offspring into the wild."
-msgstr ""
+msgstr "把后代放生到野外。"
 
 #. Key:	BadSettingsMessage
 #. SourceLocation:	Source/Radiant/Public/Characters/SexyCharacterSystem.cpp:1233
 #: Source/Radiant/Public/Characters/SexyCharacterSystem.cpp:1233
 msgctxt "ASexyCharacterSystem,BadSettingsMessage"
 msgid "Both female hominal and exotic variants are disabled, default will be used."
-msgstr ""
+msgstr "关闭了随机生成人形女性魔弗灵的特殊配色和身材，仅使用默认值。"
 
 #. Key:	SpiritForm
 #. SourceLocation:	Source/Radiant/Public/Characters/SexyCharacterSystem.cpp:2055
 #: Source/Radiant/Public/Characters/SexyCharacterSystem.cpp:2055
 msgctxt "ASexyCharacterSystem,SpiritForm"
 msgid "Spirit form has been saved."
-msgstr ""
+msgstr "魂灵形态已保存"
 
 #. Key:	EndlessDaze
 #. SourceLocation:	Source/Radiant/Public/World/SexyDazeSystem.cpp:103
 #: Source/Radiant/Public/World/SexyDazeSystem.cpp:103
 msgctxt "ASexyDazeSystem,EndlessDaze"
 msgid "{0} has lost conciousness..."
-msgstr ""
+msgstr "{0}失去了意识……"
 
 #. Key:	ReaperToll
 #. SourceLocation:	Source/Radiant/Public/World/SexyDazeSystem.cpp:132
 #: Source/Radiant/Public/World/SexyDazeSystem.cpp:132
 msgctxt "ASexyDazeSystem,ReaperToll"
 msgid "The Reaper will have her toll..."
-msgstr ""
+msgstr "死神会让她付出代价…"
 
 #. Key:	NoFuta
 #. SourceLocation:	Source/Radiant/Public/Game/Monsters/SexyMonsterSystem.cpp:753
 #: Source/Radiant/Public/Game/Monsters/SexyMonsterSystem.cpp:753
 msgctxt "ASexyDialogueSystem,NoFuta"
 msgid "Futa is disabled."
-msgstr ""
+msgstr "关闭扶她"
 
 #. Key:	PostBreedingTask
 #. SourceLocation:	Source/Radiant/Public/Characters/Dialogue/SexyDialogueSystem.cpp:299
 #: Source/Radiant/Public/Characters/Dialogue/SexyDialogueSystem.cpp:299
 msgctxt "ASexyDialogueSystem,PostBreedingTask"
 msgid "A special breeding task has been added."
-msgstr ""
+msgstr "发布了特殊的育种任务。"
 
 #. Key:	SpiritForm
 #. SourceLocation:	Source/Radiant/Public/Game/SexyGameMode.cpp:377
 #: Source/Radiant/Public/Game/SexyGameMode.cpp:377
 msgctxt "ASexyGameMode,SpiritForm"
 msgid "Spirit form has been unlocked."
-msgstr ""
+msgstr "已解锁魂灵形态"
 
 #. Key:	MoreFavor
 #. SourceLocation:	Source/Radiant/Public/Economy/SexyMerchantSystem.cpp:415
 #: Source/Radiant/Public/Economy/SexyMerchantSystem.cpp:415
 msgctxt "ASexyMerchantSystem,MoreFavor"
 msgid "Favor from the Goddess is required."
-msgstr ""
+msgstr "需要女神的帮助"
 
 #. Key:	MoreLust
 #. SourceLocation:	Source/Radiant/Public/Economy/SexyMerchantSystem.cpp:406
 #: Source/Radiant/Public/Economy/SexyMerchantSystem.cpp:406
 msgctxt "ASexyMerchantSystem,MoreLust"
 msgid "Lust is required."
-msgstr ""
+msgstr "性欲不足"
 
 #. Key:	FernThanks
 #. SourceLocation:	Source/Radiant/Public/Game/Monsters/SexyMonsterSystem.cpp:1038
 #: Source/Radiant/Public/Game/Monsters/SexyMonsterSystem.cpp:1038
 msgctxt "ASexyMonsterSystem,FernThanks"
 msgid "Fern gave {0} 150 shiny."
-msgstr ""
+msgstr "小蕨给了{0}150亮片"
 
 #. Key:	LearnedPosition
 #. SourceLocation:	Source/Radiant/Public/Game/Monsters/SexyMonsterSystem.cpp:1077
 #: Source/Radiant/Public/Game/Monsters/SexyMonsterSystem.cpp:1077
 msgctxt "ASexyMonsterSystem,LearnedPosition"
 msgid "{0}'s consciousness has expanded."
-msgstr ""
+msgstr "0}的觉察力得到了提升"
 
 #. Key:	NoBathForYou
 #. SourceLocation:	Source/Radiant/Public/Game/Monsters/SexyMonsterSystem.cpp:1227
 #: Source/Radiant/Public/Game/Monsters/SexyMonsterSystem.cpp:1227
 msgctxt "ASexyMonsterSystem,NoBathForYou"
 msgid "Not enough orgasium."
-msgstr ""
+msgstr "性高潮不足"
 
 #. Key:	NoFutaScene
 #. SourceLocation:	Source/Radiant/Public/Game/Monsters/SexyMonsterSystem.cpp:1214
 #: Source/Radiant/Public/Game/Monsters/SexyMonsterSystem.cpp:1214
 msgctxt "ASexyMonsterSystem,NoFutaScene"
 msgid "Futa scene skipped, sex postion learned."
-msgstr ""
+msgstr "已跳过扶她场景，学会了新的性爱姿势"
 
 #. Key:	Breaks
 #. SourceLocation:	Source/Radiant/Public/World/SexyOverworldInterface.cpp:212
 #: Source/Radiant/Public/World/SexyOverworldInterface.cpp:212
 msgctxt "ASexyOverworldInterface,Breaks"
 msgid "Virgin Breaks"
-msgstr ""
+msgstr "落红断崖"
 
 #. Key:	Cavern
 #. SourceLocation:	Source/Radiant/Public/World/SexyOverworldInterface.cpp:224
 #: Source/Radiant/Public/World/SexyOverworldInterface.cpp:224
 msgctxt "ASexyOverworldInterface,Cavern"
 msgid "Amorous Hallows"
-msgstr ""
+msgstr "性欲圣地"
 
 #. Key:	ClimaxPeak
 #. SourceLocation:	Source/Radiant/Public/World/SexyOverworldInterface.cpp:218
 #: Source/Radiant/Public/World/SexyOverworldInterface.cpp:218
 msgctxt "ASexyOverworldInterface,ClimaxPeak"
 msgid "Climax Peak"
-msgstr ""
+msgstr "极乐之巅"
 
 #. Key:	Cove
 #. SourceLocation:	Source/Radiant/Public/World/SexyOverworldInterface.cpp:200
 #: Source/Radiant/Public/World/SexyOverworldInterface.cpp:200
 msgctxt "ASexyOverworldInterface,Cove"
 msgid "Cove of Rapture"
-msgstr ""
+msgstr "狂喜海湾"
 
 #. Key:	Crag
 #. SourceLocation:	Source/Radiant/Public/World/SexyOverworldInterface.cpp:230
 #: Source/Radiant/Public/World/SexyOverworldInterface.cpp:230
 msgctxt "ASexyOverworldInterface,Crag"
 msgid "Moaning Crag"
-msgstr ""
+msgstr "娇喘峭壁"
 
 #. Key:	Garden
 #. SourceLocation:	Source/Radiant/Public/World/SexyOverworldInterface.cpp:182
 #: Source/Radiant/Public/World/SexyOverworldInterface.cpp:182
 msgctxt "ASexyOverworldInterface,Garden"
 msgid "Hivelands"
-msgstr ""
+msgstr "蜂巢大地"
 
 #. Key:	Glade
 #. SourceLocation:	Source/Radiant/Public/World/SexyOverworldInterface.cpp:206
 #: Source/Radiant/Public/World/SexyOverworldInterface.cpp:206
 msgctxt "ASexyOverworldInterface,Glade"
 msgid "Esoteric Glade"
-msgstr ""
+msgstr "密荫之地"
 
 #. Key:	HedonTownship
 #. SourceLocation:	Source/Radiant/Public/World/SexyOverworldInterface.cpp:158
 #: Source/Radiant/Public/World/SexyOverworldInterface.cpp:158
 msgctxt "ASexyOverworldInterface,HedonTownship"
 msgid "Hedon Township"
-msgstr ""
+msgstr "海顿小镇"
 
 #. Key:	Homestead
 #. SourceLocation:	Source/Radiant/Public/World/SexyOverworldInterface.cpp:170
 #: Source/Radiant/Public/World/SexyOverworldInterface.cpp:170
 msgctxt "ASexyOverworldInterface,Homestead"
 msgid "Homestead"
-msgstr ""
+msgstr "自家宅地"
 
 #. Key:	Jungle
 #. SourceLocation:	Source/Radiant/Public/World/SexyOverworldInterface.cpp:188
 #: Source/Radiant/Public/World/SexyOverworldInterface.cpp:188
 msgctxt "ASexyOverworldInterface,Jungle"
 msgid "Sultry Plateau"
-msgstr ""
+msgstr "潮热高原"
 
 #. Key:	Lustwood
 #. SourceLocation:	Source/Radiant/Public/World/SexyOverworldInterface.cpp:164
 #: Source/Radiant/Public/World/SexyOverworldInterface.cpp:164
 msgctxt "ASexyOverworldInterface,Lustwood"
 msgid "Lustwood"
-msgstr ""
+msgstr "迷情之森"
 
 #. Key:	Pastures
 #. SourceLocation:	Source/Radiant/Public/World/SexyOverworldInterface.cpp:176
 #: Source/Radiant/Public/World/SexyOverworldInterface.cpp:176
 msgctxt "ASexyOverworldInterface,Pastures"
 msgid "Pleasure Pastures"
-msgstr ""
+msgstr "快感牧场"
 
 #. Key:	Sands
 #. SourceLocation:	Source/Radiant/Public/World/SexyOverworldInterface.cpp:194
 #: Source/Radiant/Public/World/SexyOverworldInterface.cpp:194
 msgctxt "ASexyOverworldInterface,Sands"
 msgid "Lewd Desert"
-msgstr ""
+msgstr "淫荡沙漠"
 
 #. Key:	BoringCum
 #. SourceLocation:	Source/Radiant/Public/Game/Monsters/SexyRoamingSystem.cpp:685
 #: Source/Radiant/Public/Game/Monsters/SexyRoamingSystem.cpp:685
 msgctxt "ASexyRoamingSystem,BoringCum"
 msgid "She wanted more..."
-msgstr ""
+msgstr "她还想要……"
 
 #. Key:	BreederBoringCum
 #. SourceLocation:	Source/Radiant/Public/Game/Monsters/SexyRoamingSystem.cpp:685
 #: Source/Radiant/Public/Game/Monsters/SexyRoamingSystem.cpp:685
 msgctxt "ASexyRoamingSystem,BreederBoringCum"
 msgid "The wild one wanted more..."
-msgstr ""
+msgstr "这头野生的魔弗灵还想要……"
 
 #. Key:	BreederClimaxedFirst
 #. SourceLocation:	Source/Radiant/Public/Game/Monsters/SexyRoamingSystem.cpp:690
 #: Source/Radiant/Public/Game/Monsters/SexyRoamingSystem.cpp:690
 msgctxt "ASexyRoamingSystem,BreederClimaxedFirst"
 msgid "{0} has climaxed first..."
-msgstr ""
+msgstr "{0}先高潮了……"
 
 #. Key:	BreederLikedCum
 #. SourceLocation:	Source/Radiant/Public/Game/Monsters/SexyRoamingSystem.cpp:679
 #: Source/Radiant/Public/Game/Monsters/SexyRoamingSystem.cpp:679
 msgctxt "ASexyRoamingSystem,BreederLikedCum"
 msgid "The wild one is pleased!"
-msgstr ""
+msgstr "这头野生的魔弗灵满足了!"
 
 #. Key:	CatchSuccess
 #. SourceLocation:	Source/Radiant/Public/Game/Monsters/SexyRoamingSystem.cpp:863
 #: Source/Radiant/Public/Game/Monsters/SexyRoamingSystem.cpp:863
 msgctxt "ASexyRoamingSystem,CatchSuccess"
 msgid "The wild one has been captured."
-msgstr ""
+msgstr "这头野生的魔弗灵被捕获了。"
 
 #. Key:	LikedCum
 #. SourceLocation:	Source/Radiant/Public/Game/Monsters/SexyRoamingSystem.cpp:680
 #: Source/Radiant/Public/Game/Monsters/SexyRoamingSystem.cpp:680
 msgctxt "ASexyRoamingSystem,LikedCum"
 msgid "She loves how {0} tastes!"
-msgstr ""
+msgstr "她喜欢{0}的味道!"
 
 #. Key:	RBJStart
 #. SourceLocation:	Source/Radiant/Public/Game/Monsters/SexyRoamingSystem.cpp:621
 #: Source/Radiant/Public/Game/Monsters/SexyRoamingSystem.cpp:621
 msgctxt "ASexyRoamingSystem,RBJStart"
 msgid "Spontaneous Blow Job!"
-msgstr ""
+msgstr "情不自禁的口交！"
 
 #. Key:	SurpriseSexStart
 #. SourceLocation:	Source/Radiant/Public/Game/Monsters/SexyRoamingSystem.cpp:621
 #: Source/Radiant/Public/Game/Monsters/SexyRoamingSystem.cpp:621
 msgctxt "ASexyRoamingSystem,SurpriseSexStart"
 msgid "Surprise Sex!"
-msgstr ""
+msgstr "性爱突袭！"
 
 #. Key:	SurpriseSexSuccess
 #. SourceLocation:	Source/Radiant/Public/Game/Monsters/SexyRoamingSystem.cpp:691
 #: Source/Radiant/Public/Game/Monsters/SexyRoamingSystem.cpp:691
 msgctxt "ASexyRoamingSystem,SurpriseSexSuccess"
 msgid "The wild one has climaxed first!"
-msgstr ""
+msgstr "野生的魔弗灵先高潮了！"
 
 #. Key:	SameShrine
 #. SourceLocation:	Source/Radiant/Public/World/Travel/SexyTravelSystem.cpp:146
 #: Source/Radiant/Public/World/Travel/SexyTravelSystem.cpp:146
 msgctxt "ASexyTravelSystem,SameShrine"
 msgid "You are already here."
-msgstr ""
+msgstr "你已经在这里了。"
 
 #. Key:	DMMilkMateTask
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:528
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:528
 msgctxt "ASexyWorldSystem,DMMilkMateTask"
 msgid "Quench my thirst for creamy Bovaur breast milk, and perhaps it will restore my energy."
-msgstr ""
+msgstr "满足我对奶牛娘的乳汁渴望，也许它能恢复我的精力。"
 
 #. Key:	DMMilkTaskReward
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:527
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:527
 msgctxt "ASexyWorldSystem,DMMilkTaskReward"
 msgid "The Dragon Matriarch wishes to speak with you."
-msgstr ""
+msgstr "女族长想和您谈谈。"
 
 #. Key:	DMMilkTitle
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:526
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:526
 msgctxt "ASexyWorldSystem,DMMilkTitle"
 msgid "Milk for the Matriarch"
-msgstr ""
+msgstr "给女族长挤奶"
 
 #. Key:	DragonSemenMateTask
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:480
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:480
 msgctxt "ASexyWorldSystem,DragonSemenMateTask"
 msgid "I require dragon semen in order to make the flowers grow in the Hivelands."
-msgstr ""
+msgstr "我需要巨龙的精液才能让花朵在蜂巢大地上生长。"
 
 #. Key:	DragonSemenTaskReward
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:479
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:479
 msgctxt "ASexyWorldSystem,DragonSemenTaskReward"
 msgid "The Queen Bee wishes to speak with you."
-msgstr ""
+msgstr "蜂后想要和您谈谈。"
 
 #. Key:	DragonSemenTitle
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:478
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:478
 msgctxt "ASexyWorldSystem,DragonSemenTitle"
 msgid "Semen Flowers"
-msgstr ""
+msgstr "蜜精之花"
 
 #. Key:	DryadMateTask
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:518
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:518
 msgctxt "ASexyWorldSystem,DryadMateTask"
 msgid "If you would, breed me a lusty little honey bee. She can \"pollinate\" me all day, and I can produce more bosom cherries for my adorable cows."
-msgstr ""
+msgstr "如果你愿意养一只精壮的蜂娘给我。她可以整天给我'授粉'，我就可以为我可爱的奶牛们生产更多的乳房樱桃"
 
 #. Key:	DryadMateTaskReward
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:516
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:516
 msgctxt "ASexyWorldSystem,DryadMateTaskReward"
 msgid "Autumn wishes to speak with you."
-msgstr ""
+msgstr "欧特想要和您谈谈。"
 
 #. Key:	DryadMateTitle
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:515
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:515
 msgctxt "ASexyWorldSystem,DryadMateTitle"
 msgid "Autumn's Honey Bee"
-msgstr ""
+msgstr "树妖欧特的蜂娘"
 
 #. Key:	FessiTitanTask
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:551
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:551
 msgctxt "ASexyWorldSystem,FessiTitanTask"
 msgid "Sexy human, my goddess hindquarters have rendered me sssstuck. Breed me a strong Titan capable of freeing me from my cave. Hiss!"
-msgstr ""
+msgstr "性感的人类呀，我女神般的性感大屁股让我卡……嘶嘶……卡住了。可以带给我一个精壮的泰坦族把我从洞穴里解救出来吗，嘶嘶!”"
 
 #. Key:	FesssiTitan
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:548
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:548
 msgctxt "ASexyWorldSystem,FesssiTitan"
 msgid "Fat Ass Fesssi's Titan"
-msgstr ""
+msgstr "肥臀菲希的泰坦"
 
 #. Key:	FesssiTitanTaskReward
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:549
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:549
 msgctxt "ASexyWorldSystem,FesssiTitanTaskReward"
 msgid "Fesssi wishes to speak with you."
-msgstr ""
+msgstr "菲希想要和您谈谈"
 
 #. Key:	KybeleMateTaskF
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:406
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:406
 msgctxt "ASexyWorldSystem,KybeleMateTaskF"
 msgid "Bring to me a Vulwarg with a large soft ass! I wish feel her cushion as I thrust my cock deep and plant my seed in her strong body."
-msgstr ""
+msgstr "给我带一个有着柔软大屁股的的狼人过来吧！我希望我能在深深插入我的屌和中出之时能够感受到她那柔软的'坐垫'。"
 
 #. Key:	KybeleMateTaskReward
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:403
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:403
 msgctxt "ASexyWorldSystem,KybeleMateTaskReward"
 msgid "Kybele wishes to speak with you."
-msgstr ""
+msgstr "凯布莉想要和您谈谈"
 
 #. Key:	KybeleMateTaskT
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:409
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:409
 msgctxt "ASexyWorldSystem,KybeleMateTaskT"
 msgid "Bring to me a Vulwarg with a large fat dick! I wish feel like I'm being mounted by a mighty stallion."
-msgstr ""
+msgstr "给我带一个有着刚挺肥硕大屌的狼人过来吧！我想尝尝被一匹强壮的种马骑着是什么感觉。"
 
 #. Key:	KybeleMateTitle
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:402
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:402
 msgctxt "ASexyWorldSystem,KybeleMateTitle"
 msgid "Kybele's Mighty Mate"
-msgstr ""
+msgstr "凯布莉的精壮种马"
 
 #. Key:	MilkFluid
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:337
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:337
 msgctxt "ASexyWorldSystem,MilkFluid"
 msgid "Milk"
-msgstr ""
+msgstr "榨"
 
 #. Key:	MonarchMateTask
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:470
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:470
 msgctxt "ASexyWorldSystem,MonarchMateTask"
 msgid "Uh... please b-b-breed me an adorable Foxen that is fast enough to collect nectar for me. Thank you!"
-msgstr ""
+msgstr "嗯………请给我生一只动作迅捷的狐狸，我想用来采蜜。谢谢你！"
 
 #. Key:	MonarchMateTaskReward
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:468
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:468
 msgctxt "ASexyWorldSystem,MonarchMateTaskReward"
 msgid "Monarch wishes to speak with you."
-msgstr ""
+msgstr "莫娜尔克想要和您谈谈"
 
 #. Key:	MonarchMateTitle
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:467
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:467
 msgctxt "ASexyWorldSystem,MonarchMateTitle"
 msgid "Monarch's Swift Helper"
-msgstr ""
+msgstr "莫娜尔克的迅捷小帮手"
 
 #. Key:	NotEnoughMilk
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:647
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:647
 msgctxt "ASexyWorldSystem,NotEnoughMilk"
 msgid "More milk is required."
-msgstr ""
+msgstr "需要更多的乳汁"
 
 #. Key:	NotEnoughSemen
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:653
@@ -14284,203 +14286,203 @@ msgstr ""
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:593
 msgctxt "ASexyWorldSystem,OrcMate"
 msgid "Toy for the Tribe"
-msgstr ""
+msgstr "部落的肉便器"
 
 #. Key:	OrcMateTask
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:596
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:596
 msgctxt "ASexyWorldSystem,OrcMateTask"
 msgid "Grrr! Breed us a fertile female! We want strong offspring."
-msgstr ""
+msgstr "呃啊啊啊！给我们带一个丰满的女人过来！我们想要强壮的后代"
 
 #. Key:	OrcMateTaskReward
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:594
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:594
 msgctxt "ASexyWorldSystem,OrcMateTaskReward"
 msgid "Chieftain Xena wishes to speak with you."
-msgstr ""
+msgstr "部落族长齐娜想要和您谈谈。"
 
 #. Key:	PetraMate
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:613
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:613
 msgctxt "ASexyWorldSystem,PetraMate"
 msgid "Practice Succubus"
-msgstr ""
+msgstr "练习用的魅魔"
 
 #. Key:	PetraMateTask
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:616
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:616
 msgctxt "ASexyWorldSystem,PetraMateTask"
 msgid "Pawsmaati gave me the task of practicing her lesson with a succubus!"
-msgstr ""
+msgstr "帕丝玛媞给我了一只魅魔来练习她的课程教学。"
 
 #. Key:	PetraMateTaskReward
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:614
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:614
 msgctxt "ASexyWorldSystem,PetraMateTaskReward"
 msgid "Petra wishes to speak with you."
-msgstr ""
+msgstr "帕丝玛媞想要和您谈谈。"
 
 #. Key:	SemenFluid
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:327
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:327
 msgctxt "ASexyWorldSystem,SemenFluid"
 msgid "Semen"
-msgstr ""
+msgstr "精液"
 
 #. Key:	TaskFullfilled
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:707
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:707
 msgctxt "ASexyWorldSystem,TaskFullfilled"
 msgid "Task fulfilled."
-msgstr ""
+msgstr "任务完成"
 
 #. Key:	TaskRefresh
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:213
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:213
 msgctxt "ASexyWorldSystem,TaskRefresh"
 msgid "New breeding requests have arrived."
-msgstr ""
+msgstr "新的配种要求已发布"
 
 #. Key:	TraitRequirement
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:367
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:367
 msgctxt "ASexyWorldSystem,TraitRequirement"
 msgid "{0}\n{1}\n{2}"
-msgstr ""
+msgstr "{0}\n{1}\n{2}"
 
 #. Key:	TraitRequirementFluid
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:340
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:340
 msgctxt "ASexyWorldSystem,TraitRequirementFluid"
 msgid "{0} {1}\n{2}ml\n"
-msgstr ""
+msgstr "{0} {1}\n{2}ml\n"
 
 #. Key:	TraitRequirementStat
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:364
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:364
 msgctxt "ASexyWorldSystem,TraitRequirementStat"
 msgid "{0}\n{1}\n{2}{3}"
-msgstr ""
+msgstr "{0}\n{1}\n{2}{3}"
 
 #. Key:	WidowElf
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:573
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:573
 msgctxt "ASexyWorldSystem,WidowElf"
 msgid "Widow's Juicy Elf"
-msgstr ""
+msgstr "寡妇的多汁精灵"
 
 #. Key:	WidowElfTask
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:576
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:576
 msgctxt "ASexyWorldSystem,WidowElfTask"
 msgid "This lonely spider wishes for her own personal elf, both as a mate and a tasty morsel."
-msgstr ""
+msgstr "这只孤独的蜘蛛希望有一只专属的精灵，既能成为它的伴侣，又能成为它的美味佳肴的精灵。"
 
 #. Key:	WidowElfTaskReward
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:574
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:574
 msgctxt "ASexyWorldSystem,WidowElfTaskReward"
 msgid "Widow wishes to speak with you."
-msgstr ""
+msgstr "寡妇想要和您谈谈。"
 
 #. Key:	Activate
 #. SourceLocation:	Source/Radiant/Public/Characters/SexyBreederCharacter.cpp:179
 #: Source/Radiant/Public/Characters/SexyBreederCharacter.cpp:179
 msgctxt "ASOG,Activate"
 msgid "View Inscribed Names"
-msgstr ""
+msgstr "浏览内置名字"
 
 #. Key:	Description
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyBarnActionDetails.cpp:21
 #: Source/Radiant/Public/UI/Components/SexyBarnActionDetails.cpp:21
 msgctxt "BarnActionDetails,Description"
 msgid "Description"
-msgstr ""
+msgstr "说明"
 
 #. Key:	HarvestDesc
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyBarnActionDetails.cpp:33
 #: Source/Radiant/Public/UI/Components/SexyBarnActionDetails.cpp:33
 msgctxt "BarnActionDetails,HarvestDesc"
 msgid "Select an action and then press Start."
-msgstr ""
+msgstr "选择一个动作,然后开始播种"
 
 #. Key:	NewOffspring
 #. SourceLocation:	Source/Radiant/Public/Characters/Breeder/SexyBreederController.cpp:137
 #: Source/Radiant/Public/Characters/Breeder/SexyBreederController.cpp:137
 msgctxt "BreederController,NewOffspring"
 msgid "Congratulations, {0} has summoned new offspring!"
-msgstr ""
+msgstr "恭喜，{0}已经诞下新的后代!"
 
 #. Key:	AdvanceButtonTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:108
 #: Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:108
 msgctxt "BreedingSession,AdvanceButtonTitle"
 msgid "Advance"
-msgstr ""
+msgstr "下一步"
 
 #. Key:	BreedButtonTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:100
 #: Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:100
 msgctxt "BreedingSession,BreedButtonTitle"
 msgid "Skip"
-msgstr ""
+msgstr "跳过"
 
 #. Key:	BreedButtonTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:101
 #: Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:101
 msgctxt "BreedingSession,BreedButtonTooltip"
 msgid "Skip the rest of the scene, offspring may still be produced."
-msgstr ""
+msgstr "跳过剩下的场景，依然可以怀孕"
 
 #. Key:	DebugTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:186
 #: Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:186
 msgctxt "BreedingSession,DebugTitle"
 msgid "Debug"
-msgstr ""
+msgstr "调试"
 
 #. Key:	IKBelly
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:369
 #: Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:369
 msgctxt "BreedingSession,IKBelly"
 msgid "Belly"
-msgstr ""
+msgstr "腹部"
 
 #. Key:	IKDick
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:296
 #: Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:296
 msgctxt "BreedingSession,IKDick"
 msgid "Dick"
-msgstr ""
+msgstr "阴茎"
 
 #. Key:	IKDickSpline
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:308
 #: Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:308
 msgctxt "BreedingSession,IKDickSpline"
 msgid "P,L,S C,T,V"
-msgstr ""
+msgstr "P,L,S C,T,V"
 
 #. Key:	IKGiver
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:209
 #: Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:209
 msgctxt "BreedingSession,IKGiver"
 msgid "Giver"
-msgstr ""
+msgstr "攻"
 
 #. Key:	IKHips
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:350
 #: Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:350
 msgctxt "BreedingSession,IKHips"
 msgid "Hips"
-msgstr ""
+msgstr "臀围"
 
 #. Key:	IKLHand
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:265
 #: Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:265
 msgctxt "BreedingSession,IKLHand"
 msgid "Hand L"
-msgstr ""
+msgstr "Hand L"
 
 #. Key:	IKLHandTarget
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:277
@@ -14501,7 +14503,7 @@ msgstr ""
 #: Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:209
 msgctxt "BreedingSession,IKReceiver"
 msgid "Receiver"
-msgstr ""
+msgstr "受"
 
 #. Key:	IKRHand
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:241
@@ -14536,14 +14538,14 @@ msgstr ""
 #: Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:331
 msgctxt "BreedingSession,IKSpine"
 msgid "Spine"
-msgstr ""
+msgstr "脊椎"
 
 #. Key:	IKTail
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:388
 #: Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:388
 msgctxt "BreedingSession,IKTail"
 msgid "Tail"
-msgstr ""
+msgstr "尾巴"
 
 #. Key:	Prop
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:438
@@ -14557,1519 +14559,1519 @@ msgstr ""
 #: Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:179
 msgctxt "BreedingSession,SaveGiverTitle"
 msgid "Save Giver"
-msgstr ""
+msgstr "保存攻的对象"
 
 #. Key:	SaveReceiverTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:193
 #: Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:193
 msgctxt "BreedingSession,SaveReceiverTitle"
 msgid "Save Receiver"
-msgstr ""
+msgstr "保存受的对象"
 
 #. Key:	SemenPool
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:450
 #: Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:450
 msgctxt "BreedingSession,SemenPool"
 msgid "Semen Pool"
-msgstr ""
+msgstr "精液池"
 
 #. Key:	SkipButtonTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:109
 #: Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:109
 msgctxt "BreedingSession,SkipButtonTooltip"
 msgid "Proceed to the next phase of this scene."
-msgstr ""
+msgstr "进入这个场景的下一阶段"
 
 #. Key:	SpeedTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:31
 #: Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:31
 msgctxt "BreedingSession,SpeedTitle"
 msgid "Speed"
-msgstr ""
+msgstr "速度"
 
 #. Key:	BreedButtonTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyBreedingSetupMenu.cpp:63
 #: Source/Radiant/Public/UI/Menus/SexyBreedingSetupMenu.cpp:63
 msgctxt "BreedingSetup,BreedButtonTitle"
 msgid "Start"
-msgstr ""
+msgstr "开始"
 
 #. Key:	BreedButtonTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyBreedingSetupMenu.cpp:64
 #: Source/Radiant/Public/UI/Menus/SexyBreedingSetupMenu.cpp:64
 msgctxt "BreedingSetup,BreedButtonTooltip"
 msgid "Start a breeding scene with the currently selected mates and options."
-msgstr ""
+msgstr "用当前选定的配偶和体位开始播种"
 
 #. Key:	GiverWindowTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyBreedingSetupMenu.cpp:72
 #: Source/Radiant/Public/UI/Menus/SexyBreedingSetupMenu.cpp:72
 msgctxt "BreedingSetup,GiverWindowTitle"
 msgid "Select Giver"
-msgstr ""
+msgstr "选择攻的对象"
 
 #. Key:	QuickButtonTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyBreedingSetupMenu.cpp:55
 #: Source/Radiant/Public/UI/Menus/SexyBreedingSetupMenu.cpp:55
 msgctxt "BreedingSetup,QuickButtonTitle"
 msgid "Quick"
-msgstr ""
+msgstr "快速播种"
 
 #. Key:	QuickButtonTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyBreedingSetupMenu.cpp:56
 #: Source/Radiant/Public/UI/Menus/SexyBreedingSetupMenu.cpp:56
 msgctxt "BreedingSetup,QuickButtonTooltip"
 msgid "Breed this pair without starting a scene."
-msgstr ""
+msgstr "让当前选择的这一对立刻播种并跳过播种场景"
 
 #. Key:	ReceiverWindowTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyBreedingSetupMenu.cpp:128
 #: Source/Radiant/Public/UI/Menus/SexyBreedingSetupMenu.cpp:128
 msgctxt "BreedingSetup,ReceiverWindowTitle"
 msgid "Select Receiver"
-msgstr ""
+msgstr "选择受的对象"
 
 #. Key:	ImpossibleCombo
 #. SourceLocation:	Source/Radiant/Public/Game/Monsters/SexyBreedingSystem.cpp:175
 #: Source/Radiant/Public/Game/Monsters/SexyBreedingSystem.cpp:175
 msgctxt "BreedingSystem,ImpossibleCombo"
 msgid "Impossible breeding combination."
-msgstr ""
+msgstr "无法繁殖的组合"
 
 #. Key:	NoFemaleGiver
 #. SourceLocation:	Source/Radiant/Public/Game/Monsters/SexyBreedingSystem.cpp:171
 #: Source/Radiant/Public/Game/Monsters/SexyBreedingSystem.cpp:171
 msgctxt "BreedingSystem,NoFemaleGiver"
 msgid "Giver must be futa or male."
-msgstr ""
+msgstr "攻必须是扶她或者是男性。"
 
 #. Key:	NoGiver
 #. SourceLocation:	Source/Radiant/Public/Game/Monsters/SexyBreedingSystem.cpp:159
 #: Source/Radiant/Public/Game/Monsters/SexyBreedingSystem.cpp:159
 msgctxt "BreedingSystem,NoGiver"
 msgid "Giver must be selected."
-msgstr ""
+msgstr "请选择攻的对象"
 
 #. Key:	NoMaleReceiver
 #. SourceLocation:	Source/Radiant/Public/Game/Monsters/SexyBreedingSystem.cpp:167
 #: Source/Radiant/Public/Game/Monsters/SexyBreedingSystem.cpp:167
 msgctxt "BreedingSystem,NoMaleReceiver"
 msgid "Receiver must be female or futa."
-msgstr ""
+msgstr "受必须是女性或者是扶她"
 
 #. Key:	NoOffspring
 #. SourceLocation:	Source/Radiant/Public/Game/Monsters/SexyBreedingSystem.cpp:597
 #: Source/Radiant/Public/Game/Monsters/SexyBreedingSystem.cpp:597
 msgctxt "BreedingSystem,NoOffspring"
 msgid "No offspring this time..."
-msgstr ""
+msgstr "这次没有受孕成功……"
 
 #. Key:	NoReceiver
 #. SourceLocation:	Source/Radiant/Public/Game/Monsters/SexyBreedingSystem.cpp:163
 #: Source/Radiant/Public/Game/Monsters/SexyBreedingSystem.cpp:163
 msgctxt "BreedingSystem,NoReceiver"
 msgid "Receiver must be selected."
-msgstr ""
+msgstr "请选择受的对象"
 
 #. Key:	NoRoomOffspring
 #. SourceLocation:	Source/Radiant/Public/Game/Monsters/SexyBreedingSystem.cpp:591
 #: Source/Radiant/Public/Game/Monsters/SexyBreedingSystem.cpp:591
 msgctxt "BreedingSystem,NoRoomOffspring"
 msgid "Not enough space for offspring, it was released into the wild."
-msgstr ""
+msgstr "没有足够的空间容纳后代，自动放归野外。"
 
 #. Key:	NoSexPosition
 #. SourceLocation:	Source/Radiant/Public/Game/Monsters/SexyBreedingSystem.cpp:155
 #: Source/Radiant/Public/Game/Monsters/SexyBreedingSystem.cpp:155
 msgctxt "BreedingSystem,NoSexPosition"
 msgid "Sex position must be selected."
-msgstr ""
+msgstr "请选择做爱的体位"
 
 #. Key:	Allure
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:149
 #: Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:149
 msgctxt "CharacterDetails,Allure"
 msgid "Allure"
-msgstr ""
+msgstr "魅力"
 
 #. Key:	AllureTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:150
 #: Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:150
 msgctxt "CharacterDetails,AllureTooltip"
 msgid "Allure is a measure of the pheromones given off by this one."
-msgstr ""
+msgstr "魅力值是对它所释放的信息素的一种测量。"
 
 #. Key:	Attributes
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:63
 #: Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:63
 msgctxt "CharacterDetails,Attributes"
 msgid "Attributes"
-msgstr ""
+msgstr "属性"
 
 #. Key:	Dexterity
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:163
 #: Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:163
 msgctxt "CharacterDetails,Dexterity"
 msgid "Dexterity"
-msgstr ""
+msgstr "灵巧"
 
 #. Key:	DexterityTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:164
 #: Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:164
 msgctxt "CharacterDetails,DexterityTooltip"
 msgid "Measures how quick and agile this one can be."
-msgstr ""
+msgstr "衡量这个对象究竟有多敏捷"
 
 #. Key:	Father
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:111
 #: Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:111
 msgctxt "CharacterDetails,Father"
 msgid "Father"
-msgstr ""
+msgstr "父亲"
 
 #. Key:	FatherTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:112
 #: Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:112
 msgctxt "CharacterDetails,FatherTooltip"
 msgid "The provider of the semen."
-msgstr ""
+msgstr "精液的提供者"
 
 #. Key:	Fertility
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:142
 #: Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:142
 msgctxt "CharacterDetails,Fertility"
 msgid "Fertility"
-msgstr ""
+msgstr "生育能力"
 
 #. Key:	FertiliyTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:143
 #: Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:143
 msgctxt "CharacterDetails,FertiliyTooltip"
 msgid "How likely it would be for this one to produce offspring."
-msgstr ""
+msgstr "成功繁衍的可能性有多大?"
 
 #. Key:	Level
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:128
 #: Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:128
 msgctxt "CharacterDetails,Level"
 msgid "Level"
-msgstr ""
+msgstr "等级"
 
 #. Key:	LevelTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:129
 #: Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:129
 msgctxt "CharacterDetails,LevelTooltip"
 msgid "Level represents how much power this one has absorbed through sexual activity."
-msgstr ""
+msgstr "等级代表这个对象通过性活动吸收了多少能量。"
 
 #. Key:	Lifeforce
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:38
 #: Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:38
 msgctxt "CharacterDetails,Lifeforce"
 msgid "Spirit"
-msgstr ""
+msgstr "魂灵"
 
 #. Key:	LifeforceTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:39
 #: Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:39
 msgctxt "CharacterDetails,LifeforceTooltip"
 msgid "Spirit energy. Used to transform into your spirit form."
-msgstr ""
+msgstr "精神能量。需要精神能量才能让你变成魂灵状态。"
 
 #. Key:	Loyalty
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:44
 #: Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:44
 msgctxt "CharacterDetails,Loyalty"
 msgid "Loyalty"
-msgstr ""
+msgstr "忠诚"
 
 #. Key:	LoyaltyTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:45
 #: Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:45
 msgctxt "CharacterDetails,LoyaltyTooltip"
 msgid "How happy this one is to stay on your ranch."
-msgstr ""
+msgstr "表示这个对象在你的牧场有多幸福。"
 
 #. Key:	Lust
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:31
 #: Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:31
 msgctxt "CharacterDetails,Lust"
 msgid "Lust"
-msgstr ""
+msgstr "性欲"
 
 #. Key:	LustTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:32
 #: Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:32
 msgctxt "CharacterDetails,LustTooltip"
 msgid "Represents how horny this one has become. When lust reaches zero, sexual activity and most actions cannot be performed."
-msgstr ""
+msgstr "表示这对象有多饥渴。当性欲归零时，无法进行繁衍和大多数行为。"
 
 #. Key:	Mother
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:104
 #: Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:104
 msgctxt "CharacterDetails,Mother"
 msgid "Mother"
-msgstr ""
+msgstr "母亲"
 
 #. Key:	MotherTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:105
 #: Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:105
 msgctxt "CharacterDetails,MotherTooltip"
 msgid "The female who summoned this one into the world."
-msgstr ""
+msgstr "召唤对象来这个世界的女性"
 
 #. Key:	Pregnancy
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:56
 #: Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:56
 msgctxt "CharacterDetails,Pregnancy"
 msgid "Pregnant"
-msgstr ""
+msgstr "怀孕"
 
 #. Key:	PregnancyTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:57
 #: Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:57
 msgctxt "CharacterDetails,PregnancyTooltip"
 msgid "Progress toward summoning offspring.\nMilk production is doubled during pregnancy."
-msgstr ""
+msgstr "表示召唤后代的进展天数。\n怀孕期间产奶量翻倍"
 
 #. Key:	Procreators
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:94
 #: Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:94
 msgctxt "CharacterDetails,Procreators"
 msgid "Procreators"
-msgstr ""
+msgstr "亲族"
 
 #. Key:	Race
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:73
 #: Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:73
 msgctxt "CharacterDetails,Race"
 msgid "Race"
-msgstr ""
+msgstr "种族"
 
 #. Key:	RaceTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:74
 #: Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:74
 msgctxt "CharacterDetails,RaceTooltip"
 msgid "The race this one belongs to."
-msgstr ""
+msgstr "该对象归属的种族"
 
 #. Key:	Sex
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:87
 #: Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:87
 msgctxt "CharacterDetails,Sex"
 msgid "Sex"
-msgstr ""
+msgstr "性别"
 
 #. Key:	SexTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:88
 #: Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:88
 msgctxt "CharacterDetails,SexTooltip"
 msgid "What genetalia this one was born with."
-msgstr ""
+msgstr "这个对象出生时的第一性征"
 
 #. Key:	Stats
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:118
 #: Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:118
 msgctxt "CharacterDetails,Stats"
 msgid "Stats"
-msgstr ""
+msgstr "三围数据"
 
 #. Key:	Strength
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:135
 #: Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:135
 msgctxt "CharacterDetails,Strength"
 msgid "Strength"
-msgstr ""
+msgstr "力量"
 
 #. Key:	StrengthTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:136
 #: Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:136
 msgctxt "CharacterDetails,StrengthTooltip"
 msgid "The physical strength of this one."
-msgstr ""
+msgstr "这个对象的物理力量"
 
 #. Key:	Traits
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:177
 #: Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:177
 msgctxt "CharacterDetails,Traits"
 msgid "Traits"
-msgstr ""
+msgstr "特征与性格"
 
 #. Key:	Value
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:170
 #: Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:170
 msgctxt "CharacterDetails,Value"
 msgid "Value"
-msgstr ""
+msgstr "稀有度"
 
 #. Key:	ValueTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:171
 #: Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:171
 msgctxt "CharacterDetails,ValueTooltip"
 msgid "The net worth of this one, a result of stats and the rarity of its variant."
-msgstr ""
+msgstr "稀有度数值取决于对象的三围属性和变种。"
 
 #. Key:	Variant
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:80
 #: Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:80
 msgctxt "CharacterDetails,Variant"
 msgid "Variant"
-msgstr ""
+msgstr "种族"
 
 #. Key:	VariantTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:81
 #: Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:81
 msgctxt "CharacterDetails,VariantTooltip"
 msgid "The morphology within this one's race."
-msgstr ""
+msgstr "该对象的归属族群"
 
 #. Key:	Willpower
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:156
 #: Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:156
 msgctxt "CharacterDetails,Willpower"
 msgid "Willpower"
-msgstr ""
+msgstr "意志力"
 
 #. Key:	WillpowerTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:157
 #: Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:157
 msgctxt "CharacterDetails,WillpowerTooltip"
 msgid "Willpower measures the ability of this one to control their lust."
-msgstr ""
+msgstr "意志力影响该对象控制欲望的能力"
 
 #. Key:	XP
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:50
 #: Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:50
 msgctxt "CharacterDetails,XP"
 msgid "XP"
-msgstr ""
+msgstr "精咽值"
 
 #. Key:	XPTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:51
 #: Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:51
 msgctxt "CharacterDetails,XPTooltip"
 msgid "Progress toward the next level."
-msgstr ""
+msgstr "表示需要多少才能升级"
 
 #. Key:	AdditionalMaterial
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:444
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:444
 msgctxt "CharacterEditor,AdditionalMaterial"
 msgid "Additional Material"
-msgstr ""
+msgstr "附加模块"
 
 #. Key:	AmbientEffects
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:487
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:487
 msgctxt "CharacterEditor,AmbientEffects"
 msgid "Ambient Effects"
-msgstr ""
+msgstr "环境效果"
 
 #. Key:	AnusMaterial
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:419
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:419
 msgctxt "CharacterEditor,AnusMaterial"
 msgid "Anus"
-msgstr ""
+msgstr "肛门"
 
 #. Key:	BackButton
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:73
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:73
 msgctxt "CharacterEditor,BackButton"
 msgid "Back"
-msgstr ""
+msgstr "返回"
 
 #. Key:	BackButtonTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:74
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:74
 msgctxt "CharacterEditor,BackButtonTooltip"
 msgid "Return to the previous screen."
-msgstr ""
+msgstr "返回上一步"
 
 #. Key:	BellyShape
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:361
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:361
 msgctxt "CharacterEditor,BellyShape"
 msgid "Belly"
-msgstr ""
+msgstr "腹部"
 
 #. Key:	BodyAttachments
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:482
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:482
 msgctxt "CharacterEditor,BodyAttachments"
 msgid "Attachments"
-msgstr ""
+msgstr "毛发"
 
 #. Key:	BodyAttachmentsMaterial
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:449
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:449
 msgctxt "CharacterEditor,BodyAttachmentsMaterial"
 msgid "Body Attachments"
-msgstr ""
+msgstr "身体上的模块"
 
 #. Key:	BodyMaterial
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:424
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:424
 msgctxt "CharacterEditor,BodyMaterial"
 msgid "Body"
-msgstr ""
+msgstr "身体"
 
 #. Key:	BodyPhysics
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:492
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:492
 msgctxt "CharacterEditor,BodyPhysics"
 msgid "Bounce Physics"
-msgstr ""
+msgstr "物理效果"
 
 #. Key:	BootsGroup
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:469
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:469
 msgctxt "CharacterEditor,BootsGroup"
 msgid "Footwear"
-msgstr ""
+msgstr "鞋子"
 
 #. Key:	BreastsShape
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:356
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:356
 msgctxt "CharacterEditor,BreastsShape"
 msgid "Breasts"
-msgstr ""
+msgstr "乳房"
 
 #. Key:	BreedingTags
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:497
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:497
 msgctxt "CharacterEditor,BreedingTags"
 msgid "Breeding Tags"
-msgstr ""
+msgstr "繁殖标签"
 
 #. Key:	ButtShape
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:376
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:376
 msgctxt "CharacterEditor,ButtShape"
 msgid "Butt"
-msgstr ""
+msgstr "臀部"
 
 #. Key:	CancelButton
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:535
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:535
 msgctxt "CharacterEditor,CancelButton"
 msgid "Cancel"
-msgstr ""
+msgstr "取消"
 
 #. Key:	ChangeSexTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:263
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:263
 msgctxt "CharacterEditor,ChangeSexTooltip"
 msgid "Change this character's sex.\nWARNING: This will overwrite the current appearance."
-msgstr ""
+msgstr "改变这个角色的性别。\n警告:这将覆盖当前的外观！"
 
 #. Key:	ChooseAnimationTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:179
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:179
 msgctxt "CharacterEditor,ChooseAnimationTooltip"
 msgid "Change the current animation."
-msgstr ""
+msgstr "更改当前动画"
 
 #. Key:	ChooseTraitTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:311
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:311
 msgctxt "CharacterEditor,ChooseTraitTooltip"
 msgid "Preview an appearance altering trait."
-msgstr ""
+msgstr "预览改变外观的特征"
 
 #. Key:	CopyTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:216
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:216
 msgctxt "CharacterEditor,CopyTooltip"
 msgid "Copy to clipboard."
-msgstr ""
+msgstr "复制到剪贴板"
 
 #. Key:	DetailsWindowTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:477
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:477
 msgctxt "CharacterEditor,DetailsWindowTitle"
 msgid "Details"
-msgstr ""
+msgstr "细节"
 
 #. Key:	ExoticTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:158
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:158
 msgctxt "CharacterEditor,ExoticTooltip"
 msgid "Give this character its exotic trait if one exists.\nWARNING: This will overwrite the current appearance."
-msgstr ""
+msgstr "给予这个角色特殊的外来特征（如果有的话\n警告:这将覆盖当前的外观）"
 
 #. Key:	EyebrowMaterial
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:404
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:404
 msgctxt "CharacterEditor,EyebrowMaterial"
 msgid "Eyebrows"
-msgstr ""
+msgstr "眉毛"
 
 #. Key:	EyeMaterial
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:399
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:399
 msgctxt "CharacterEditor,EyeMaterial"
 msgid "Eyes"
-msgstr ""
+msgstr "眼睛"
 
 #. Key:	FaceMaterial
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:394
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:394
 msgctxt "CharacterEditor,FaceMaterial"
 msgid "Face"
-msgstr ""
+msgstr "脸部"
 
 #. Key:	FaceShape
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:341
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:341
 msgctxt "CharacterEditor,FaceShape"
 msgid "Face"
-msgstr ""
+msgstr "脸部"
 
 #. Key:	FullBodyShape
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:346
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:346
 msgctxt "CharacterEditor,FullBodyShape"
 msgid "Full Body"
-msgstr ""
+msgstr "全身"
 
 #. Key:	FurMaterial
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:439
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:439
 msgctxt "CharacterEditor,FurMaterial"
 msgid "Fur"
-msgstr ""
+msgstr "体毛"
 
 #. Key:	GalleryButton
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:90
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:90
 msgctxt "CharacterEditor,GalleryButton"
 msgid "Gallery"
-msgstr ""
+msgstr "画廊"
 
 #. Key:	GalleryButtonTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:91
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:91
 msgctxt "CharacterEditor,GalleryButtonTooltip"
 msgid "Switch to the breeding scene gallery."
-msgstr ""
+msgstr "切换到繁殖场景画廊"
 
 #. Key:	GenitaliaMaterial
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:414
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:414
 msgctxt "CharacterEditor,GenitaliaMaterial"
 msgid "Genitals"
-msgstr ""
+msgstr "生殖器"
 
 #. Key:	GenitalsShape
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:371
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:371
 msgctxt "CharacterEditor,GenitalsShape"
 msgid "Genitals"
-msgstr ""
+msgstr "生殖器"
 
 #. Key:	HairMaterial
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:434
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:434
 msgctxt "CharacterEditor,HairMaterial"
 msgid "Hair"
-msgstr ""
+msgstr "头发"
 
 #. Key:	HominalTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:151
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:151
 msgctxt "CharacterEditor,HominalTooltip"
 msgid "Give this character its hominal trait if one exists.\nWARNING: This will overwrite the current appearance."
-msgstr ""
+msgstr "给予这个角色原始的特性（如果有的话）\nWARNING:这将覆盖当前的外观"
 
 #. Key:	LeaveButton
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:98
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:98
 msgctxt "CharacterEditor,LeaveButton"
 msgid "Leave"
-msgstr ""
+msgstr "离开"
 
 #. Key:	LeaveButtonTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:99
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:99
 msgctxt "CharacterEditor,LeaveButtonTooltip"
 msgid "Stop editing your spirit form."
-msgstr ""
+msgstr "停止编辑你的魂灵形态"
 
 #. Key:	LoadUsrPresetTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:128
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:128
 msgctxt "CharacterEditor,LoadUsrPresetTooltip"
 msgid "Load a saved preset.\nWARNING: This will overwrite the current appearance."
-msgstr ""
+msgstr "加载保存的预设值。\n警告:这将覆盖当前的外观"
 
 #. Key:	LowerBodyShape
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:366
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:366
 msgctxt "CharacterEditor,LowerBodyShape"
 msgid "Lower Body"
-msgstr ""
+msgstr "下半身"
 
 #. Key:	LowerClothing
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:459
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:459
 msgctxt "CharacterEditor,LowerClothing"
 msgid "Lower Clothing"
-msgstr ""
+msgstr "下身衣装"
 
 #. Key:	MaterialWindowTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:384
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:384
 msgctxt "CharacterEditor,MaterialWindowTitle"
 msgid "Color"
-msgstr ""
+msgstr "颜色"
 
 #. Key:	NailsMaterial
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:429
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:429
 msgctxt "CharacterEditor,NailsMaterial"
 msgid "Nails"
-msgstr ""
+msgstr "指甲"
 
 #. Key:	NextButton
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:81
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:81
 msgctxt "CharacterEditor,NextButton"
 msgid "Next"
-msgstr ""
+msgstr "下一步"
 
 #. Key:	NextButtonTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:82
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:82
 msgctxt "CharacterEditor,NextButtonTooltip"
 msgid "Continue to the next screen."
-msgstr ""
+msgstr "继续到下一个画面"
 
 #. Key:	NippleMaterial
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:409
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:409
 msgctxt "CharacterEditor,NippleMaterial"
 msgid "Nipples"
-msgstr ""
+msgstr "乳头"
 
 #. Key:	PasteTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:223
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:223
 msgctxt "CharacterEditor,PasteTooltip"
 msgid "Paste from clipboard.\nWARNING: This will overwrite the current appearance, and might look terrible on different variants."
-msgstr ""
+msgstr "从剪贴板粘贴。\n警告：这将覆盖当前外观，并且在不同的变体上可能看起来很糟糕。"
 
 #. Key:	PresetNameTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:505
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:505
 msgctxt "CharacterEditor,PresetNameTitle"
 msgid "Save Preset"
-msgstr ""
+msgstr "保存预设值"
 
 #. Key:	RandomBodyTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:186
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:186
 msgctxt "CharacterEditor,RandomBodyTooltip"
 msgid "Generate a random body shape for this variant."
-msgstr ""
+msgstr "为这个对象生成一个随机的身体外观"
 
 #. Key:	RenameTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:325
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:325
 msgctxt "CharacterEditor,RenameTooltip"
 msgid "Rename this character."
-msgstr ""
+msgstr "重新命名这个角色"
 
 #. Key:	SaveButton
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:529
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:529
 msgctxt "CharacterEditor,SaveButton"
 msgid "Save"
-msgstr ""
+msgstr "保存"
 
 #. Key:	SavePresetTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:196
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:196
 msgctxt "CharacterEditor,SavePresetTooltip"
 msgid "Save current appearance as a preset."
-msgstr ""
+msgstr "将当前外观保存为预设"
 
 #. Key:	SaveSpiritTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:118
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:118
 msgctxt "CharacterEditor,SaveSpiritTooltip"
 msgid "Save this as your spirit form."
-msgstr ""
+msgstr "保存当前你设置的魂灵形态"
 
 #. Key:	ShapeWindowTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:336
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:336
 msgctxt "CharacterEditor,ShapeWindowTitle"
 msgid "Shape"
-msgstr ""
+msgstr "形状"
 
 #. Key:	SkinMaterial
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:389
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:389
 msgctxt "CharacterEditor,SkinMaterial"
 msgid "Skin"
-msgstr ""
+msgstr "皮肤"
 
 #. Key:	ToggleClothesTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:278
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:278
 msgctxt "CharacterEditor,ToggleClothesTooltip"
 msgid "Toggle all clothing except underwear."
-msgstr ""
+msgstr "褪去内衣外所有的衣服"
 
 #. Key:	ToggleLinkedMode
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:165
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:165
 msgctxt "CharacterEditor,ToggleLinkedMode"
 msgid "Toggle linking of similar or mirrored values."
-msgstr ""
+msgstr "切换类似或镜像值链接"
 
 #. Key:	ToggleUnderwearTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:285
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:285
 msgctxt "CharacterEditor,ToggleUnderwearTooltip"
 msgid "Toggle only underwear."
-msgstr ""
+msgstr "仅穿内衣"
 
 #. Key:	UnderwearGroup
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:464
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:464
 msgctxt "CharacterEditor,UnderwearGroup"
 msgid "Underwear"
-msgstr ""
+msgstr "内衣"
 
 #. Key:	UpperBodyShape
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:351
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:351
 msgctxt "CharacterEditor,UpperBodyShape"
 msgid "Upper Body"
-msgstr ""
+msgstr "上身"
 
 #. Key:	UpperClothing
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:454
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:454
 msgctxt "CharacterEditor,UpperClothing"
 msgid "Upper Clothing"
-msgstr ""
+msgstr "上装"
 
 #. Key:	VariantTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:144
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:144
 msgctxt "CharacterEditor,VariantTooltip"
 msgid "Change this character's variant.\nWARNING: This will overwrite the current appearance."
-msgstr ""
+msgstr "改变这个角色的外观。\n警告:这将覆盖当前的外观"
 
 #. Key:	ErrorSavingPreset
 #. SourceLocation:	Source/Radiant/Public/Characters/SexyCharacterSystem.cpp:2441
 #: Source/Radiant/Public/Characters/SexyCharacterSystem.cpp:2441
 msgctxt "CharacterSystem,ErrorSavingPreset"
 msgid "Error while trying to save preset."
-msgstr ""
+msgstr "试图保存预设时发生错误"
 
 #. Key:	SavedPreset
 #. SourceLocation:	Source/Radiant/Public/Characters/SexyCharacterSystem.cpp:2438
 #: Source/Radiant/Public/Characters/SexyCharacterSystem.cpp:2438
 msgctxt "CharacterSystem,SavedPreset"
 msgid "Successfully saved preset."
-msgstr ""
+msgstr "保存预设值成功"
 
 #. Key:	DecrementTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyComponentModifier.cpp:31
 #: Source/Radiant/Public/UI/Components/SexyComponentModifier.cpp:31
 msgctxt "ComponentModifier,DecrementTooltip"
 msgid "Previous component."
-msgstr ""
+msgstr "返回上一个部件"
 
 #. Key:	IncrementTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyComponentModifier.cpp:49
 #: Source/Radiant/Public/UI/Components/SexyComponentModifier.cpp:49
 msgctxt "ComponentModifier,IncrementTooltip"
 msgid "Next component."
-msgstr ""
+msgstr "下一个部件"
 
 #. Key:	None
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyComponentModifier.cpp:100
 #: Source/Radiant/Public/UI/Components/SexyComponentModifier.cpp:100
 msgctxt "ComponentModifier,None"
 msgid "None"
-msgstr ""
+msgstr "没有"
 
 #. Key:	CancelButton
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:56
 #: Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:56
 msgctxt "ConfirmationBox,CancelButton"
 msgid "No"
-msgstr ""
+msgstr "取消"
 
 #. Key:	ConfirmButton
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:50
 #: Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:50
 msgctxt "ConfirmationBox,ConfirmButton"
 msgid "Yes"
-msgstr ""
+msgstr "确认"
 
 #. Key:	ExitConfirmTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:98
 #: Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:98
 msgctxt "ConfirmationBox,ExitConfirmTitle"
 msgid "Exit to Desktop?"
-msgstr ""
+msgstr "退出到桌面？"
 
 #. Key:	FulfillConfirm
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:107
 #: Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:107
 msgctxt "ConfirmationBox,FulfillConfirm"
 msgid "The selected Nephelym will be given away."
-msgstr ""
+msgstr "被选中的魔弗灵将会被送走。"
 
 #. Key:	FulfillConfirmTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:106
 #: Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:106
 msgctxt "ConfirmationBox,FulfillConfirmTitle"
 msgid "Fulfill Task?"
-msgstr ""
+msgstr "完成任务?"
 
 #. Key:	FulfillFluidConfirm
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:111
 #: Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:111
 msgctxt "ConfirmationBox,FulfillFluidConfirm"
 msgid "Fluids will be removed from your inventory."
-msgstr ""
+msgstr "体液将从您的库存中移除。"
 
 #. Key:	NewGameConfirm
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:83
 #: Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:83
 msgctxt "ConfirmationBox,NewGameConfirm"
 msgid "Begin a new adventure with a clean slate."
-msgstr ""
+msgstr "以全新的姿态开始冒险。"
 
 #. Key:	NewGameConfirmTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:82
 #: Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:82
 msgctxt "ConfirmationBox,NewGameConfirmTitle"
 msgid "Start a New Game?"
-msgstr ""
+msgstr "开始新的牧场主生活？"
 
 #. Key:	OverwriteGameConfirm
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:87
 #: Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:87
 msgctxt "ConfirmationBox,OverwriteGameConfirm"
 msgid "This will permanently overwrite the data in this slot."
-msgstr ""
+msgstr "这将永久覆盖此槽中的已保存的数据"
 
 #. Key:	OverwriteGameConfirmTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:86
 #: Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:86
 msgctxt "ConfirmationBox,OverwriteGameConfirmTitle"
 msgid "Overwrite Saved Game?"
-msgstr ""
+msgstr "保存并覆盖游戏吗？"
 
 #. Key:	ReleaseConfirm
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:103
 #: Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:103
 msgctxt "ConfirmationBox,ReleaseConfirm"
 msgid "It will permanently leave your ranch and frolic once more."
-msgstr ""
+msgstr "该对象会永久离开您的牧场，再次在野外嬉戏。"
 
 #. Key:	ReleaseConfirmTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:102
 #: Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:102
 msgctxt "ConfirmationBox,ReleaseConfirmTitle"
 msgid "Release this Nephelym?"
-msgstr ""
+msgstr "放生这只魔弗灵吗？"
 
 #. Key:	ReturnMainConfirm
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:95
 #: Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:95
 msgctxt "ConfirmationBox,ReturnMainConfirm"
 msgid "All progress since the last save will be lost."
-msgstr ""
+msgstr "自上次保存以来的所有进度都将丢失。"
 
 #. Key:	ReturnMainConfirmTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:94
 #: Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:94
 msgctxt "ConfirmationBox,ReturnMainConfirmTitle"
 msgid "Return to Main Menu?"
-msgstr ""
+msgstr "返回到主菜单界面吗？"
 
 #. Key:	SleepConfirm
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:91
 #: Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:91
 msgctxt "ConfirmationBox,SleepConfirm"
 msgid "Sleep for the rest of the day and awake with new-found lust."
-msgstr ""
+msgstr "结束这一天的时间并睡一觉，然后性欲满满地醒来"
 
 #. Key:	SleepConfirmTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:90
 #: Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:90
 msgctxt "ConfirmationBox,SleepConfirmTitle"
 msgid "Go to Sleep?"
-msgstr ""
+msgstr "去睡觉吗？"
 
 #. Key:	WindowTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:27
 #: Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:27
 msgctxt "ConfirmationBox,WindowTitle"
 msgid "Confirm"
-msgstr ""
+msgstr "确认"
 
 #. Key:	BatheMonsterMessage
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyTradeMenu.cpp:899
 #: Source/Radiant/Public/UI/Menus/SexyTradeMenu.cpp:899
 msgctxt "ConfirmTradeBox,BatheMonsterMessage"
 msgid "Bathing will remove the grungy trait."
-msgstr ""
+msgstr "洗澡可以消除你脏兮兮的属性"
 
 #. Key:	BuyUpgradeMessage
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyTradeMenu.cpp:890
 #: Source/Radiant/Public/UI/Menus/SexyTradeMenu.cpp:890
 msgctxt "ConfirmTradeBox,BuyUpgradeMessage"
 msgid "This upgrade will permanently be added to your ranch."
-msgstr ""
+msgstr "此升级将永久添加到您的牧场"
 
 #. Key:	CancelButton
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyTradeMenu.cpp:454
 #: Source/Radiant/Public/UI/Menus/SexyTradeMenu.cpp:454
 msgctxt "ConfirmTradeBox,CancelButton"
 msgid "Cancel"
-msgstr ""
+msgstr "取消"
 
 #. Key:	ConfirmButton
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyTradeMenu.cpp:448
 #: Source/Radiant/Public/UI/Menus/SexyTradeMenu.cpp:448
 msgctxt "ConfirmTradeBox,ConfirmButton"
 msgid "Confirm"
-msgstr ""
+msgstr "确认"
 
 #. Key:	FinalPrice
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyTradeMenu.cpp:556
 #: Source/Radiant/Public/UI/Menus/SexyTradeMenu.cpp:556
 msgctxt "ConfirmTradeBox,FinalPrice"
 msgid "Final Price:"
-msgstr ""
+msgstr "最终价值"
 
 #. Key:	LeaveButton
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyDialogueMenu.cpp:62
 #: Source/Radiant/Public/UI/Menus/SexyDialogueMenu.cpp:62
 msgctxt "DialogueMenu,LeaveButton"
 msgid "Goodbye"
-msgstr ""
+msgstr "再见啦"
 
 #. Key:	SkipButton
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyDialogueMenu.cpp:55
 #: Source/Radiant/Public/UI/Menus/SexyDialogueMenu.cpp:55
 msgctxt "DialogueMenu,SkipButton"
 msgid "Skip"
-msgstr ""
+msgstr "跳过"
 
 #. Key:	ExitButton
 #. SourceLocation:	Source/Radiant/Public/UI/SexyGameOverlay.cpp:116
 #: Source/Radiant/Public/UI/SexyGameOverlay.cpp:116
 msgctxt "GameOverlay,ExitButton"
 msgid "Exit"
-msgstr ""
+msgstr "离开牧场"
 
 #. Key:	LoadButton
 #. SourceLocation:	Source/Radiant/Public/UI/SexyGameOverlay.cpp:95
 #: Source/Radiant/Public/UI/SexyGameOverlay.cpp:95
 msgctxt "GameOverlay,LoadButton"
 msgid "Load Game"
-msgstr ""
+msgstr "回到牧场"
 
 #. Key:	MainMenuButton
 #. SourceLocation:	Source/Radiant/Public/UI/SexyGameOverlay.cpp:109
 #: Source/Radiant/Public/UI/SexyGameOverlay.cpp:109
 msgctxt "GameOverlay,MainMenuButton"
 msgid "Main Menu"
-msgstr ""
+msgstr "主菜单"
 
 #. Key:	OptionsButton
 #. SourceLocation:	Source/Radiant/Public/UI/SexyGameOverlay.cpp:102
 #: Source/Radiant/Public/UI/SexyGameOverlay.cpp:102
 msgctxt "GameOverlay,OptionsButton"
 msgid "Settings"
-msgstr ""
+msgstr "设置"
 
 #. Key:	SaveButton
 #. SourceLocation:	Source/Radiant/Public/UI/SexyGameOverlay.cpp:88
 #: Source/Radiant/Public/UI/SexyGameOverlay.cpp:88
 msgctxt "GameOverlay,SaveButton"
 msgid "Save Game"
-msgstr ""
+msgstr "保存农场"
 
 #. Key:	Null
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyGridItem.cpp:58
 #: Source/Radiant/Public/UI/Components/SexyGridItem.cpp:58
 msgctxt "GridItem,Null"
 msgid "Null"
-msgstr ""
+msgstr "归零"
 
 #. Key:	NotInterested
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyHarvestContainerGrid.cpp:25
 #: Source/Radiant/Public/UI/Components/SexyHarvestContainerGrid.cpp:25
 msgctxt "HarvestGrid,NotInterested"
 msgid "This merchant does not deal in petty fluids."
-msgstr ""
+msgstr "这个商人不喜欢交易零星的体液。"
 
 #. Key:	BuyMilkTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyHarvestWidget.cpp:423
 #: Source/Radiant/Public/UI/Components/SexyHarvestWidget.cpp:423
 msgctxt "HarvestWidget,BuyMilkTooltip"
 msgid "Buy milk."
-msgstr ""
+msgstr "购买乳汁"
 
 #. Key:	BuySemenTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyHarvestWidget.cpp:408
 #: Source/Radiant/Public/UI/Components/SexyHarvestWidget.cpp:408
 msgctxt "HarvestWidget,BuySemenTooltip"
 msgid "Buy semen."
-msgstr ""
+msgstr "购买精液"
 
 #. Key:	MaxMilk
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyHarvestWidget.cpp:250
 #: Source/Radiant/Public/UI/Components/SexyHarvestWidget.cpp:250
 msgctxt "HarvestWidget,MaxMilk"
 msgid "4000 ml"
-msgstr ""
+msgstr "4000 毫升"
 
 #. Key:	MaxSemen
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyHarvestWidget.cpp:155
 #: Source/Radiant/Public/UI/Components/SexyHarvestWidget.cpp:155
 msgctxt "HarvestWidget,MaxSemen"
 msgid "1500 ml"
-msgstr ""
+msgstr "1500 毫升"
 
 #. Key:	Milk
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyHarvestWidget.cpp:220
 #: Source/Radiant/Public/UI/Components/SexyHarvestWidget.cpp:220
 msgctxt "HarvestWidget,Milk"
 msgid "Milk"
-msgstr ""
+msgstr "挤奶"
 
 #. Key:	MilkML
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyHarvestWidget.cpp:238
 #: Source/Radiant/Public/UI/Components/SexyHarvestWidget.cpp:238
 msgctxt "HarvestWidget,MilkML"
 msgid "355 ml"
-msgstr ""
+msgstr "355 毫升"
 
 #. Key:	PriceML
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyHarvestWidget.cpp:170
 #: Source/Radiant/Public/UI/Components/SexyHarvestWidget.cpp:170
 msgctxt "HarvestWidget,PriceML"
 msgid "Unit Price:"
-msgstr ""
+msgstr "单价"
 
 #. Key:	SellMilkTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyHarvestWidget.cpp:421
 #: Source/Radiant/Public/UI/Components/SexyHarvestWidget.cpp:421
 msgctxt "HarvestWidget,SellMilkTooltip"
 msgid "Sell milk."
-msgstr ""
+msgstr "出售乳汁"
 
 #. Key:	SellSemenTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyHarvestWidget.cpp:406
 #: Source/Radiant/Public/UI/Components/SexyHarvestWidget.cpp:406
 msgctxt "HarvestWidget,SellSemenTooltip"
 msgid "Sell semen."
-msgstr ""
+msgstr "出售精液"
 
 #. Key:	Semen
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyHarvestWidget.cpp:125
 #: Source/Radiant/Public/UI/Components/SexyHarvestWidget.cpp:125
 msgctxt "HarvestWidget,Semen"
 msgid "Semen"
-msgstr ""
+msgstr "精液"
 
 #. Key:	SemenML
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyHarvestWidget.cpp:143
 #: Source/Radiant/Public/UI/Components/SexyHarvestWidget.cpp:143
 msgctxt "HarvestWidget,SemenML"
 msgid "118 ml"
-msgstr ""
+msgstr "118 毫升"
 
 #. Key:	UseMilkTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyHarvestWidget.cpp:419
 #: Source/Radiant/Public/UI/Components/SexyHarvestWidget.cpp:419
 msgctxt "HarvestWidget,UseMilkTooltip"
 msgid "Use 15 ml of milk in attempt to stimulate this wild Nephelym."
-msgstr ""
+msgstr "用15毫升乳汁试着刺激一下这只野生的魔弗灵。"
 
 #. Key:	UseSemenTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyHarvestWidget.cpp:404
 #: Source/Radiant/Public/UI/Components/SexyHarvestWidget.cpp:404
 msgctxt "HarvestWidget,UseSemenTooltip"
 msgid "Use 5 ml of semen in attempt to stimulate this wild Nephelym."
-msgstr ""
+msgstr "用5毫升精液试着刺激一下这只野生的魔弗灵"
 
 #. Key:	P
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyIKModifier.cpp:138
 #: Source/Radiant/Public/UI/Components/SexyIKModifier.cpp:138
 msgctxt "IKModifier,P"
 msgid "P"
-msgstr ""
+msgstr "P键"
 
 #. Key:	R
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyIKModifier.cpp:120
 #: Source/Radiant/Public/UI/Components/SexyIKModifier.cpp:120
 msgctxt "IKModifier,R"
 msgid "R"
-msgstr ""
+msgstr "R键"
 
 #. Key:	X
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyIKModifier.cpp:56
 #: Source/Radiant/Public/UI/Components/SexyIKModifier.cpp:56
 msgctxt "IKModifier,X"
 msgid "X"
-msgstr ""
+msgstr "X键"
 
 #. Key:	Y
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyIKModifier.cpp:74
 #: Source/Radiant/Public/UI/Components/SexyIKModifier.cpp:74
 msgctxt "IKModifier,Y"
 msgid "Y"
-msgstr ""
+msgstr "Y键"
 
 #. Key:	Z
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyIKModifier.cpp:92
 #: Source/Radiant/Public/UI/Components/SexyIKModifier.cpp:92
 msgctxt "IKModifier,Z"
 msgid "Z"
-msgstr ""
+msgstr "Z键"
 
 #. Key:	Allure
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyItemDetails.cpp:77
 #: Source/Radiant/Public/UI/Components/SexyItemDetails.cpp:77
 msgctxt "ItemDetails,Allure"
 msgid "Allure"
-msgstr ""
+msgstr "魅力"
 
 #. Key:	AllureTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyItemDetails.cpp:78
 #: Source/Radiant/Public/UI/Components/SexyItemDetails.cpp:78
 msgctxt "ItemDetails,AllureTooltip"
 msgid "Allure will change by this modifier when this item is used."
-msgstr ""
+msgstr "使用这个编辑的话，魅力会因此发生变化"
 
 #. Key:	Description
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyItemDetails.cpp:105
 #: Source/Radiant/Public/UI/Components/SexyItemDetails.cpp:105
 msgctxt "ItemDetails,Description"
 msgid "Description"
-msgstr ""
+msgstr "说明"
 
 #. Key:	Dexterity
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyItemDetails.cpp:91
 #: Source/Radiant/Public/UI/Components/SexyItemDetails.cpp:91
 msgctxt "ItemDetails,Dexterity"
 msgid "Dexterity"
-msgstr ""
+msgstr "灵巧"
 
 #. Key:	DexterityTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyItemDetails.cpp:92
 #: Source/Radiant/Public/UI/Components/SexyItemDetails.cpp:92
 msgctxt "ItemDetails,DexterityTooltip"
 msgid "Dexterity will change by this modifier when this item is used."
-msgstr ""
+msgstr "使用这个编辑的话，敏捷会因此发生变化"
 
 #. Key:	Fertility
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyItemDetails.cpp:70
 #: Source/Radiant/Public/UI/Components/SexyItemDetails.cpp:70
 msgctxt "ItemDetails,Fertility"
 msgid "Fertility"
-msgstr ""
+msgstr "生育能力"
 
 #. Key:	FertilityTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyItemDetails.cpp:71
 #: Source/Radiant/Public/UI/Components/SexyItemDetails.cpp:71
 msgctxt "ItemDetails,FertilityTooltip"
 msgid "Fertility will change by this modifier when this item is used."
-msgstr ""
+msgstr "使用这个编辑的话，生育能力会发生变化"
 
 #. Key:	Level
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyItemDetails.cpp:49
 #: Source/Radiant/Public/UI/Components/SexyItemDetails.cpp:49
 msgctxt "ItemDetails,Level"
 msgid "Level"
-msgstr ""
+msgstr "等级"
 
 #. Key:	LevelTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyItemDetails.cpp:50
 #: Source/Radiant/Public/UI/Components/SexyItemDetails.cpp:50
 msgctxt "ItemDetails,LevelTooltip"
 msgid "Level will change by this modifier when this item is used."
-msgstr ""
+msgstr "使用这个编辑的话，等级会发生变化"
 
 #. Key:	Loyalty
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyItemDetails.cpp:56
 #: Source/Radiant/Public/UI/Components/SexyItemDetails.cpp:56
 msgctxt "ItemDetails,Loyalty"
 msgid "Loyalty"
-msgstr ""
+msgstr "忠诚"
 
 #. Key:	LoyaltyTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyItemDetails.cpp:57
 #: Source/Radiant/Public/UI/Components/SexyItemDetails.cpp:57
 msgctxt "ItemDetails,LoyaltyTooltip"
 msgid "Loyalty will change by this modifier when this item is used."
-msgstr ""
+msgstr "使用这个编辑的话，忠诚会发生变化"
 
 #. Key:	Modifiers
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyItemDetails.cpp:39
 #: Source/Radiant/Public/UI/Components/SexyItemDetails.cpp:39
 msgctxt "ItemDetails,Modifiers"
 msgid "Modifiers"
-msgstr ""
+msgstr "编辑器"
 
 #. Key:	Name
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyItemDetails.cpp:27
 #: Source/Radiant/Public/UI/Components/SexyItemDetails.cpp:27
 msgctxt "ItemDetails,Name"
 msgid "Item"
-msgstr ""
+msgstr "物品"
 
 #. Key:	Strength
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyItemDetails.cpp:63
 #: Source/Radiant/Public/UI/Components/SexyItemDetails.cpp:63
 msgctxt "ItemDetails,Strength"
 msgid "Strength"
-msgstr ""
+msgstr "力量"
 
 #. Key:	StrengthTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyItemDetails.cpp:64
 #: Source/Radiant/Public/UI/Components/SexyItemDetails.cpp:64
 msgctxt "ItemDetails,StrengthTooltip"
 msgid "Strength will change by this modifier when this item is used."
-msgstr ""
+msgstr "使用这个编辑的话，力量会发生变化"
 
 #. Key:	Type
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyItemDetails.cpp:33
 #: Source/Radiant/Public/UI/Components/SexyItemDetails.cpp:33
 msgctxt "ItemDetails,Type"
 msgid "Type"
-msgstr ""
+msgstr "种类"
 
 #. Key:	Value
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyItemDetails.cpp:98
 #: Source/Radiant/Public/UI/Components/SexyItemDetails.cpp:98
 msgctxt "ItemDetails,Value"
 msgid "Value"
-msgstr ""
+msgstr "稀有度"
 
 #. Key:	ValueTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyItemDetails.cpp:99
 #: Source/Radiant/Public/UI/Components/SexyItemDetails.cpp:99
 msgctxt "ItemDetails,ValueTooltip"
 msgid "Value will change by this modifier when this item is used."
-msgstr ""
+msgstr "使用这个编辑的话，稀有度会发生变化"
 
 #. Key:	Willpower
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyItemDetails.cpp:84
 #: Source/Radiant/Public/UI/Components/SexyItemDetails.cpp:84
 msgctxt "ItemDetails,Willpower"
 msgid "Willpower"
-msgstr ""
+msgstr "意志力"
 
 #. Key:	WillpowerTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyItemDetails.cpp:85
 #: Source/Radiant/Public/UI/Components/SexyItemDetails.cpp:85
 msgctxt "ItemDetails,WillpowerTooltip"
 msgid "Willpower will change by this modifier when this item is used."
-msgstr ""
+msgstr "使用这个编辑的话，意志力会发生变化"
 
 #. Key:	NotEnoughFluid
 #. SourceLocation:	Source/Radiant/Public/Items/SexyItemSystem.cpp:170
 #: Source/Radiant/Public/Items/SexyItemSystem.cpp:170
 msgctxt "ItemSystem,NotEnoughFluid"
 msgid "Not enough fluid."
-msgstr ""
+msgstr "体液不够了"
 
 #. Key:	Action
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:174
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:174
 msgctxt "Keybinds,Action"
 msgid "Action"
-msgstr ""
+msgstr "互动"
 
 #. Key:	Back
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:179
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:179
 msgctxt "Keybinds,Back"
 msgid "Back"
-msgstr ""
+msgstr "返回"
 
 #. Key:	Crouch
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:139
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:139
 msgctxt "Keybinds,Crouch"
 msgid "Crouch"
-msgstr ""
+msgstr "下蹲"
 
 #. Key:	GalleryMenu
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:195
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:195
 msgctxt "Keybinds,GalleryMenu"
 msgid "Toggle Gallery"
-msgstr ""
+msgstr "切换画廊"
 
 #. Key:	Jump
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:135
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:135
 msgctxt "Keybinds,Jump"
 msgid "Jump"
-msgstr ""
+msgstr "跳跃"
 
 #. Key:	Look
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:160
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:160
 msgctxt "Keybinds,Look"
 msgid "Camera Look"
-msgstr ""
+msgstr "摄影视角"
 
 #. Key:	MoveBackward
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:123
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:123
 msgctxt "Keybinds,MoveBackward"
 msgid "Move Backwards"
-msgstr ""
+msgstr "向后"
 
 #. Key:	MoveForward
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:119
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:119
 msgctxt "Keybinds,MoveForward"
 msgid "Move Forward"
-msgstr ""
+msgstr "向前"
 
 #. Key:	MoveLeft
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:131
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:131
 msgctxt "Keybinds,MoveLeft"
 msgid "Move Left"
-msgstr ""
+msgstr "向左"
 
 #. Key:	MoveRight
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:127
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:127
 msgctxt "Keybinds,MoveRight"
 msgid "Move Right"
-msgstr ""
+msgstr "向右"
 
 #. Key:	Pan
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:167
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:167
 msgctxt "Keybinds,Pan"
 msgid "Pan"
-msgstr ""
+msgstr "镜头平移"
 
 #. Key:	Rotate
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:170
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:170
 msgctxt "Keybinds,Rotate"
 msgid "Rotate"
-msgstr ""
+msgstr "旋转"
 
 #. Key:	SingleTapDodge
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:146
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:146
 msgctxt "Keybinds,SingleTapDodge"
 msgid "One Tap Dodge"
-msgstr ""
+msgstr "一键闪避"
 
 #. Key:	Slide
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:143
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:143
 msgctxt "Keybinds,Slide"
 msgid "Slide"
-msgstr ""
+msgstr "倾斜"
 
 #. Key:	SpiritForm
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:188
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:188
 msgctxt "Keybinds,SpiritForm"
 msgid "Spirit Form"
-msgstr ""
+msgstr "魂灵形态"
 
 #. Key:	Sprint
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:149
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:149
 msgctxt "Keybinds,Sprint"
 msgid "Sprint"
-msgstr ""
+msgstr "冲刺"
 
 #. Key:	ToggleBoots
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:211
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:211
 msgctxt "Keybinds,ToggleBoots"
 msgid "Toggle Boots"
-msgstr ""
+msgstr "穿脱纽扣靴"
 
 #. Key:	ToggleClothing
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:199
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:199
 msgctxt "Keybinds,ToggleClothing"
 msgid "Toggle Clothing"
-msgstr ""
+msgstr "穿脱衣服"
 
 #. Key:	TogglePants
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:205
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:205
 msgctxt "Keybinds,TogglePants"
 msgid "Toggle Pants"
-msgstr ""
+msgstr "穿脱裤子"
 
 #. Key:	ToggleShirt
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:202
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:202
 msgctxt "Keybinds,ToggleShirt"
 msgid "Toggle Shirt"
-msgstr ""
+msgstr "穿脱衬衫"
 
 #. Key:	ToggleUnderwear
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:208
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:208
 msgctxt "Keybinds,ToggleUnderwear"
 msgid "Toggle Underwear"
-msgstr ""
+msgstr "穿脱内衣"
 
 #. Key:	Turn
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:156
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:156
 msgctxt "Keybinds,Turn"
 msgid "Camera Turn"
-msgstr ""
+msgstr "镜头反转"
 
 #. Key:	UtilityMenu
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:192
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:192
 msgctxt "Keybinds,UtilityMenu"
 msgid "Toggle Utility Menu"
-msgstr ""
+msgstr "切换工具菜单"
 
 #. Key:	Walk
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:152
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:152
 msgctxt "Keybinds,Walk"
 msgid "Walk"
-msgstr ""
+msgstr "步行"
 
 #. Key:	Zoom
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:164
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:164
 msgctxt "Keybinds,Zoom"
 msgid "Camera Zoom"
-msgstr ""
+msgstr "镜头聚焦"
 
 #. Key:	EmptySave
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyListedResource.cpp:171
 #: Source/Radiant/Public/UI/Components/SexyListedResource.cpp:171
 msgctxt "ListedResources,EmptySave"
 msgid "Empty Save Slot"
-msgstr ""
+msgstr "清空存档"
 
 #. Key:	DiscordButton
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyMainMenu.cpp:59
@@ -16083,1085 +16085,1085 @@ msgstr ""
 #: Source/Radiant/Public/UI/Menus/SexyMainMenu.cpp:66
 msgctxt "MainMenu,ExitGameButton"
 msgid "Exit"
-msgstr ""
+msgstr "退出牧场"
 
 #. Key:	LoadGameButton
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyMainMenu.cpp:45
 #: Source/Radiant/Public/UI/Menus/SexyMainMenu.cpp:45
 msgctxt "MainMenu,LoadGameButton"
 msgid "Load Game"
-msgstr ""
+msgstr "读取牧场"
 
 #. Key:	NewGameButton
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyMainMenu.cpp:38
 #: Source/Radiant/Public/UI/Menus/SexyMainMenu.cpp:38
 msgctxt "MainMenu,NewGameButton"
 msgid "New Game"
-msgstr ""
+msgstr "新的牧场"
 
 #. Key:	SettingsButton
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyMainMenu.cpp:52
 #: Source/Radiant/Public/UI/Menus/SexyMainMenu.cpp:52
 msgctxt "MainMenu,SettingsButton"
 msgid "Settings"
-msgstr ""
+msgstr "设置"
 
 #. Key:	ActionButton
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyMonsterMenu.cpp:51
 #: Source/Radiant/Public/UI/Menus/SexyMonsterMenu.cpp:51
 msgctxt "ManageMonster,ActionButton"
 msgid "Start"
-msgstr ""
+msgstr "开始"
 
 #. Key:	ActionTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyMonsterMenu.cpp:52
 #: Source/Radiant/Public/UI/Menus/SexyMonsterMenu.cpp:52
 msgctxt "ManageMonster,ActionTooltip"
 msgid "Perform the selected action, starting a scene if one exists."
-msgstr ""
+msgstr "执行所选动作，如果场景存在，则启动该场景。"
 
 #. Key:	HarvestDev
 #. SourceLocation:	Source/Radiant/Public/Game/Monsters/SexyMonsterSystem.cpp:586
 #: Source/Radiant/Public/Game/Monsters/SexyMonsterSystem.cpp:586
 msgctxt "ManageMonster,HarvestDev"
 msgid "Harvest scene in development."
-msgstr ""
+msgstr "该收获场景正在紧锣密鼓开发中"
 
 #. Key:	InvalidAction
 #. SourceLocation:	Source/Radiant/Public/Game/Monsters/SexyMonsterSystem.cpp:390
 #: Source/Radiant/Public/Game/Monsters/SexyMonsterSystem.cpp:390
 msgctxt "ManageMonster,InvalidAction"
 msgid "Select a harvest action."
-msgstr ""
+msgstr "选择你想要做的收获类型"
 
 #. Key:	ManageWindowTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyMonsterMenu.cpp:133
 #: Source/Radiant/Public/UI/Menus/SexyMonsterMenu.cpp:133
 msgctxt "ManageMonster,ManageWindowTitle"
 msgid "Actions"
-msgstr ""
+msgstr "互动"
 
 #. Key:	QuickActionButton
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyMonsterMenu.cpp:44
 #: Source/Radiant/Public/UI/Menus/SexyMonsterMenu.cpp:44
 msgctxt "ManageMonster,QuickActionButton"
 msgid "Quick"
-msgstr ""
+msgstr "快速执行"
 
 #. Key:	QuickActionTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyMonsterMenu.cpp:45
 #: Source/Radiant/Public/UI/Menus/SexyMonsterMenu.cpp:45
 msgctxt "ManageMonster,QuickActionTooltip"
 msgid "Perform the selected action without starting a scene."
-msgstr ""
+msgstr "在没有开始一个场景的情况下执行所选择的动作"
 
 #. Key:	Giver
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyMateSizeChart.cpp:33
 #: Source/Radiant/Public/UI/Components/SexyMateSizeChart.cpp:33
 msgctxt "MateSizeChart,Giver"
 msgid "Giver"
-msgstr ""
+msgstr "攻"
 
 #. Key:	Receiver
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyMateSizeChart.cpp:22
 #: Source/Radiant/Public/UI/Components/SexyMateSizeChart.cpp:22
 msgctxt "MateSizeChart,Receiver"
 msgid "Receiver"
-msgstr ""
+msgstr "受"
 
 #. Key:	MerchantNoRoomMilk
 #. SourceLocation:	Source/Radiant/Public/Economy/SexyMerchantSystem.cpp:271
 #: Source/Radiant/Public/Economy/SexyMerchantSystem.cpp:271
 msgctxt "MerchantSystem,MerchantNoRoomMilk"
 msgid "This merchant cannot carry more of this race's milk."
-msgstr ""
+msgstr "这个商人收了太多这个种族的乳汁了。"
 
 #. Key:	MerchantNoRoomSemen
 #. SourceLocation:	Source/Radiant/Public/Economy/SexyMerchantSystem.cpp:243
 #: Source/Radiant/Public/Economy/SexyMerchantSystem.cpp:243
 msgctxt "MerchantSystem,MerchantNoRoomSemen"
 msgid "This merchant cannot carry more of this race's semen."
-msgstr ""
+msgstr "这个商人收了太多这个种族的精液了"
 
 #. Key:	NoRoomMilk
 #. SourceLocation:	Source/Radiant/Public/Economy/SexyMerchantSystem.cpp:366
 #: Source/Radiant/Public/Economy/SexyMerchantSystem.cpp:366
 msgctxt "MerchantSystem,NoRoomMilk"
 msgid "You cannot carry more of this race's milk."
-msgstr ""
+msgstr "你带不了那么多这个种族的乳汁。"
 
 #. Key:	NoRoomSemen
 #. SourceLocation:	Source/Radiant/Public/Economy/SexyMerchantSystem.cpp:334
 #: Source/Radiant/Public/Economy/SexyMerchantSystem.cpp:334
 msgctxt "MerchantSystem,NoRoomSemen"
 msgid "You cannot carry more of this race's semen."
-msgstr ""
+msgstr "你带不了那么多这个种族的精液"
 
 #. Key:	NewOffspringMessage
 #. SourceLocation:	Source/Radiant/Public/Game/Monsters/SexyMonsterSystem.cpp:329
 #: Source/Radiant/Public/Game/Monsters/SexyMonsterSystem.cpp:329
 msgctxt "MonsterSystem,NewOffspringMessage"
 msgid "New offspring were produced, check your barns."
-msgstr ""
+msgstr "你的后代诞生啦，快去你的牧场看看吧！"
 
 #. Key:	AcceptButtonTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyOffspringMenu.cpp:41
 #: Source/Radiant/Public/UI/Menus/SexyOffspringMenu.cpp:41
 msgctxt "Offspring,AcceptButtonTitle"
 msgid "Accept"
-msgstr ""
+msgstr "接受"
 
 #. Key:	AcceptButtonTitleTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyOffspringMenu.cpp:42
 #: Source/Radiant/Public/UI/Menus/SexyOffspringMenu.cpp:42
 msgctxt "Offspring,AcceptButtonTitleTooltip"
 msgid "Keep this offspring and add it to your ranch."
-msgstr ""
+msgstr "把后代留在你的农场里生活。"
 
 #. Key:	ReceiverWindowTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyOffspringMenu.cpp:50
 #: Source/Radiant/Public/UI/Menus/SexyOffspringMenu.cpp:50
 msgctxt "Offspring,ReceiverWindowTitle"
 msgid "Nephelym Offspring"
-msgstr ""
+msgstr "魔弗灵的后代"
 
 #. Key:	ReleaseButtonTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyOffspringMenu.cpp:27
 #: Source/Radiant/Public/UI/Menus/SexyOffspringMenu.cpp:27
 msgctxt "Offspring,ReleaseButtonTitle"
 msgid "Release"
-msgstr ""
+msgstr "放生"
 
 #. Key:	ReleaseButtonTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyOffspringMenu.cpp:28
 #: Source/Radiant/Public/UI/Menus/SexyOffspringMenu.cpp:28
 msgctxt "Offspring,ReleaseButtonTooltip"
 msgid "Release this offspring into the wild."
-msgstr ""
+msgstr "将该魔弗灵放生到野外"
 
 #. Key:	RenameButton
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyOffspringMenu.cpp:34
 #: Source/Radiant/Public/UI/Menus/SexyOffspringMenu.cpp:34
 msgctxt "Offspring,RenameButton"
 msgid "Rename"
-msgstr ""
+msgstr "重命名"
 
 #. Key:	RenameButtonTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyOffspringMenu.cpp:35
 #: Source/Radiant/Public/UI/Menus/SexyOffspringMenu.cpp:35
 msgctxt "Offspring,RenameButtonTooltip"
 msgid "Rename this offspring before adding it to your ranch."
-msgstr ""
+msgstr "给他命名并留在您的农场里生活。"
 
 #. Key:	Female
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:353
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:353
 msgctxt "Radiant,Female"
 msgid "Female"
-msgstr ""
+msgstr "女性"
 
 #. Key:	Futa
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:356
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:356
 msgctxt "Radiant,Futa"
 msgid "Futa"
-msgstr ""
+msgstr "扶她"
 
 #. Key:	Male
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:359
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:359
 msgctxt "Radiant,Male"
 msgid "Male"
-msgstr ""
+msgstr "男性"
 
 #. Key:	NullText
 #. SourceLocation:	Source/Radiant/Public/Data/SexyData.h:2403
 #: Source/Radiant/Public/Data/SexyData.h:2403
 msgctxt "Radiant,NullText"
 msgid "None"
-msgstr ""
+msgstr "无"
 
 #. Key:	AcceptButton
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyRenameBox.cpp:60
 #: Source/Radiant/Public/UI/Components/SexyRenameBox.cpp:60
 msgctxt "RenameBox,AcceptButton"
 msgid "Accept"
-msgstr ""
+msgstr "接受"
 
 #. Key:	CancelButton
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyRenameBox.cpp:66
 #: Source/Radiant/Public/UI/Components/SexyRenameBox.cpp:66
 msgctxt "RenameBox,CancelButton"
 msgid "Cancel"
-msgstr ""
+msgstr "取消"
 
 #. Key:	RandomNameTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyRenameBox.cpp:48
 #: Source/Radiant/Public/UI/Components/SexyRenameBox.cpp:48
 msgctxt "RenameBox,RandomNameTooltip"
 msgid "Generate a random name."
-msgstr ""
+msgstr "随机取名"
 
 #. Key:	WindowTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyRenameBox.cpp:28
 #: Source/Radiant/Public/UI/Components/SexyRenameBox.cpp:28
 msgctxt "RenameBox,WindowTitle"
 msgid "Rename"
-msgstr ""
+msgstr "重命名"
 
 #. Key:	ActionGiveFavorite
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyResourceList.cpp:885
 #: Source/Radiant/Public/UI/Components/SexyResourceList.cpp:885
 msgctxt "ResourceList,ActionGiveFavorite"
 msgid "Give Fluid"
-msgstr ""
+msgstr "给予体液"
 
 #. Key:	ActionHarvestMilk
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyResourceList.cpp:867
 #: Source/Radiant/Public/UI/Components/SexyResourceList.cpp:867
 msgctxt "ResourceList,ActionHarvestMilk"
 msgid "Harvest Milk"
-msgstr ""
+msgstr "挤奶"
 
 #. Key:	ActionHarvestMilkAssist
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyResourceList.cpp:871
 #: Source/Radiant/Public/UI/Components/SexyResourceList.cpp:871
 msgctxt "ResourceList,ActionHarvestMilkAssist"
 msgid "Harvest Milk (Fern)"
-msgstr ""
+msgstr "挤奶（小蕨）"
 
 #. Key:	ActionHarvestMilkAssist2
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyResourceList.cpp:876
 #: Source/Radiant/Public/UI/Components/SexyResourceList.cpp:876
 msgctxt "ResourceList,ActionHarvestMilkAssist2"
 msgid "Harvest Milk (Blossom)"
-msgstr ""
+msgstr "挤奶（花花）"
 
 #. Key:	ActionHarvestSemen
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyResourceList.cpp:864
 #: Source/Radiant/Public/UI/Components/SexyResourceList.cpp:864
 msgctxt "ResourceList,ActionHarvestSemen"
 msgid "Harvest Semen"
-msgstr ""
+msgstr "收获精液"
 
 #. Key:	ActionHarvestSemen2
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyResourceList.cpp:865
 #: Source/Radiant/Public/UI/Components/SexyResourceList.cpp:865
 msgctxt "ResourceList,ActionHarvestSemen2"
 msgid "Capture Semen"
-msgstr ""
+msgstr "榨取精液"
 
 #. Key:	ActionHarvestSemenAssist
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyResourceList.cpp:869
 #: Source/Radiant/Public/UI/Components/SexyResourceList.cpp:869
 msgctxt "ResourceList,ActionHarvestSemenAssist"
 msgid "Harvest Semen (Fern)"
-msgstr ""
+msgstr "收获精液（小蕨）"
 
 #. Key:	ActionHarvestSemenAssist2
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyResourceList.cpp:870
 #: Source/Radiant/Public/UI/Components/SexyResourceList.cpp:870
 msgctxt "ResourceList,ActionHarvestSemenAssist2"
 msgid "Capture Semen (Fern)"
-msgstr ""
+msgstr "榨取精液（小蕨）"
 
 #. Key:	ActionHarvestSemenAssist3
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyResourceList.cpp:874
 #: Source/Radiant/Public/UI/Components/SexyResourceList.cpp:874
 msgctxt "ResourceList,ActionHarvestSemenAssist3"
 msgid "Harvest Semen (Blossom)"
-msgstr ""
+msgstr "收获精液（花花）"
 
 #. Key:	ActionHarvestSemenAssist4
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyResourceList.cpp:875
 #: Source/Radiant/Public/UI/Components/SexyResourceList.cpp:875
 msgctxt "ResourceList,ActionHarvestSemenAssist4"
 msgid "Capture Semen (Blossom)"
-msgstr ""
+msgstr "榨取精液（花花）"
 
 #. Key:	ActionRelease
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyResourceList.cpp:878
 #: Source/Radiant/Public/UI/Components/SexyResourceList.cpp:878
 msgctxt "ResourceList,ActionRelease"
 msgid "Release into the Wild"
-msgstr ""
+msgstr "放归野外"
 
 #. Key:	ActionRename
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyResourceList.cpp:862
 #: Source/Radiant/Public/UI/Components/SexyResourceList.cpp:862
 msgctxt "ResourceList,ActionRename"
 msgid "Rename"
-msgstr ""
+msgstr "重命名"
 
 #. Key:	ActionSeduce
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyResourceList.cpp:898
 #: Source/Radiant/Public/UI/Components/SexyResourceList.cpp:898
 msgctxt "ResourceList,ActionSeduce"
 msgid "Seduce"
-msgstr ""
+msgstr "魅惑"
 
 #. Key:	ActionSleep
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyResourceList.cpp:855
 #: Source/Radiant/Public/UI/Components/SexyResourceList.cpp:855
 msgctxt "ResourceList,ActionSleep"
 msgid "Sleep"
-msgstr ""
+msgstr "休息"
 
 #. Key:	ActionSurpriseSex
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyResourceList.cpp:921
 #: Source/Radiant/Public/UI/Components/SexyResourceList.cpp:921
 msgctxt "ResourceList,ActionSurpriseSex"
 msgid "Surprise Sex"
-msgstr ""
+msgstr "性爱突袭"
 
 #. Key:	SaveWindowTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexySaveMenu.cpp:19
 #: Source/Radiant/Public/UI/Menus/SexySaveMenu.cpp:19
 msgctxt "SaveMenu,SaveWindowTitle"
 msgid "Saved Games"
-msgstr ""
+msgstr "保存农场进度"
 
 #. Key:	SlotPath
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexySaveMenu.cpp:29
 #: Source/Radiant/Public/UI/Menus/SexySaveMenu.cpp:29
 msgctxt "SaveMenu,SlotPath"
 msgid "Save Location"
-msgstr ""
+msgstr "存档地址"
 
 #. Key:	ErrorSavingGame
 #. SourceLocation:	Source/Radiant/Public/UI/Saving/SexySaveSystem.cpp:276
 #: Source/Radiant/Public/UI/Saving/SexySaveSystem.cpp:276
 msgctxt "SaveSystem,ErrorSavingGame"
 msgid "Error while trying to save."
-msgstr ""
+msgstr "存档时发生错误"
 
 #. Key:	SavedGame
 #. SourceLocation:	Source/Radiant/Public/UI/Saving/SexySaveSystem.cpp:273
 #: Source/Radiant/Public/UI/Saving/SexySaveSystem.cpp:273
 msgctxt "SaveSystem,SavedGame"
 msgid "Game successfully saved."
-msgstr ""
+msgstr "您的农场状况保存好了"
 
 #. Key:	AllFutas
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:99
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:99
 msgctxt "SettingsMenu,AllFutas"
 msgid "Only Futas"
-msgstr ""
+msgstr "只有扶她"
 
 #. Key:	AllFutasHelp
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:99
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:99
 msgctxt "SettingsMenu,AllFutasHelp"
 msgid "With the exception of the breeders, all other characters are futas."
-msgstr ""
+msgstr "除了农场主，其他所有角色都是futas。"
 
 #. Key:	AudioTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:84
 #: Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:84
 msgctxt "SettingsMenu,AudioTitle"
 msgid "Sound"
-msgstr ""
+msgstr "声音选项"
 
 #. Key:	AutoplayDialogue
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:106
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:106
 msgctxt "SettingsMenu,AutoplayDialogue"
 msgid "Autoplay Dialogue"
-msgstr ""
+msgstr "自动播放对话"
 
 #. Key:	AutoplayDialogueHelp
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:106
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:106
 msgctxt "SettingsMenu,AutoplayDialogueHelp"
 msgid "Automatically cycle through lines of dialogue without having to press next."
-msgstr ""
+msgstr "无需按下一步，即可自动对话。"
 
 #. Key:	BodyComposition
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:94
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:94
 msgctxt "SettingsMenu,BodyComposition"
 msgid "Body Composition"
-msgstr ""
+msgstr "身体组成"
 
 #. Key:	BodyCompositionHelp
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:94
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:94
 msgctxt "SettingsMenu,BodyCompositionHelp"
 msgid "Makes all wild Nephelym bodies random, and allows you to change them via items."
-msgstr ""
+msgstr "随机生成野生魔弗灵的身体外观，并允许你修改变其外观"
 
 #. Key:	CameraControls
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:180
 #: Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:180
 msgctxt "SettingsMenu,CameraControls"
 msgid "Camera"
-msgstr ""
+msgstr "镜头"
 
 #. Key:	CameraPan
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:214
 #: Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:214
 msgctxt "SettingsMenu,CameraPan"
 msgid "Pan Rate"
-msgstr ""
+msgstr "水平镜头视角速度"
 
 #. Key:	CameraRotate
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:193
 #: Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:193
 msgctxt "SettingsMenu,CameraRotate"
 msgid "Rotate Rate"
-msgstr ""
+msgstr "镜头旋转速度"
 
 #. Key:	CameraZoom
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:235
 #: Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:235
 msgctxt "SettingsMenu,CameraZoom"
 msgid "Zoom Rate"
-msgstr ""
+msgstr "镜头缩放变焦"
 
 #. Key:	CamShakeHelp
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:111
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:111
 msgctxt "SettingsMenu,CamShakeHelp"
 msgid "Camera will shake when large characters are nearby."
-msgstr ""
+msgstr "当巨大的魔弗灵在附近时，镜头就会随之抖动。"
 
 #. Key:	CamShakeOption
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:111
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:111
 msgctxt "SettingsMenu,CamShakeOption"
 msgid "Camera Shake"
-msgstr ""
+msgstr "镜头抖动"
 
 #. Key:	CIHelp
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:103
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:103
 msgctxt "SettingsMenu,CIHelp"
 msgid "Female body will swell in proportion to the amount of cum received."
-msgstr ""
+msgstr "女性的身体会随着射精量的增加而隆起。"
 
 #. Key:	ControlsTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:74
 #: Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:74
 msgctxt "SettingsMenu,ControlsTitle"
 msgid "Controls"
-msgstr ""
+msgstr "按键设置"
 
 #. Key:	CumInflation
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:103
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:103
 msgctxt "SettingsMenu,CumInflation"
 msgid "Cum Inflation"
-msgstr ""
+msgstr "精液膨胀效果"
 
 #. Key:	DickSheath
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:341
 #: Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:341
 msgctxt "SettingsMenu,DickSheath"
 msgid "Dick Blur Sheath"
-msgstr ""
+msgstr "模糊处理阴茎"
 
 #. Key:	EffectsVolume
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:410
 #: Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:410
 msgctxt "SettingsMenu,EffectsVolume"
 msgid "Effects"
-msgstr ""
+msgstr "效果"
 
 #. Key:	FeralFemales
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:96
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:96
 msgctxt "SettingsMenu,FeralFemales"
 msgid "Exotic Females"
-msgstr ""
+msgstr "女性魔物化"
 
 #. Key:	FeralFemalesHelp
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:96
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:96
 msgctxt "SettingsMenu,FeralFemalesHelp"
 msgid "Female and futa Nephelym can have a trait that alters their appearance to be more monster than human. Males are always exotic."
-msgstr ""
+msgstr "女性和扶她的魔弗灵可能具有改变其外表的特性，相对于人类外观继承了更多的野兽的特征，男性总是野兽外观。"
 
 #. Key:	Futanari
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:97
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:97
 msgctxt "SettingsMenu,Futanari"
 msgid "Futanari"
-msgstr ""
+msgstr "扶她"
 
 #. Key:	FutanariHelp
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:97
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:97
 msgctxt "SettingsMenu,FutanariHelp"
 msgid "Female Nephelym and NPCs can have a fully functional dick."
-msgstr ""
+msgstr "女性魔弗灵和NPC们会有一根健全功能的阴茎"
 
 #. Key:	GameplayTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:54
 #: Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:54
 msgctxt "SettingsMenu,GameplayTitle"
 msgid "Gameplay"
-msgstr ""
+msgstr "游戏性"
 
 #. Key:	GraphicsTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:64
 #: Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:64
 msgctxt "SettingsMenu,GraphicsTitle"
 msgid "Graphics"
-msgstr ""
+msgstr "图像"
 
 #. Key:	HominalFemales
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:95
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:95
 msgctxt "SettingsMenu,HominalFemales"
 msgid "Hominal Females"
-msgstr ""
+msgstr "魔物娘人形化"
 
 #. Key:	HominalFemalesHelp
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:95
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:95
 msgctxt "SettingsMenu,HominalFemalesHelp"
 msgid "Female and futa Nephelym can have a trait that alters their appearance to be more human than monster."
-msgstr ""
+msgstr "女性和扶她的魔弗灵可能具有一种改变其外表的特性，相对于野兽继承了更多的人类外观。"
 
 #. Key:	KeyBinds
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:252
 #: Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:252
 msgctxt "SettingsMenu,KeyBinds"
 msgid "Action Bindings"
-msgstr ""
+msgstr "按键绑定"
 
 #. Key:	LangMode
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:495
 #: Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:495
 msgctxt "SettingsMenu,LangMode"
 msgid "Language"
-msgstr ""
+msgstr "语种选择"
 
 #. Key:	LangTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:483
 #: Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:483
 msgctxt "SettingsMenu,LangTitle"
 msgid "Localization"
-msgstr ""
+msgstr "本地文件地址"
 
 #. Key:	MalesFutas
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:98
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:98
 msgctxt "SettingsMenu,MalesFutas"
 msgid "All Males are Futas"
-msgstr ""
+msgstr "男性均是扶她"
 
 #. Key:	MalesFutasHelp
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:98
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:98
 msgctxt "SettingsMenu,MalesFutasHelp"
 msgid "With the exception of the male breeder, all male Nephelym will be replaced with futas."
-msgstr ""
+msgstr "除男性主角外，所有男性的魔弗灵都将被扶她取代，野外也不会刷新男性魔弗灵。"
 
 #. Key:	MasterVolume
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:389
 #: Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:389
 msgctxt "SettingsMenu,MasterVolume"
 msgid "Master"
-msgstr ""
+msgstr "主要音量"
 
 #. Key:	MusicVolume
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:452
 #: Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:452
 msgctxt "SettingsMenu,MusicVolume"
 msgid "Music"
-msgstr ""
+msgstr "音乐"
 
 #. Key:	OptionsWindowTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:36
 #: Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:36
 msgctxt "SettingsMenu,OptionsWindowTitle"
 msgid "Settings"
-msgstr ""
+msgstr "设置"
 
 #. Key:	PhysHelp
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:110
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:110
 msgctxt "SettingsMenu,PhysHelp"
 msgid "Simulate Breeder's jiggly bits, disable for performance gain. Restart required for full effect."
-msgstr ""
+msgstr "在主角身上适用物理效果，禁用以提高性能。需要重新启动游戏才能生效。"
 
 #. Key:	PhysicsTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:355
 #: Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:355
 msgctxt "SettingsMenu,PhysicsTitle"
 msgid "Physics"
-msgstr ""
+msgstr "图像效果"
 
 #. Key:	PhysOption
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:110
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:110
 msgctxt "SettingsMenu,PhysOption"
 msgid "Physics"
-msgstr ""
+msgstr "物理效果"
 
 #. Key:	Pregnancy
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:100
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:100
 msgctxt "SettingsMenu,Pregnancy"
 msgid "Pregnancy"
-msgstr ""
+msgstr "怀孕"
 
 #. Key:	PregnancyHelp
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:100
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:100
 msgctxt "SettingsMenu,PregnancyHelp"
 msgid "Female Nephelym will take 4 days to summon their offspring, and the belly will morph to reflect this.\nWARNING: Toggling this off during gameplay will cause existing pregnancies to be lost."
-msgstr ""
+msgstr "女性魔弗灵将需要4天时间来孕育他们的后代诞生，而腹部也会随之不断隆起。\n警告:在游戏过程中关闭这个选项会使正处怀孕中的魔弗灵丢失子嗣。"
 
 #. Key:	Quality
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:326
 #: Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:326
 msgctxt "SettingsMenu,Quality"
 msgid "Overall Quality"
-msgstr ""
+msgstr "整体画面质量"
 
 #. Key:	RenderingFeatures
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:315
 #: Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:315
 msgctxt "SettingsMenu,RenderingFeatures"
 msgid "Rendering Features"
-msgstr ""
+msgstr "渲染功能"
 
 #. Key:	Resolution
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:301
 #: Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:301
 msgctxt "SettingsMenu,Resolution"
 msgid "Resolution"
-msgstr ""
+msgstr "分辨率"
 
 #. Key:	ScreenTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:274
 #: Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:274
 msgctxt "SettingsMenu,ScreenTitle"
 msgid "Screen"
-msgstr ""
+msgstr "画面"
 
 #. Key:	SurpriseHelp
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:101
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:101
 msgctxt "SettingsMenu,SurpriseHelp"
 msgid "Allow consensual surprise sex."
-msgstr ""
+msgstr "允许性爱突袭"
 
 #. Key:	SurpriseSex
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:101
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:101
 msgctxt "SettingsMenu,SurpriseSex"
 msgid "Surprise Sex"
-msgstr ""
+msgstr "性爱突袭"
 
 #. Key:	ThemedFluids
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:102
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:102
 msgctxt "SettingsMenu,ThemedFluids"
 msgid "Racial Body Fluids"
-msgstr ""
+msgstr "种族体液"
 
 #. Key:	ThemedFluidsHelp
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:102
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:102
 msgctxt "SettingsMenu,ThemedFluidsHelp"
 msgid "Each race has unique colors for their body fluids. If disabled, human colors will be used."
-msgstr ""
+msgstr "每个种族的体液都有其独特的颜色。如果禁用，只会使用人类的体液色。"
 
 #. Key:	UITitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:94
 #: Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:94
 msgctxt "SettingsMenu,UITitle"
 msgid "UI"
-msgstr ""
+msgstr "用户界面"
 
 #. Key:	VocalsVolume
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:431
 #: Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:431
 msgctxt "SettingsMenu,VocalsVolume"
 msgid "Vocals"
-msgstr ""
+msgstr "人声"
 
 #. Key:	Volume
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:376
 #: Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:376
 msgctxt "SettingsMenu,Volume"
 msgid "Volume"
-msgstr ""
+msgstr "音量"
 
 #. Key:	WindowMode
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:286
 #: Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:286
 msgctxt "SettingsMenu,WindowMode"
 msgid "Window Mode"
-msgstr ""
+msgstr "窗口模式"
 
 #. Key:	BuyPositionMessage
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyTradeMenu.cpp:908
 #: Source/Radiant/Public/UI/Menus/SexyTradeMenu.cpp:908
 msgctxt "SexyTradeMenu,BuyPositionMessage"
 msgid "You will learn this sex position."
-msgstr ""
+msgstr "你将学习这个体位。"
 
 #. Key:	CollapseGStats
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyBreedingSetupMenu.cpp:121
 #: Source/Radiant/Public/UI/Menus/SexyBreedingSetupMenu.cpp:121
 msgctxt "SSexyBreedingSetupMenu,CollapseGStats"
 msgid "Hide detailed stats for selected giver."
-msgstr ""
+msgstr "隐藏给予者的三围数据"
 
 #. Key:	CollapseRStats
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyBreedingSetupMenu.cpp:177
 #: Source/Radiant/Public/UI/Menus/SexyBreedingSetupMenu.cpp:177
 msgctxt "SSexyBreedingSetupMenu,CollapseRStats"
 msgid "Hide detailed stats for selected receiver."
-msgstr ""
+msgstr "隐藏接受者的三围数据"
 
 #. Key:	ExpandGStats
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyBreedingSetupMenu.cpp:100
 #: Source/Radiant/Public/UI/Menus/SexyBreedingSetupMenu.cpp:100
 msgctxt "SSexyBreedingSetupMenu,ExpandGStats"
 msgid "View detailed stats for selected giver."
-msgstr ""
+msgstr "查看给予者的三围数据"
 
 #. Key:	ExpandRStats
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyBreedingSetupMenu.cpp:156
 #: Source/Radiant/Public/UI/Menus/SexyBreedingSetupMenu.cpp:156
 msgctxt "SSexyBreedingSetupMenu,ExpandRStats"
 msgid "View detailed stats for selected receiver."
-msgstr ""
+msgstr "查看接受者的三围数据"
 
 #. Key:	SpiritForm
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:239
 #: Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:239
 msgctxt "SSexyCharacterDetails,SpiritForm"
 msgid "Spirit Form"
-msgstr ""
+msgstr "魂灵形态"
 
 #. Key:	ExoticTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterGalleryControls.cpp:46
 #: Source/Radiant/Public/UI/Components/SexyCharacterGalleryControls.cpp:46
 msgctxt "SSexyCharacterGalleryControls,ExoticTooltip"
 msgid "Give this character its exotic trait if one exists."
-msgstr ""
+msgstr "给予这个角色兽形外观（如果有的话）"
 
 #. Key:	HominalTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterGalleryControls.cpp:35
 #: Source/Radiant/Public/UI/Components/SexyCharacterGalleryControls.cpp:35
 msgctxt "SSexyCharacterGalleryControls,HominalTooltip"
 msgid "Give this character its hominal trait if one exists."
-msgstr ""
+msgstr "给予这个角色人形外观（如果有的话）"
 
 #. Key:	UsrPresetTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterGalleryControls.cpp:57
 #: Source/Radiant/Public/UI/Components/SexyCharacterGalleryControls.cpp:57
 msgctxt "SSexyCharacterGalleryControls,UsrPresetTooltip"
 msgid "Load a preset for this character."
-msgstr ""
+msgstr "加载此角色的预设值"
 
 #. Key:	None
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyDropList.cpp:82
 #: Source/Radiant/Public/UI/Components/SexyDropList.cpp:82
 msgctxt "SSexyDropList,None"
 msgid "None"
-msgstr ""
+msgstr "无"
 
 #. Key:	BackButtonTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyGalleryMenu.cpp:56
 #: Source/Radiant/Public/UI/Menus/SexyGalleryMenu.cpp:56
 msgctxt "SSexyGalleryMenu,BackButtonTitle"
 msgid "Back"
-msgstr ""
+msgstr "后退"
 
 #. Key:	BackButtonTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyGalleryMenu.cpp:57
 #: Source/Radiant/Public/UI/Menus/SexyGalleryMenu.cpp:57
 msgctxt "SSexyGalleryMenu,BackButtonTooltip"
 msgid "Return to the creator."
-msgstr ""
+msgstr "回归造物主"
 
 #. Key:	GiverWindowTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyGalleryMenu.cpp:72
 #: Source/Radiant/Public/UI/Menus/SexyGalleryMenu.cpp:72
 msgctxt "SSexyGalleryMenu,GiverWindowTitle"
 msgid "Select Giver"
-msgstr ""
+msgstr "选择给予者"
 
 #. Key:	ReceiverWindowTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyGalleryMenu.cpp:107
 #: Source/Radiant/Public/UI/Menus/SexyGalleryMenu.cpp:107
 msgctxt "SSexyGalleryMenu,ReceiverWindowTitle"
 msgid "Select Receiver"
-msgstr ""
+msgstr "选择接受者"
 
 #. Key:	ViewButtonTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyGalleryMenu.cpp:63
 #: Source/Radiant/Public/UI/Menus/SexyGalleryMenu.cpp:63
 msgctxt "SSexyGalleryMenu,ViewButtonTitle"
 msgid "View"
-msgstr ""
+msgstr "预览"
 
 #. Key:	ViewButtonTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyGalleryMenu.cpp:64
 #: Source/Radiant/Public/UI/Menus/SexyGalleryMenu.cpp:64
 msgctxt "SSexyGalleryMenu,ViewButtonTooltip"
 msgid "View the sex scene for the currently selected mates and options."
-msgstr ""
+msgstr "查看当前选定魔弗灵的性爱场景和选项。"
 
 #. Key:	ASOGMessage
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyGenericMenu.cpp:83
 #: Source/Radiant/Public/UI/Menus/SexyGenericMenu.cpp:83
 msgctxt "SSexyGenericMenu,ASOGMessage"
 msgid "Special thanks to the following people:"
-msgstr ""
+msgstr "特别感谢以下人士："
 
 #. Key:	ASOGWindowTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyGenericMenu.cpp:72
 #: Source/Radiant/Public/UI/Menus/SexyGenericMenu.cpp:72
 msgctxt "SSexyGenericMenu,ASOGWindowTitle"
 msgid "Ancient Stone of Glory"
-msgstr ""
+msgstr "古老的荣耀之石"
 
 #. Key:	DailyTasksTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyGenericMenu.cpp:117
 #: Source/Radiant/Public/UI/Menus/SexyGenericMenu.cpp:117
 msgctxt "SSexyGenericMenu,DailyTasksTitle"
 msgid "Daily"
-msgstr ""
+msgstr "日常"
 
 #. Key:	FulfillButton
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyGenericMenu.cpp:173
 #: Source/Radiant/Public/UI/Menus/SexyGenericMenu.cpp:173
 msgctxt "SSexyGenericMenu,FulfillButton"
 msgid "Fulfill"
-msgstr ""
+msgstr "完成"
 
 #. Key:	FulfillButtonTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyGenericMenu.cpp:174
 #: Source/Radiant/Public/UI/Menus/SexyGenericMenu.cpp:174
 msgctxt "SSexyGenericMenu,FulfillButtonTooltip"
 msgid "Accept the reward for this task."
-msgstr ""
+msgstr "收下这项任务的奖励"
 
 #. Key:	SpecialTasksTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyGenericMenu.cpp:127
 #: Source/Radiant/Public/UI/Menus/SexyGenericMenu.cpp:127
 msgctxt "SSexyGenericMenu,SpecialTasksTitle"
 msgid "Special Requests"
-msgstr ""
+msgstr "特殊需求"
 
 #. Key:	TaskMonsterWindowTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyGenericMenu.cpp:183
 #: Source/Radiant/Public/UI/Menus/SexyGenericMenu.cpp:183
 msgctxt "SSexyGenericMenu,TaskMonsterWindowTitle"
 msgid "Select Nephelym to Fulfill Task"
-msgstr ""
+msgstr "选择完成该任务的魔弗灵"
 
 #. Key:	TaskWindowTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyGenericMenu.cpp:100
 #: Source/Radiant/Public/UI/Menus/SexyGenericMenu.cpp:100
 msgctxt "SSexyGenericMenu,TaskWindowTitle"
 msgid "Breeding Tasks"
-msgstr ""
+msgstr "育种需求"
 
 #. Key:	TravelWindowTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyGenericMenu.cpp:57
 #: Source/Radiant/Public/UI/Menus/SexyGenericMenu.cpp:57
 msgctxt "SSexyGenericMenu,TravelWindowTitle"
 msgid "Select Destination"
-msgstr ""
+msgstr "选择目的地"
 
 #. Key:	BindButton
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyKeyBind.cpp:33
 #: Source/Radiant/Public/UI/Components/SexyKeyBind.cpp:33
 msgctxt "SSexyKeyBind,BindButton"
 msgid "Bind"
-msgstr ""
+msgstr "绑定"
 
 #. Key:	BindKey
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyKeyBind.cpp:56
 #: Source/Radiant/Public/UI/Components/SexyKeyBind.cpp:56
 msgctxt "SSexyKeyBind,BindKey"
 msgid "Press Key"
-msgstr ""
+msgstr "请按键"
 
 #. Key:	CollapseStats
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyMonsterMenu.cpp:126
 #: Source/Radiant/Public/UI/Menus/SexyMonsterMenu.cpp:126
 msgctxt "SSexyMonsterMenu,CollapseStats"
 msgid "Hide detailed stats for selected Nephelym."
-msgstr ""
+msgstr "隐藏选中的魔弗灵的三围信息。"
 
 #. Key:	ExpandStats
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyMonsterMenu.cpp:107
 #: Source/Radiant/Public/UI/Menus/SexyMonsterMenu.cpp:107
 msgctxt "SSexyMonsterMenu,ExpandStats"
 msgid "View detailed stats for selected Nephelym."
-msgstr ""
+msgstr "查看选中的魔弗灵的三围信息"
 
 #. Key:	ManageWindowTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyRanchMenu.cpp:76
 #: Source/Radiant/Public/UI/Menus/SexyRanchMenu.cpp:76
 msgctxt "SSexyRanchMenu,ManageWindowTitle"
 msgid "Actions"
-msgstr ""
+msgstr "互动"
 
 #. Key:	ClearFilterTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyResourceList.cpp:144
 #: Source/Radiant/Public/UI/Components/SexyResourceList.cpp:144
 msgctxt "SSexyResourceList,ClearFilterTooltip"
 msgid "Clear all current filters."
-msgstr ""
+msgstr "清除筛选条件"
 
 #. Key:	HarvestFilterTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyResourceList.cpp:117
 #: Source/Radiant/Public/UI/Components/SexyResourceList.cpp:117
 msgctxt "SSexyResourceList,HarvestFilterTooltip"
 msgid "Filter by harvest ability."
-msgstr ""
+msgstr "按能否收获体液过滤"
 
 #. Key:	RaceFilterTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyResourceList.cpp:75
 #: Source/Radiant/Public/UI/Components/SexyResourceList.cpp:75
 msgctxt "SSexyResourceList,RaceFilterTooltip"
 msgid "Filter by race."
-msgstr ""
+msgstr "按种族筛选"
 
 #. Key:	SexFilterTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyResourceList.cpp:89
 #: Source/Radiant/Public/UI/Components/SexyResourceList.cpp:89
 msgctxt "SSexyResourceList,SexFilterTooltip"
 msgid "Filter by sex."
-msgstr ""
+msgstr "按性别筛选"
 
 #. Key:	SizeFilterTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyResourceList.cpp:103
 #: Source/Radiant/Public/UI/Components/SexyResourceList.cpp:103
 msgctxt "SSexyResourceList,SizeFilterTooltip"
 msgid "Filter by body size trait."
-msgstr ""
+msgstr "根据体型尺寸筛选"
 
 #. Key:	StatsFilterTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyResourceList.cpp:131
 #: Source/Radiant/Public/UI/Components/SexyResourceList.cpp:131
 msgctxt "SSexyResourceList,StatsFilterTooltip"
 msgid "Filter by stats."
-msgstr ""
+msgstr "根据三围数据筛选"
 
 #. Key:	Breeder
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyRoamerMenu.cpp:189
 #: Source/Radiant/Public/UI/Menus/SexyRoamerMenu.cpp:189
 msgctxt "SSexyRoamerMenu,Breeder"
 msgid "Breeder:"
-msgstr ""
+msgstr "饲魔者"
 
 #. Key:	CatchButton
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyRoamerMenu.cpp:98
 #: Source/Radiant/Public/UI/Menus/SexyRoamerMenu.cpp:98
 msgctxt "SSexyRoamerMenu,CatchButton"
 msgid "Catch"
-msgstr ""
+msgstr "捕获"
 
 #. Key:	CatchButtonTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyRoamerMenu.cpp:99
 #: Source/Radiant/Public/UI/Menus/SexyRoamerMenu.cpp:99
 msgctxt "SSexyRoamerMenu,CatchButtonTooltip"
 msgid "Add this wild Nephelym to your collection."
-msgstr ""
+msgstr "添加这只魔弗灵到您的农场中"
 
 #. Key:	CollapseStats
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyRoamerMenu.cpp:142
 #: Source/Radiant/Public/UI/Menus/SexyRoamerMenu.cpp:142
 msgctxt "SSexyRoamerMenu,CollapseStats"
 msgid "Hide detailed stats for this wild Nephelym."
-msgstr ""
+msgstr "隐藏野生魔弗灵的三围数据"
 
 #. Key:	ExpandStats
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyRoamerMenu.cpp:123
 #: Source/Radiant/Public/UI/Menus/SexyRoamerMenu.cpp:123
 msgctxt "SSexyRoamerMenu,ExpandStats"
 msgid "View detailed stats for this wild Nephelym."
-msgstr ""
+msgstr "查看野生魔弗灵的三围数据"
 
 #. Key:	ItemWindowTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyRoamerMenu.cpp:220
 #: Source/Radiant/Public/UI/Menus/SexyRoamerMenu.cpp:220
 msgctxt "SSexyRoamerMenu,ItemWindowTitle"
 msgid "Give Fluid"
-msgstr ""
+msgstr "给予体液"
 
 #. Key:	LeaveButton
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyRoamerMenu.cpp:60
 #: Source/Radiant/Public/UI/Menus/SexyRoamerMenu.cpp:60
 msgctxt "SSexyRoamerMenu,LeaveButton"
 msgid "Leave"
-msgstr ""
+msgstr "离开"
 
 #. Key:	LeaveButtonTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyRoamerMenu.cpp:61
 #: Source/Radiant/Public/UI/Menus/SexyRoamerMenu.cpp:61
 msgctxt "SSexyRoamerMenu,LeaveButtonTooltip"
 msgid "Leave this wild Nephelym alone."
-msgstr ""
+msgstr "别管这只野生魔弗灵了"
 
 #. Key:	Nephelym
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyRoamerMenu.cpp:172
 #: Source/Radiant/Public/UI/Menus/SexyRoamerMenu.cpp:172
 msgctxt "SSexyRoamerMenu,Nephelym"
 msgid "Nephelym:"
-msgstr ""
+msgstr "魔弗灵："
 
 #. Key:	RBJ
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyRoamerMenu.cpp:292
 #: Source/Radiant/Public/UI/Menus/SexyRoamerMenu.cpp:292
 msgctxt "SSexyRoamerMenu,RBJ"
 msgid "Spontaneous Blow Job!"
-msgstr ""
+msgstr "情不自禁地的口交"
 
 #. Key:	ResistMessage
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyRoamerMenu.cpp:299
 #: Source/Radiant/Public/UI/Menus/SexyRoamerMenu.cpp:299
 msgctxt "SSexyRoamerMenu,ResistMessage"
 msgid "Rapidly click to resist climax."
-msgstr ""
+msgstr 快速点击以抵抗高潮的来临""
 
 #. Key:	RoamerWindowTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyRoamerMenu.cpp:202
 #: Source/Radiant/Public/UI/Menus/SexyRoamerMenu.cpp:202
 msgctxt "SSexyRoamerMenu,RoamerWindowTitle"
 msgid "Actions"
-msgstr ""
+msgstr "互动"
 
 #. Key:	SurpriseSex
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyRoamerMenu.cpp:292
 #: Source/Radiant/Public/UI/Menus/SexyRoamerMenu.cpp:292
 msgctxt "SSexyRoamerMenu,SurpriseSex"
 msgid "Surprise Sex!"
-msgstr ""
+msgstr "性爱突袭"
 
 #. Key:	TaskRBJ
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyRoamerMenu.cpp:299
 #: Source/Radiant/Public/UI/Menus/SexyRoamerMenu.cpp:299
 msgctxt "SSexyRoamerMenu,TaskRBJ"
 msgid "Let her work her wonder."
-msgstr ""
+msgstr "让她努力榨出来吧"
 
 #. Key:	CheatFavor
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:764
 #: Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:764
 msgctxt "SSexySettingsMenu,CheatFavor"
 msgid "Added 1,000 favor."
-msgstr ""
+msgstr "增加了1,000女神恩赐"
 
 #. Key:	CheatFluids
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:801
 #: Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:801
 msgctxt "SSexySettingsMenu,CheatFluids"
 msgid "All fluids maxed."
-msgstr ""
+msgstr "储备体液全部满溢了"
 
 #. Key:	CheatLust
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:768
@@ -17175,7 +17177,7 @@ msgstr "每个人都有无限的情欲值"
 #: Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:760
 msgctxt "SSexySettingsMenu,CheatMoney"
 msgid "Added 1,000,000 orgasium."
-msgstr "增加1000000"
+msgstr "增加1,000,000 亮片。
 
 #. Key:	CheatPortals
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:811
@@ -17203,14 +17205,14 @@ msgstr "移除所有作弊。"
 #: Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:777
 msgctxt "SSexySettingsMenu,CheatSpirit"
 msgid "You now have infinite spirit."
-msgstr "您现在拥有无限的精神。"
+msgstr "您现在拥有无限的魂灵。"
 
 #. Key:	CheatSurprise
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:805
 #: Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:805
 msgctxt "SSexySettingsMenu,CheatSurprise"
 msgid "You will always win surprise sex."
-msgstr "您将永远赢得surprise sex.。"
+msgstr "您将自动在性爱突袭中获胜。"
 
 #. Key:	CheatTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:142
@@ -17224,7 +17226,7 @@ msgstr "金手指"
 #: Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:781
 msgctxt "SSexySettingsMenu,CheatTraitLvl"
 msgid "Trait level is maxed."
-msgstr "特长等级最大化。"
+msgstr "全部特性已添加。"
 
 #. Key:	CreatorMode
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:846
@@ -17259,21 +17261,21 @@ msgstr "确认"
 #: Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:863
 msgctxt "SSexySettingsMenu,FemG"
 msgid "Futas use SS FemG."
-msgstr ""
+msgstr "扶她套用SS FemG"
 
 #. Key:	FetishTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:125
 #: Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:125
 msgctxt "SSexySettingsMenu,FetishTitle"
 msgid "Fetish"
-msgstr ""
+msgstr "性癖"
 
 #. Key:	NFemG
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:867
 #: Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:867
 msgctxt "SSexySettingsMenu,NFemG"
 msgid "Futas use SS TG."
-msgstr ""
+msgstr "扶她套用SS TG"
 
 #. Key:	SizePairs
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexySexPositionDetails.cpp:25
@@ -17287,14 +17289,14 @@ msgstr "与场景配对"
 #: Source/Radiant/Public/UI/Components/SexyTaskGridItem.cpp:231
 msgctxt "SSexyTaskGridItem,DaysRemaining"
 msgid "Days remaining: {0}"
-msgstr ""
+msgstr "剩余天数：{0}"
 
 #. Key:	Reward
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyTaskGridItem.cpp:151
 #: Source/Radiant/Public/UI/Components/SexyTaskGridItem.cpp:151
 msgctxt "SSexyTaskGridItem,Reward"
 msgid "Reward:"
-msgstr ""
+msgstr "报酬："
 
 #. Key:	FavorTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyTradeMenu.cpp:1024
@@ -17308,7 +17310,7 @@ msgstr "确认交换"
 #: Source/Radiant/Public/UI/Menus/SexyTradeMenu.cpp:488
 msgctxt "SSexyTradeMenu,FinalFavor"
 msgid "Favor gained:"
-msgstr "女神恩惠;"
+msgstr "女神恩赐;"
 
 #. Key:	PositionDescription
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyTradeMenu.cpp:403
@@ -17336,14 +17338,14 @@ msgstr "确认出售"
 #: Source/Radiant/Public/UI/Menus/SexyTradeMenu.cpp:854
 msgctxt "SSexyTradeMenu,SellMonsterMessage"
 msgid "Ascend this one and gain favor?"
-msgstr ""
+msgstr "供奉这只魔弗灵以此换取女神恩赐吗？"
 
 #. Key:	Activate
 #. SourceLocation:	Source/Radiant/Public/Characters/SexyBreederCharacter.cpp:174
 #: Source/Radiant/Public/Characters/SexyBreederCharacter.cpp:174
 msgctxt "TaskBoard,Activate"
 msgid "Check Breeding Tasks"
-msgstr "检查配种任务"
+msgstr "查看育种任务"
 
 #. Key:	BuyFunds
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyTradeMenu.cpp:247
@@ -17392,7 +17394,7 @@ msgstr "收获"
 #: Source/Radiant/Public/UI/Menus/SexyRanchMenu.cpp:37
 msgctxt "UtilityMenu,InventoryWindowTitle"
 msgid "Ranch Inventory"
-msgstr "牧场仓库"
+msgstr "牧场库存"
 
 #. Key:	ActivateAction
 #. SourceLocation:	Source/Radiant/Public/UI/SexyInterface.cpp:343
@@ -17406,14 +17408,14 @@ msgstr "使用"
 #: Source/Radiant/Public/UI/SexyInterface.cpp:349
 msgctxt "WorldAction,ActivateDazeShrine"
 msgid "Commune with the Reaper"
-msgstr ""
+msgstr "与死神交谈"
 
 #. Key:	BreedingSetupAction
 #. SourceLocation:	Source/Radiant/Public/UI/SexyInterface.cpp:337
 #: Source/Radiant/Public/UI/SexyInterface.cpp:337
 msgctxt "WorldAction,BreedingSetupAction"
 msgid "Setup Breeding Session"
-msgstr ""
+msgstr "设置繁殖环节的细节"
 
 #. Key:	InteractAction
 #. SourceLocation:	Source/Radiant/Public/UI/SexyInterface.cpp:352
@@ -17441,5 +17443,5 @@ msgstr "交谈"
 #: Source/Radiant/Public/UI/SexyInterface.cpp:346
 msgctxt "WorldAction,TraverseAction"
 msgid "Traverse Portal"
-msgstr ""
+msgstr "穿过传送门"
 


### PR DESCRIPTION
1. Correct the language problems caused by the original Chinese translator.
2. Give some NPC conversations more personalized
3. Complete all the remaining untranslated parts
4. Unified Chinese names for all NPCs
5.Some abbreviations are still a bit of a translation problem.