### PR TITLE
Update Spanish.po PB 0.74.3

### DIFF
--- a/spanish.po
+++ b/spanish.po
@@ -1,31 +1,32 @@
-﻿# Radiant Spanish (Spain) translation.
 # Copyright Epic Games, Inc. All Rights Reserved.
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Radiant\n"
 "POT-Creation-Date: 2021-06-14 02:04\n"
-"PO-Revision-Date: 2021-06-14 02:04\n"
+"PO-Revision-Date: 2021-12-01 00:25+0100\n"
 "Language-Team: \n"
-"Language: es-ES\n"
+"Language: es_ES\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Last-Translator: \n"
+"X-Generator: Poedit 3.0\n"
 
 #. Key:	0009BEE346934010A7F79C8CF23B20D5
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03_R02.Default__FernDefault03_R02_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03_R02.Default__FernDefault03_R02_C.SessionData.Lines(1).Lines
 msgctxt ",0009BEE346934010A7F79C8CF23B20D5"
 msgid "This is my final form, and it feels so amazing. I smell beautiful too!"
-msgstr "Esta es mi forma final y se siente increíble. ¡Tambien huelo hermoso!"
+msgstr "Esta es mi forma final y se siente increíble. ¡También huelo hermoso!"
 
 #. Key:	00164C5345E544D784CC289035CEF701
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimePlay_RL.Default__MegaSlimePlay_RL_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePlay_RL.Default__MegaSlimePlay_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",00164C5345E544D784CC289035CEF701"
 msgid "About that orb..."
-msgstr ""
+msgstr "Sobre ese orbe..."
 
 #. Key:	002DAFE7433D240D0A5822A932016D65
 #. SourceLocation:	/Game/Ranch/Upgrades/BovaurShed.Default__BovaurShed_C.Upgrade.DisplayName
@@ -39,7 +40,7 @@ msgstr "Cobertizo de Bovaurs"
 #: /Game/Dialogue/Leylanna/Default/LeylannaHadSex01.Default__LeylannaHadSex01_C.SessionData.LinesToFuta(3).LinesToFuta
 msgctxt ",002F7FED4D68AF160CEAFFB092D0F2E2"
 msgid "Bring that hard cock over here... I want to feel it inside me."
-msgstr ""
+msgstr "Trae esa polla dura aquí... quiero sentirla dentro de mí."
 
 #. Key:	0061A5124B098F61DE991D81AB884112
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDefault01_Meow.Default__CassieDefault01_Meow_C.SessionData.LinesToFemale(3).LinesToFemale
@@ -53,7 +54,7 @@ msgstr "¡Este pequeño cinturón de herramientas de cuero apenas puede contener
 #: /Game/Dialogue/QueenBee/Default/BeeHaveKeystone.Default__BeeHaveKeystone_C.SessionData.Lines(1).Lines
 msgctxt ",00D1AE354BA8FEC1FB7DB5A02D3F12AA"
 msgid "Ahh... oh! Ahem."
-msgstr ""
+msgstr "¡Ahh... oh! Ejem."
 
 #. Key:	01386D9C478E6BE9974F00942E5EA1E0
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_RL.Default__MirruDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
@@ -67,14 +68,14 @@ msgstr "¿Formuria?"
 #: /Game/Dialogue/AmberMae/Default/AmberMaeDefault01_SuckJugs.Default__AmberMaeDefault01_SuckJugs_C.SessionData.Lines(3).Lines
 msgctxt ",014BFFCA4F173DACEC2A00A8398888F4"
 msgid "Aye, yer not leaving 'til you suck every last drop!"
-msgstr "¡Seh, no te iráh hahta que shupe hahta la úrtima gota!"
+msgstr "¡Seh, no te iráh hahta que shupeh hahta la úrtima gota!"
 
 #. Key:	0169F2A34BA4C1104CDDEE99B3A3B50E
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchStartShySex.Default__MonarchStartShySex_C.SessionData.LinesToMale(3).LinesToMale
 #: /Game/Dialogue/Monarch/Default/MonarchStartShySex.Default__MonarchStartShySex_C.SessionData.LinesToMale(3).LinesToMale
 msgctxt ",0169F2A34BA4C1104CDDEE99B3A3B50E"
 msgid "So I can, y-y-you know... feel your cock deep inside me."
-msgstr ""
+msgstr "Entonces puedo, y-y-ya sabes... sentir tu polla profundamente dentro de mí."
 
 #. Key:	017B23B341D5CE5BB9CC0293262CBD91
 #. SourceLocation:	/Game/Ranch/Upgrades/HarpyAviary.Default__HarpyAviary_C.Upgrade.Description
@@ -88,7 +89,7 @@ msgstr "Esto te permite capturar y almacenar todas las variantes de Arpías."
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFuta(4).LinesToFuta
 msgctxt ",017CCB4443E3658AEA961E9EDC5B53BF"
 msgid "And I'm one of them! A blessed female Painted Elf to be exact!"
-msgstr "¡Y yo soy una de ellos! ¡Una bendecida elfa pintada para ser exactas!"
+msgstr "¡Y yo soy una de ellos! ¡Una elfa pintada bendecida para ser exactas!"
 
 #. Key:	0180484249AE71470005A78484607A18
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_AboutMusic.Default__RomyDefault01_AboutMusic_C.SessionData.Lines(1).Lines
@@ -99,7 +100,8 @@ msgstr "Ah, supongo que eres como la mayoría de los @MONSTER_RACE@ entonces."
 
 #. Key:	01DB8D8A43F7EC40F07FB3A355D39722
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TravelShrines(2 - Value).TravelShrines.ShrineName
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TravelShrines(2 - Value).TravelShrines.ShrineName
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TravelShrines(2 -
+#: Value).TravelShrines.ShrineName
 msgctxt ",01DB8D8A43F7EC40F07FB3A355D39722"
 msgid "Cove of Rapture"
 msgstr "Ensenada del Éxtasis"
@@ -109,49 +111,49 @@ msgstr "Ensenada del Éxtasis"
 #: /Game/Dialogue/Neela/Default/NeelaGreeting01.Default__NeelaGreeting01_C.SessionData.Lines(0).Lines
 msgctxt ",01DE9F6A42AB1019681AE1B74E68632C"
 msgid "Well now, this is a rare sight."
-msgstr "Bueno, ahora esta es una rara vista."
+msgstr "Bueno, esta es una vista rara."
 
 #. Key:	0207AC704D78649132718BBF7F0F0CA1
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03_RL_F.Default__FernDefault03_RL_F_C.ResponseData(5).ResponseData.BreederPrompt
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03_RL_F.Default__FernDefault03_RL_F_C.ResponseData(5).ResponseData.BreederPrompt
 msgctxt ",0207AC704D78649132718BBF7F0F0CA1"
 msgid "The Queen Bee demands flowers."
-msgstr ""
+msgstr "La Abeja Reina exige flores."
 
 #. Key:	022313C047D185193F98C48BE5852E62
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruHadSex01.Default__MirruHadSex01_C.SessionData.LinesToMale(4).LinesToMale
 #: /Game/Dialogue/Mirru/Default/MirruHadSex01.Default__MirruHadSex01_C.SessionData.LinesToMale(4).LinesToMale
 msgctxt ",022313C047D185193F98C48BE5852E62"
 msgid "It's not often one so small has the courage to dick a kraken. I hope my fleshy body pleased you."
-msgstr ""
+msgstr "No es frecuente que alguien tan pequeño tenga el coraje de follar a un kraken. Espero que mi cuerpo carnoso te haya complacido."
 
 #. Key:	026D19BC4A6B81E2694FF6B5E6EC3D9C
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMDefault_RL5_F.Default__DMDefault_RL5_F_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/DragonMatriarch/Default/DMDefault_RL5_F.Default__DMDefault_RL5_F_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",026D19BC4A6B81E2694FF6B5E6EC3D9C"
 msgid "Eeek... big genitals!"
-msgstr ""
+msgstr "¡Eeek... genitales grandes!"
 
 #. Key:	028C9ACB45CFD05DB106DBA06B056886
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.StarfallenMonolith.ManageActionMessage
 #: /Game/World/Overworld.Overworld:PersistentLevel.StarfallenMonolith.ManageActionMessage
 msgctxt ",028C9ACB45CFD05DB106DBA06B056886"
 msgid "Manage your Starfallen"
-msgstr "Gestiona tus Caídos de las Estrellas"
+msgstr "Gestiona tus Starfallens"
 
 #. Key:	02A5F6F34ADE67C0A32ECE8E542DCC88
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(26).LinesToMale
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(26).LinesToMale
 msgctxt ",02A5F6F34ADE67C0A32ECE8E542DCC88"
 msgid "Gently of course, to date there has never been an instance where a @MONSTER_RACE@ has intentionally harmed a human."
-msgstr "Gentilmente por supuesto, hasta la fecha nunca ha habido un caso en el que una @MONSTER_RACE@ haya dañado intencionalmente a un humano."
+msgstr "Gentilmente por supuesto. Hasta la fecha, nunca ha habido un caso en el que un @MONSTER_RACE@ haya lastimado intencionalmente a un humano."
 
 #. Key:	02FA062A4ABF915F50D8B38C08105557
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_AboutLamias.Default__NeelaDefault01_AboutLamias_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_AboutLamias.Default__NeelaDefault01_AboutLamias_C.SessionData.Lines(2).Lines
 msgctxt ",02FA062A4ABF915F50D8B38C08105557"
 msgid "From what I remember, I was of Liasis descent. A race said to roam Lewd Desert long ago."
-msgstr ""
+msgstr "Por lo que recuerdo, era descendiente de Liasis. Una raza que se dice que vagaba por el Desierto Lascivo hace mucho tiempo."
 
 #. Key:	02FDE6D44BCEE7E9CD0113AACDF9C4E2
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_RechargeSpiritForm_RL_T.Default__LeylannaDefault01_RechargeSpiritForm_RL_T_C.ResponseData(1).ResponseData.BreederPrompt
@@ -165,7 +167,7 @@ msgstr "Esto se está volviendo raro..."
 #: /Game/Dialogue/Fesssi/Default/FesssiCave.Default__FesssiCave_C.SessionData.Lines(1).Lines
 msgctxt ",03434DDC47EC9AE95DD6FF899A0ECE62"
 msgid "Deep in the dark caverns of the world live the more \"unsavory\" @MONSTER_RACE@."
-msgstr ""
+msgstr "En lo profundo de las oscuras cavernas del mundo viven los más \"desagradables\" @MONSTER_RACE@."
 
 #. Key:	034A5C0F4CB9984BC7F902A4AE65BB8A
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R05.Default__CamillaDefault01_R05_C.SessionData.Lines(0).Lines
@@ -186,7 +188,7 @@ msgstr "Fluidos corporales de Titán."
 #: /Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToMale(4).LinesToMale
 msgctxt ",035F52234F8DA96ED37A5AAC5DD88039"
 msgid "Ahh, plant your delicious seed in my little body! Give me... ohhh... all of it!"
-msgstr "¡Ahh, planta tu deliciosa semilla en mi cuerpecito! ¡Dámelo... ohhh... todo!"
+msgstr "¡Ahh, planta tu deliciosa semilla en mi cuerpecito! ¡Dámelo... ohhh… todo!"
 
 #. Key:	03BD054E4D9907C2DF497EA4DCC0D8C3
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(6).LinesToFemale
@@ -200,154 +202,154 @@ msgstr "Mi nombre es Falene, la especialista de @MONSTER_RACE@ líder en todo @W
 #: /Game/Dialogue/Fern/Default/FernDefault01_RL_T.Default__FernDefault01_RL_T_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",03C3FCAE4B8424BCF5F580BC933E08E8"
 msgid "Why did you call me master?"
-msgstr "¿Por qué me llamaste maestro/a?"
+msgstr "¿Por qué me llamaste, Master?"
 
 #. Key:	03FDE484412EB5432BA89A9FF52176AD
 #. SourceLocation:	/Game/Dialogue/Cassie/SexScenes/CassieSplintersT.Default__CassieSplintersT_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Cassie/SexScenes/CassieSplintersT.Default__CassieSplintersT_C.SessionData.Lines(3).Lines
 msgctxt ",03FDE484412EB5432BA89A9FF52176AD"
 msgid "Meow! It feels so good! I'm going to get kitty cum all over myself!"
-msgstr "¡Miau! ¡Se siente tan bien! ¡Voy a tener semen de gatito por todas partes!"
+msgstr "¡Miau! ¡Se siente tan bien! ¡Voy a hacer que el gatito se corra por todas partes!"
 
 #. Key:	0417FF204F76BA02C95525915D7673A9
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowKeystone.Default__WidowKeystone_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Widow/Default/WidowKeystone.Default__WidowKeystone_C.SessionData.Lines(1).Lines
 msgctxt ",0417FF204F76BA02C95525915D7673A9"
 msgid "A clumsy lamia with an oversized behind came down here a few years ago and left it there."
-msgstr ""
+msgstr "Una torpe lamia con un sobredimensionado trasero vino aquí hace unos años y la dejó allí."
 
 #. Key:	04205AC945DE4E603D9147AFE4BB7547
 #. SourceLocation:	/Game/Dialogue/Neela/SexScenes/NeelaSnakeCuddleT.Default__NeelaSnakeCuddleT_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Neela/SexScenes/NeelaSnakeCuddleT.Default__NeelaSnakeCuddleT_C.SessionData.Lines(0).Lines
 msgctxt ",04205AC945DE4E603D9147AFE4BB7547"
 msgid "Ohh yes! Ahhh... penetrate my ancient vagina..."
-msgstr "¡Ohh sí! Ahhh... Penetra mi vagina ancestral..."
+msgstr "¡Ohh sí! Ahhh... penetra mi vagina ancestral..."
 
 #. Key:	0468AC1040BB9A10D1960B833F9A8305
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruHadSex01.Default__MirruHadSex01_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/Mirru/Default/MirruHadSex01.Default__MirruHadSex01_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",0468AC1040BB9A10D1960B833F9A8305"
 msgid "For that I am thankful."
-msgstr ""
+msgstr "Por eso estoy agradecida."
 
 #. Key:	04744CA84CBAE9AB13EA1989A23A0DDC
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01.Default__FaleneDefault01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01.Default__FaleneDefault01_C.SessionData.Lines(0).Lines
 msgctxt ",04744CA84CBAE9AB13EA1989A23A0DDC"
 msgid "I will leave your ranch soon! But don't worry, you can find me in Hedon."
-msgstr "¡Me ire de tu rancho pronto! Pero no te preocupes, puedes encontrarme en Hedon."
+msgstr "¡Dejaré tu rancho pronto! Pero no te preocupes, puedes encontrarme en Hedon."
 
 #. Key:	047A2B2C4D533C816757C8B486F04CC0
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeHaveKeystone.Default__BeeHaveKeystone_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/QueenBee/Default/BeeHaveKeystone.Default__BeeHaveKeystone_C.SessionData.Lines(0).Lines
 msgctxt ",047A2B2C4D533C816757C8B486F04CC0"
 msgid "Of course not. It's been a symbol of my hive for ages."
-msgstr ""
+msgstr "Por supuesto no. Ha sido un símbolo de mi colmena durante años."
 
 #. Key:	04809803498EAC7920E3F09D8A29F0BF
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernGreeting01.Default__FernGreeting01_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Fern/Default/FernGreeting01.Default__FernGreeting01_C.SessionData.Lines(4).Lines
 msgctxt ",04809803498EAC7920E3F09D8A29F0BF"
 msgid "Timeeee for the fluidsssss?"
-msgstr "¿Es tieeeempo de los fluidossss?"
+msgstr "¿Hoooora de los fluidosssss?"
 
 #. Key:	04B934DA4280B01E3757EB87CAD514BE
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiDefault01.Default__FesssiDefault01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiDefault01.Default__FesssiDefault01_C.SessionData.Lines(0).Lines
 msgctxt ",04B934DA4280B01E3757EB87CAD514BE"
 msgid "Sure, letting the dryad play with my ass in exchange for fruit was fun for awhile. Her decadent cherries are delicious."
-msgstr ""
+msgstr "Claro, dejar que la dríada jugara con mi culo a cambio de fruta fue divertido por un tiempo. Sus cerezas decadentes son deliciosas."
 
 #. Key:	0500B4944007820F3A7BB096A4E699AB
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieGreeting01.Default__CassieGreeting01_C.SessionData.Lines(6).Lines
 #: /Game/Dialogue/Cassie/Default/CassieGreeting01.Default__CassieGreeting01_C.SessionData.Lines(6).Lines
 msgctxt ",0500B4944007820F3A7BB096A4E699AB"
 msgid "Lemme know if y'all want new buildings for your wild @MONSTER_RACE@..."
-msgstr "Avísame si quieres nuevos edificios para tus @MONSTER_RACE@ salvajes..."
+msgstr "Avísame si quieres nuevos edificios para tus @MONSTER_RACE@ silvestres..."
 
 #. Key:	051883BC403A71EC7220ACAE27A63552
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDungeon.Default__CassieDungeon_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Cassie/Default/CassieDungeon.Default__CassieDungeon_C.SessionData.Lines(4).Lines
 msgctxt ",051883BC403A71EC7220ACAE27A63552"
 msgid "That old rusty set of gears above the town entrance probably controls a pulley system."
-msgstr ""
+msgstr "Ese viejo y oxidado juego de engranajes sobre la entrada de la ciudad probablemente controla un sistema de poleas."
 
 #. Key:	0522652344116C917836F4A1A78C8815
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R07.Default__CamillaDefault01_R07_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R07.Default__CamillaDefault01_R07_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",0522652344116C917836F4A1A78C8815"
 msgid "Don't waste your beautiful tall body on me human. Just wait for Falene to come back, or go suck on Amber's tits."
-msgstr "No desperdicies tu hermoso cuerpo en mí, humana. Solo espera a que Falene vuelva, o ve a chupar las tetas de Amber."
+msgstr "No desperdicies tu hermoso y alto cuerpo en mi humana. Solo espera a que vuelva Falene o ve a chupar las tetas de Amber."
 
 #. Key:	052657834F6DBDBBC49BDAADA6E5E88A
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_RL.Default__NeelaDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_RL.Default__NeelaDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
 msgctxt ",052657834F6DBDBBC49BDAADA6E5E88A"
 msgid "Tell me about Lamias."
-msgstr "Háblame acerca de las Lamias."
+msgstr "Háblame de las lamias."
 
 #. Key:	0529D0BB4C3047950C7EE496E1F0E5BC
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeTaskFulfilled.Default__BeeTaskFulfilled_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/QueenBee/Default/BeeTaskFulfilled.Default__BeeTaskFulfilled_C.SessionData.Lines(0).Lines
 msgctxt ",0529D0BB4C3047950C7EE496E1F0E5BC"
 msgid "Rejoice, for the flowers have returned!"
-msgstr ""
+msgstr "¡Alégrate, porque las flores han vuelto!"
 
 #. Key:	0559493D46F48B86A2683FB3AC087112
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_FutaBalls.Default__CamillaDefault01_FutaBalls_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_FutaBalls.Default__CamillaDefault01_FutaBalls_C.SessionData.Lines(0).Lines
 msgctxt ",0559493D46F48B86A2683FB3AC087112"
 msgid "Sugar walls before balls!"
-msgstr "¡Vaginas antes que bolas!"
+msgstr "¡Azúcar en gotas antes que pelotas!"
 
 #. Key:	056C9C1748701D33A4113FB426A3981C
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraGetKeystone.Default__PetraGetKeystone_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Petra/Default/PetraGetKeystone.Default__PetraGetKeystone_C.SessionData.Lines(1).Lines
 msgctxt ",056C9C1748701D33A4113FB426A3981C"
 msgid "However..."
-msgstr ""
+msgstr "Sin embargo..."
 
 #. Key:	06271AC24974DE1182364AAD430A9574
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaHadSex02.Default__CamillaHadSex02_C.SessionData.LinesToMale(3).LinesToMale
 #: /Game/Dialogue/Camilla/Default/CamillaHadSex02.Default__CamillaHadSex02_C.SessionData.LinesToMale(3).LinesToMale
 msgctxt ",06271AC24974DE1182364AAD430A9574"
 msgid "If you... uh... ever get desperate again, you know where to find me!"
-msgstr ""
+msgstr "Si... eh... alguna vez te desesperas de nuevo, ¡ya sabes dónde encontrarme!"
 
 #. Key:	0629816F428092E0C5B0169DD3E8F968
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R02.Default__FaleneDefault01_R02_C.SessionData.Lines(8).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R02.Default__FaleneDefault01_R02_C.SessionData.Lines(8).Lines
 msgctxt ",0629816F428092E0C5B0169DD3E8F968"
 msgid "Blessed ones can be found everywhere in @WORLD_NAME@, and for reasons I'm trying to solve, the vast majority are female."
-msgstr "Los celestiales se pueden encontrar en todas partes en @WORLD_NAME@, y por razones que estoy tratando de entender, la gran mayoría son mujeres."
+msgstr "Los benditos se pueden encontrar en todas partes en @WORLD_NAME@, y por razones que estoy tratando de resolver, la gran mayoría son mujeres."
 
 #. Key:	063FE1B64CA363E1B1CB09BFE7E6043C
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDefault01.Default__CassieDefault01_C.SessionData.Lines(6).Lines
 #: /Game/Dialogue/Cassie/Default/CassieDefault01.Default__CassieDefault01_C.SessionData.Lines(6).Lines
 msgctxt ",063FE1B64CA363E1B1CB09BFE7E6043C"
 msgid "Heh... sometimes I just can't stop."
-msgstr "Jeje... A veces no puedo parar."
+msgstr "Jeh... a veces simplemente no puedo parar."
 
 #. Key:	0685B494422BDD14CE725297CA6A02B0
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToMale(1).LinesToMale
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToMale(1).LinesToMale
 msgctxt ",0685B494422BDD14CE725297CA6A02B0"
 msgid "See, there is nowhere in @WORLD_NAME@ that I haven't slithered."
-msgstr "Mira, no hay ningún lugar en @WORLD_NAME@ que no haya visitado."
+msgstr "Mira, no hay ningún lugar en @WORLD_NAME@ por el que no me haya deslizado."
 
 #. Key:	06A529F441EB1545EE626A8ECC49CBCC
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeDefault02_RL.Default__BeeDefault02_RL_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/QueenBee/Default/BeeDefault02_RL.Default__BeeDefault02_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",06A529F441EB1545EE626A8ECC49CBCC"
 msgid "Do you masturbate all day?"
-msgstr ""
+msgstr "¿Te masturbas todo el día?"
 
 #. Key:	06DCC78B4F1DECA217645DA58B3BB2A4
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01_R02_R01.Default__FernDefault01_R02_R01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Fern/Default/FernDefault01_R02_R01.Default__FernDefault01_R02_R01_C.SessionData.Lines(0).Lines
 msgctxt ",06DCC78B4F1DECA217645DA58B3BB2A4"
 msgid "Fern help mastah! Fern harvest fluidssss for you!"
-msgstr "¡Helecho ayuda a maeztra! ¡Helecho colecta fluidossss para usted!"
+msgstr "¡Fern ayuda a Mastah! ¡Fern recolecta fluidossss para ti!"
 
 #. Key:	06F45D04453307E37897C89FC16861F0
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(8).Lines
@@ -361,49 +363,49 @@ msgstr "Bueno ¡ehtoy segura de que eh mejoh que te vayah!"
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(3).LinesToMale
 msgctxt ",070169104C3375DAB052E18982B50AE4"
 msgid "This world is home to the @MONSTER_RACE@, an enigmatic race of human-monster hybrids."
-msgstr "Este mundo es el hogar de @MONSTER_RACE@, una raza enigmática de híbridos humano-monstruo."
+msgstr "Este mundo es el hogar de los @MONSTER_RACE@, una raza enigmática de híbridos humano-monstruo."
 
 #. Key:	07035EA54B778F47897F278270889BBF
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadBossomCherries.Default__DryadBossomCherries_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Autumn/Default/DryadBossomCherries.Default__DryadBossomCherries_C.SessionData.Lines(3).Lines
 msgctxt ",07035EA54B778F47897F278270889BBF"
 msgid "Aww... it's so adorable watching them figure out how to reach the fruit on the high branches."
-msgstr ""
+msgstr "Amm... es tan adorable verlos descubrir cómo alcanzar la fruta en las ramas altas."
 
 #. Key:	075A16DA4BA7F51C3A07099921F7F1B3
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyHadSex01.Default__RomyHadSex01_C.SessionData.LinesGrungy(1).LinesGrungy
 #: /Game/Dialogue/Romy/Default/RomyHadSex01.Default__RomyHadSex01_C.SessionData.LinesGrungy(1).LinesGrungy
 msgctxt ",075A16DA4BA7F51C3A07099921F7F1B3"
 msgid "You need a bath. Come now, place your body between my breasts and let's get you clean."
-msgstr ""
+msgstr "Necesitas un baño. Ven ahora, coloca tu cuerpo entre mis pechos y vamos a limpiarte."
 
 #. Key:	07B2E95342A617616201F19B87E3655A
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimePlay1.Default__MegaSlimePlay1_C.SessionData.LinesToFuta(3).LinesToFuta
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePlay1.Default__MegaSlimePlay1_C.SessionData.LinesToFuta(3).LinesToFuta
 msgctxt ",07B2E95342A617616201F19B87E3655A"
 msgid "You will feel so good as I milk your cock for all of its delicious semen..."
-msgstr ""
+msgstr "Te sentirás tan bien mientras ordeño tu polla por todo su delicioso semen..."
 
 #. Key:	07E0077146239E020D026BADBDFCE890
 #. SourceLocation:	/Game/Breeding/Positions/Harvest.Default__Harvest_C.SessionData.PositionName
 #: /Game/Breeding/Positions/Harvest.Default__Harvest_C.SessionData.PositionName
 msgctxt ",07E0077146239E020D026BADBDFCE890"
 msgid "Harvest"
-msgstr ""
+msgstr "Cosecha"
 
 #. Key:	07F233504BDA1232640FB1846CBFE868
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01.Default__FernDefault01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Fern/Default/FernDefault01.Default__FernDefault01_C.SessionData.Lines(0).Lines
 msgctxt ",07F233504BDA1232640FB1846CBFE868"
 msgid "Mastah! Fern love you."
-msgstr "¡Maeztra! Helecho te ama."
+msgstr "¡Mastah! Fern te ama."
 
 #. Key:	07F5EE754EC13715610F3E8746D2A3D2
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_AboutLamias.Default__NeelaDefault01_AboutLamias_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_AboutLamias.Default__NeelaDefault01_AboutLamias_C.SessionData.Lines(0).Lines
 msgctxt ",07F5EE754EC13715610F3E8746D2A3D2"
 msgid "Honestly, I don't know much about my kind."
-msgstr "Honestamente, no sé mucho sobre mi especie."
+msgstr "Honestamente, no sé mucho sobre los de mi clase."
 
 #. Key:	08236DA548D9257F9FE293A6ACBC8A84
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_RL_T.Default__FernDefault02_RL_T_C.ResponseData(3).ResponseData.BreederPrompt
@@ -417,49 +419,49 @@ msgstr "¡Puedes tener mi semen!"
 #: /Game/Dialogue/OrcChief/Default/OrcDefault03_RL.Default__OrcDefault03_RL_C.ResponseData(4).ResponseData.BreederPrompt
 msgctxt ",085EF70E45D784AFAEFB07BC461A23D9"
 msgid "Are all orcs as brash and dumb as you?"
-msgstr ""
+msgstr "¿Son todos los orcos tan impetuosos y tontos como tú?"
 
 #. Key:	08A1991945921B46D9EF9A94894EF846
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeDefault01.Default__BeeDefault01_C.SessionData.LinesToMale(0).LinesToMale
 #: /Game/Dialogue/QueenBee/Default/BeeDefault01.Default__BeeDefault01_C.SessionData.LinesToMale(0).LinesToMale
 msgctxt ",08A1991945921B46D9EF9A94894EF846"
 msgid "This corner is n-n-nice and safe!"
-msgstr ""
+msgstr "¡Este rincón es a-a-agradable y seguro!"
 
 #. Key:	08A2508F4D57261E790AB8BEA258D6B2
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryHadSex01.Default__EmissaryHadSex01_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/Emissary/Default/EmissaryHadSex01.Default__EmissaryHadSex01_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",08A2508F4D57261E790AB8BEA258D6B2"
 msgid "Understand, thou has licked a vagina as old as time itself."
-msgstr ""
+msgstr "Entiendelo, has lamido una vagina tan antigua como el tiempo mismo."
 
 #. Key:	08DE001E4420BE30688798BF6B70729D
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryCockblockGates.Default__EmissaryCockblockGates_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryCockblockGates.Default__EmissaryCockblockGates_C.SessionData.Lines(4).Lines
 msgctxt ",08DE001E4420BE30688798BF6B70729D"
 msgid "You will need to satisfy their desires before they will give them up."
-msgstr ""
+msgstr "Necesitarás satisfacer sus deseos antes de que los abandonen."
 
 #. Key:	0925499D4273278AA298A99B40C4550F
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMYourChildren.Default__DMYourChildren_C.SessionData.LinesToFuta(2).LinesToFuta
 #: /Game/Dialogue/DragonMatriarch/Default/DMYourChildren.Default__DMYourChildren_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",0925499D4273278AA298A99B40C4550F"
 msgid "Believe me human, I have birthed many offspring."
-msgstr ""
+msgstr "Créeme, humano, he dado a luz a muchos descendientes."
 
 #. Key:	093760FD4181D0AA284C4D96884A3801
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon2.Default__AmberMaeLockedDungeon2_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon2.Default__AmberMaeLockedDungeon2_C.SessionData.Lines(1).Lines
 msgctxt ",093760FD4181D0AA284C4D96884A3801"
 msgid "Took me love for milk too far, 'an the 'ol bovaur genes kicked in."
-msgstr ""
+msgstr "Me llevó el amor por la leshe demasiado lejoh, y loh geneh de loh viejoh bovaur entraron en arsión."
 
 #. Key:	094AB3854E6DACE10C94B28ADCB83FE0
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaFaleneWeek.Default__CamillaFaleneWeek_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaFaleneWeek.Default__CamillaFaleneWeek_C.SessionData.Lines(2).Lines
 msgctxt ",094AB3854E6DACE10C94B28ADCB83FE0"
 msgid "The best thing she finds, she brings back here to examine."
-msgstr ""
+msgstr "Lo mejor que encuentra, lo trae aquí para examinarlo."
 
 #. Key:	0968DD0D4744523D6AFCEABE502C530F
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R07.Default__FaleneDefault01_R07_C.SessionData.LinesToFemale(1).LinesToFemale
@@ -473,84 +475,84 @@ msgstr "¡Estoy tan caliente que no puedo soportarlo más! ¡Sepáralas humana p
 #: /Game/Dialogue/Mirru/Default/MirruHadSex01.Default__MirruHadSex01_C.SessionData.LinesToFemale(4).LinesToFemale
 msgctxt ",099488164DB48F48395E94B86F3EE565"
 msgid "My lust is quickly regenerating, and I would gladly mate with you again."
-msgstr ""
+msgstr "Mi lujuria se está regenerando rápidamente y con mucho gusto volvería a aparearme contigo."
 
 #. Key:	09C95B9C48668D0B269B88826710F912
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryHadSex01.Default__EmissaryHadSex01_C.SessionData.LinesToFuta(2).LinesToFuta
 #: /Game/Dialogue/Emissary/Default/EmissaryHadSex01.Default__EmissaryHadSex01_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",09C95B9C48668D0B269B88826710F912"
 msgid "Is that a comforting feeling?"
-msgstr ""
+msgstr "¿Es un sentimiento reconfortante?"
 
 #. Key:	0A1E776A4877D11A8A4716A6FEE789C1
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(7).LinesToMale
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(7).LinesToMale
 msgctxt ",0A1E776A4877D11A8A4716A6FEE789C1"
 msgid "@MONSTER_RACE@ origins are ancient and unknown, but we desire one thing above all else..."
-msgstr "Los orígenes de @MONSTER_RACE@ son antiguos y desconocidos, pero deseamos una cosa por encima de todo..."
+msgstr "Los orígenes de los @MONSTER_RACE@ son antiguos y desconocidos, pero deseamos una cosa por encima de todo..."
 
 #. Key:	0A6AA641405E829B424AFE8894AB0083
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraAboutPawsmaati.Default__PetraAboutPawsmaati_C.SessionData.Lines(6).Lines
 #: /Game/Dialogue/Petra/Default/PetraAboutPawsmaati.Default__PetraAboutPawsmaati_C.SessionData.Lines(6).Lines
 msgctxt ",0A6AA641405E829B424AFE8894AB0083"
 msgid "When Pawsmaati finally unleashed her river of cum, I entered a dreamlike state in which I felt my mind unite with her's."
-msgstr ""
+msgstr "Cuando Pawsmaati finalmente desató su río de semen, entré en un estado de ensueño en el que sentí que mi mente se unía a la de ella."
 
 #. Key:	0A6CE0B4469F4068DE66F4AB8EC4EDA9
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimePlay1.Default__MegaSlimePlay1_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePlay1.Default__MegaSlimePlay1_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",0A6CE0B4469F4068DE66F4AB8EC4EDA9"
 msgid "I think... you might be my best friend of all time."
-msgstr ""
+msgstr "Creo que... podrías ser mi mejor amiga de todos los tiempos."
 
 #. Key:	0AA608164C47369E28D0C6BFDB27289A
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_AboutKrakens.Default__MirruDefault01_AboutKrakens_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_AboutKrakens.Default__MirruDefault01_AboutKrakens_C.SessionData.Lines(0).Lines
 msgctxt ",0AA608164C47369E28D0C6BFDB27289A"
 msgid "The most noble, mighty, and feared race beneath the waves we are!"
-msgstr "¡Somos la raza más noble, poderosa y temida!"
+msgstr "¡Somos la raza más noble, poderosa y temida bajo las olas!"
 
 #. Key:	0B1F283F4C4E0D0752DF53AB312D45F9
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMClimaxPeak.Default__DMClimaxPeak_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMClimaxPeak.Default__DMClimaxPeak_C.SessionData.Lines(3).Lines
 msgctxt ",0B1F283F4C4E0D0752DF53AB312D45F9"
 msgid "I've heard about fertile Bovaur roaming in the south which produce vast quantities of breast milk."
-msgstr ""
+msgstr "He oído hablar de los fértiles bovaur que deambulan por el sur y producen grandes cantidades de leche materna."
 
 #. Key:	0B2CFD3342EAE68FB552BF9F7876374B
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaHadSex01.Default__NeelaHadSex01_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Neela/Default/NeelaHadSex01.Default__NeelaHadSex01_C.SessionData.Lines(2).Lines
 msgctxt ",0B2CFD3342EAE68FB552BF9F7876374B"
 msgid "Ahhh... I feel so good!"
-msgstr ""
+msgstr "Ahhh... ¡me siento tan bien!"
 
 #. Key:	0B4EC1164A6993BFA78D2589D15A3FEB
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowDefault01.Default__WidowDefault01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Widow/Default/WidowDefault01.Default__WidowDefault01_C.SessionData.Lines(0).Lines
 msgctxt ",0B4EC1164A6993BFA78D2589D15A3FEB"
 msgid "What is this stuck in my web... a tasty morsel coursing with warm juice."
-msgstr ""
+msgstr "¿Qué es esto atrapado en mi telaraña? Un sabroso bocado con zumo tibio."
 
 #. Key:	0B66D1724E54B8860E24D3A0B83981AB
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcDefault03_RL.Default__OrcDefault03_RL_C.ResponseData(3).ResponseData.BreederPrompt
 #: /Game/Dialogue/OrcChief/Default/OrcDefault03_RL.Default__OrcDefault03_RL_C.ResponseData(3).ResponseData.BreederPrompt
 msgctxt ",0B66D1724E54B8860E24D3A0B83981AB"
 msgid "Your orc tribe sucks."
-msgstr ""
+msgstr "Tu tribu orca apesta."
 
 #. Key:	0B796FF84644C0154CA874BFDFA16D50
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyHadSex01.Default__RomyHadSex01_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Romy/Default/RomyHadSex01.Default__RomyHadSex01_C.SessionData.Lines(2).Lines
 msgctxt ",0B796FF84644C0154CA874BFDFA16D50"
 msgid "Let us spend the day together, for here in the warmth of this water we can sing again for hours."
-msgstr ""
+msgstr "Pasemos el día juntos, porque aquí, en el calor de esta agua, podemos cantar de nuevo durante horas."
 
 #. Key:	0BB0A695454FD69DAA129F82F023EB23
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",0BB0A695454FD69DAA129F82F023EB23"
 msgid "A human! A super cute human, this is my lucky day. I've been waiting for this phenomenon for... huh. Well as long as I can remember!"
-msgstr "¡Una humana! Una humana super linda, este es mi día de suerte. He estado esperando este fenómeno desde... Eh, bueno, ¡desde que puedo recordarlo!"
+msgstr "¡Una humana! Una humana super linda... este es mi día de suerte. He estado esperando este fenómeno desde... eh, bueno, ¡desde que puedo recordarlo!"
 
 #. Key:	0BBD00B64AD7488CC6A8008C2BAF8B41
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.VulwargKennel.ManageActionMessage
@@ -564,77 +566,77 @@ msgstr "Gestiona tus Vulwargs"
 #: /Game/Dialogue/Widow/Default/WidowKeystone.Default__WidowKeystone_C.SessionData.Lines(4).Lines
 msgctxt ",0BC94BF94437671AAC651EBA39693570"
 msgid "Long I have wished to taste an elf, but they never come up this way."
-msgstr ""
+msgstr "Hace mucho que deseaba probar una elfa, pero nunca vienen de esta manera."
 
 #. Key:	0BD52B434C91C8F5172BC0BB8C1B00BA
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_Leylanna.Default__EmissaryDefault01_Leylanna_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_Leylanna.Default__EmissaryDefault01_Leylanna_C.SessionData.Lines(0).Lines
 msgctxt ",0BD52B434C91C8F5172BC0BB8C1B00BA"
 msgid "Behold, she is a loving servant of the Goddess, praise be Her name."
-msgstr "He aquí, ella es una sirviente amorosa de la Diosa, alabado sea Su nombre."
+msgstr "He aquí, ella es una amorosa sierva de la Diosa, alabado sea Su nombre."
 
 #. Key:	0C1F84244DE410EF33BD2B924829370C
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.ThriaeHive.ManageActionMessage
 #: /Game/World/Overworld.Overworld:PersistentLevel.ThriaeHive.ManageActionMessage
 msgctxt ",0C1F84244DE410EF33BD2B924829370C"
 msgid "Manage your Thriae"
-msgstr "Gestiona tus Thriae"
+msgstr "Gestiona tus Thriaes"
 
 #. Key:	0C6185B247E0B89045AEA68A0EF63C17
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraPracticeMe.Default__PetraPracticeMe_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Petra/Default/PetraPracticeMe.Default__PetraPracticeMe_C.SessionData.Lines(3).Lines
 msgctxt ",0C6185B247E0B89045AEA68A0EF63C17"
 msgid "Get over here and teach this naughty bunny a lesson!"
-msgstr ""
+msgstr "¡Ven aquí y dale una lección a esta conejita traviesa!"
 
 #. Key:	0C7FA2DC4E91993DEDDA2CA03E98C251
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiTaskFulfilled.Default__FesssiTaskFulfilled_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiTaskFulfilled.Default__FesssiTaskFulfilled_C.SessionData.Lines(1).Lines
 msgctxt ",0C7FA2DC4E91993DEDDA2CA03E98C251"
 msgid "Hiss!"
-msgstr ""
+msgstr "¡Sss!"
 
 #. Key:	0CA6EE7548B8D90D10FC67A138E7F076
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R06.Default__FaleneDefault01_R06_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R06.Default__FaleneDefault01_R06_C.SessionData.Lines(4).Lines
 msgctxt ",0CA6EE7548B8D90D10FC67A138E7F076"
 msgid "The ones the Goddess personally mated with are said to have experienced so much pleasure, they died in Her loving embrace."
-msgstr "Se dice que aquellos con los que la Diosa se a apareado experimentaron tanto placer que murieron en sus amorosos brazos."
+msgstr "Se dice que aquellos con los que la Diosa se apareaba personalmente experimentaron tanto placer que murieron en Su amoroso abrazo."
 
 #. Key:	0CBE9A9A40E9ADB708F7C28FA2F1B657
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchShySexF_RL.Default__MonarchShySexF_RL_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/Monarch/Default/MonarchShySexF_RL.Default__MonarchShySexF_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",0CBE9A9A40E9ADB708F7C28FA2F1B657"
 msgid "My body is ready"
-msgstr ""
+msgstr "Mi cuerpo está listo"
 
 #. Key:	0CD45BB44BFDB28371B663B5B53FD368
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDefault01.Default__CassieDefault01_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Cassie/Default/CassieDefault01.Default__CassieDefault01_C.SessionData.Lines(5).Lines
 msgctxt ",0CD45BB44BFDB28371B663B5B53FD368"
 msgid "*Purr*"
-msgstr "*Ronroneo*"
+msgstr "*Ronronea*"
 
 #. Key:	0CE3BF194F0AEDEFF8FD32BC70EC9A18
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy_RL_F.Default__MirruDefault01_BodySexToy_RL_F_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy_RL_F.Default__MirruDefault01_BodySexToy_RL_F_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",0CE3BF194F0AEDEFF8FD32BC70EC9A18"
 msgid "You have multiple hearts?!"
-msgstr "¡¿Tienes multiples corazones?!"
+msgstr "¡¿Tienes múltiples corazones?!"
 
 #. Key:	0CF85A94478ED7F4CC8BA58C2B66D95C
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_RL.Default__CamillaDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_RL.Default__CamillaDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
 msgctxt ",0CF85A94478ED7F4CC8BA58C2B66D95C"
 msgid "Where can I find @MONSTER_RACE@?"
-msgstr "¿Donde puedo encontrar @MONSTER_RACE@?"
+msgstr "¿Dónde puedo encontrar @MONSTER_RACE@?"
 
 #. Key:	0D1AA721421DF16BA8A3CB90943223E5
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01.Default__NeelaDefault01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Neela/Default/NeelaDefault01.Default__NeelaDefault01_C.SessionData.Lines(1).Lines
 msgctxt ",0D1AA721421DF16BA8A3CB90943223E5"
 msgid "You sure do wander, no doubt anxious to get to your next sexual experience."
-msgstr "Seguro que deambulas, sin duda ansioso por tener tu próxima experiencia sexual."
+msgstr "Seguro que deambulas, sin duda, ansioso por tener tu próxima experiencia sexual."
 
 #. Key:	0D1B932340DB033C3F3173ABCEAE7E01
 #. SourceLocation:	/Game/Breeding/Positions/Butterfly.Default__Butterfly_C.SessionData.PositionName
@@ -648,14 +650,14 @@ msgstr "Mariposa"
 #: /Game/Dialogue/Romy/Default/RomyDefault01.Default__RomyDefault01_C.SessionData.Lines(2).Lines
 msgctxt ",0D3C4D8D4F6C01DE00A1B88BD745C860"
 msgid "A bath perhaps? Or maybe one of your wild ones made love with the dirt. I will wash them all."
-msgstr ""
+msgstr "¿Un baño quizás? O tal vez uno de tus silvestres hizo el amor con la tierra. Los lavaré a todos."
 
 #. Key:	0D41FE0947E3B6D0F4FD10AF14FE68BE
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleCentaur.Default__KybeleCentaur_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Kybele/Default/KybeleCentaur.Default__KybeleCentaur_C.SessionData.Lines(5).Lines
 msgctxt ",0D41FE0947E3B6D0F4FD10AF14FE68BE"
 msgid "For one of the @MONSTER_RACE@ race it is torture!"
-msgstr ""
+msgstr "¡Para cada uno de raza de los @MONSTER_RACE@ es una tortura!"
 
 #. Key:	0DB9C395441D2A229D61EE963260C09C
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.TitanCave.ManageActionMessage
@@ -669,7 +671,7 @@ msgstr "Gestiona tus Titanes"
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeVerySad2.Default__MegaSlimeVerySad2_C.SessionData.Lines(0).Lines
 msgctxt ",0DF191BF45A432F3BF190CAA63DF44DA"
 msgid "*Continued sobbing*"
-msgstr ""
+msgstr "*Sollozos contínuos*"
 
 #. Key:	0DFBAC884A0E11B073E5269E92E6DC30
 #. SourceLocation:	/Game/Breeding/Positions/Doggy.Default__Doggy_C.SessionData.PositionName
@@ -683,42 +685,44 @@ msgstr "Perrito"
 #: /Game/Dialogue/Fesssi/Default/FesssiDefault03_RL_F.Default__FesssiDefault03_RL_F_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",0E10569D4932D4D9DE1B73A05A7FC5FB"
 msgid "Wow... this world is full of idiots."
-msgstr ""
+msgstr "Guau... este mundo está lleno de idiotas."
 
 #. Key:	0E2A96C54ACC4571431587B73459221E
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(19 - Value).TraitIcons.DisplayName
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(19 - Value).TraitIcons.DisplayName
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(19 -
+#: Value).TraitIcons.DisplayName
 msgctxt ",0E2A96C54ACC4571431587B73459221E"
 msgid "Nymphomaniac"
-msgstr "Ninfómana/o"
+msgstr "Ninfómano"
 
 #. Key:	0E3AF3704D88CDB26D17458852A1792E
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiHadSex01.Default__ParvatiHadSex01_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Parvati/Default/ParvatiHadSex01.Default__ParvatiHadSex01_C.SessionData.Lines(3).Lines
 msgctxt ",0E3AF3704D88CDB26D17458852A1792E"
 msgid "Using our bodies in ways all too perverse."
-msgstr ""
+msgstr "Utilizando nuestros cuerpos de formas demasiado perversas."
 
 #. Key:	0E4B3CBA440B587A805453A5FAC01859
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDungeon2.Default__CassieDungeon2_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Cassie/Default/CassieDungeon2.Default__CassieDungeon2_C.SessionData.Lines(1).Lines
 msgctxt ",0E4B3CBA440B587A805453A5FAC01859"
 msgid "Meow... no one has been down there for as long as I remember."
-msgstr ""
+msgstr "Miau... nadie ha estado allí desde que tengo memoria."
 
 #. Key:	0E6E1156457FB3513C060D979FF6B9AE
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(29 - Value).TraitIcons.HelpText
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(29 - Value).TraitIcons.HelpText
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(29 -
+#: Value).TraitIcons.HelpText
 msgctxt ",0E6E1156457FB3513C060D979FF6B9AE"
 msgid "Sterile: Cannot produce offspring."
-msgstr "Estéril: No puede producir descendencia."
+msgstr "Estéril: no puede producir descendencia."
 
 #. Key:	0EA04A8B485AD7C29BE98E893200A8E3
 #. SourceLocation:	/Game/Ranch/Upgrades/DragonHoard.Default__DragonHoard_C.Upgrade.TypeDisplay
 #: /Game/Ranch/Upgrades/DragonHoard.Default__DragonHoard_C.Upgrade.TypeDisplay
 msgctxt ",0EA04A8B485AD7C29BE98E893200A8E3"
 msgid "Nephelym Barn"
-msgstr "Granero de Nephelyms"
+msgstr "Granero de Nephelym"
 
 #. Key:	0EA2FCF24AF05A8FBEF98C9F2C767D3A
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryRaiseTraitLvl_RL.Default__EmissaryRaiseTraitLvl_RL_C.ResponseData(1).ResponseData.BreederPrompt
@@ -732,14 +736,14 @@ msgstr "Rechazar"
 #: /Game/Dialogue/Emissary/Default/EmissaryHadSex01.Default__EmissaryHadSex01_C.SessionData.LinesToMale(3).LinesToMale
 msgctxt ",0EC0E30B4EEFEC910A9F1D90DC5AB286"
 msgid "Judging by the mess on the temple floor, quite good."
-msgstr ""
+msgstr "A juzgar por el desorden en el suelo del templo, bastante bueno."
 
 #. Key:	0EEEC9A34AD6162338FCA699384590D4
 #. SourceLocation:	/Game/Ranch/Upgrades/BovaurShed.Default__BovaurShed_C.Upgrade.TypeDisplay
 #: /Game/Ranch/Upgrades/BovaurShed.Default__BovaurShed_C.Upgrade.TypeDisplay
 msgctxt ",0EEEC9A34AD6162338FCA699384590D4"
 msgid "Nephelym Barn"
-msgstr "Granero de Nephelyms"
+msgstr "Granero de Nephelym"
 
 #. Key:	0F0B2E364C42C3D6BACC018A46DB5BE4
 #. SourceLocation:	/Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToFuta(5).LinesToFuta
@@ -753,56 +757,56 @@ msgstr "*Chupa* *Lame*"
 #: /Game/Dialogue/Widow/Default/WidowHadSex01.Default__WidowHadSex01_C.SessionData.Lines(1).Lines
 msgctxt ",0F2C0FD149F892CC3CC45FA0F73FA3DB"
 msgid "There is no need to fear me. Stay awhile in my web, and let us see how far we can take our love."
-msgstr ""
+msgstr "No hay necesidad de temerme. Quédate un rato en mi telaraña y veamos hasta dónde podemos llevar nuestro amor."
 
 #. Key:	0F2C916F409983084088D7B8C734556F
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_Leylanna.Default__EmissaryDefault01_Leylanna_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_Leylanna.Default__EmissaryDefault01_Leylanna_C.SessionData.Lines(4).Lines
 msgctxt ",0F2C916F409983084088D7B8C734556F"
 msgid "However, she must learn to restrain herself from inhaling so much of that blue smoke."
-msgstr "Sin embargo, ella debe aprender a evitar inhalar tanto de ese humo azul."
+msgstr "Sin embargo, debe aprender a contenerse para no inhalar tanto de ese humo azul."
 
 #. Key:	0F3DB30048A1D95AFB32AEBCA67D8C96
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01.Default__RomyDefault01_C.SessionData.LinesGrungy(1).LinesGrungy
 #: /Game/Dialogue/Romy/Default/RomyDefault01.Default__RomyDefault01_C.SessionData.LinesGrungy(1).LinesGrungy
 msgctxt ",0F3DB30048A1D95AFB32AEBCA67D8C96"
 msgid "You need a bath. Come now, place your body between my breasts and let's get you clean."
-msgstr "Necesitas un baño. Ven ahora, coloca tu cuerpo entre mis senos y vamos a limpiarte."
+msgstr "Necesitas un baño. Ven ahora, coloca tu cuerpo entre mis pechos y vamos a limpiarte."
 
 #. Key:	0F5F4BBA4C14BF84662CB09F0D97B147
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_AboutKrakens.Default__MirruDefault01_AboutKrakens_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_AboutKrakens.Default__MirruDefault01_AboutKrakens_C.SessionData.Lines(2).Lines
 msgctxt ",0F5F4BBA4C14BF84662CB09F0D97B147"
 msgid "While we have destructive past, most Krakens today are peaceful and seek only love and pleasure as other @MONSTER_RACE@."
-msgstr "Si bien tenemos un pasado destructivo, la mayoría de los Krakens de hoy son pacíficos y solo buscan amor y placer como otros @MONSTER_RACE@."
+msgstr "Si bien tenemos un pasado destructivo, la mayoría de los krakens de hoy en día son pacíficos y solo buscan amor y placer como otros @MONSTER_RACE@."
 
 #. Key:	0F62EE694ADB2071C7247C8AA042A065
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeDefault01_RL.Default__MegaSlimeDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeDefault01_RL.Default__MegaSlimeDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",0F62EE694ADB2071C7247C8AA042A065"
 msgid "I want you to have this pearl."
-msgstr ""
+msgstr "Quiero que tengas esta perla."
 
 #. Key:	0FAF6E0B4308E0F116E3C3BC117672E3
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToMale(7).LinesToMale
 #: /Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToMale(7).LinesToMale
 msgctxt ",0FAF6E0B4308E0F116E3C3BC117672E3"
 msgid "That creepy golden seraphim, the one in the temple. She appeared only a few days ago, constantly asking to speak with \"the human\"."
-msgstr ""
+msgstr "Esa espeluznante serafín dorada, la del templo. Ella apareció hace solo unos días, constantemente pidiendo hablar con \"el humano\"."
 
 #. Key:	0FB73EF84E0DB71722FC9BAB2C24DFEE
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowDefault01_RL.Default__WidowDefault01_RL_C.ResponseData(3).ResponseData.BreederPrompt
 #: /Game/Dialogue/Widow/Default/WidowDefault01_RL.Default__WidowDefault01_RL_C.ResponseData(3).ResponseData.BreederPrompt
 msgctxt ",0FB73EF84E0DB71722FC9BAB2C24DFEE"
 msgid "That poor elf..."
-msgstr ""
+msgstr "Esa pobre elfa..."
 
 #. Key:	0FC69F2441505B7DAACAC7807627892D
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03_R05.Default__FernDefault03_R05_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03_R05.Default__FernDefault03_R05_C.SessionData.Lines(1).Lines
 msgctxt ",0FC69F2441505B7DAACAC7807627892D"
 msgid "We made her together when your bodily fluids merged with mine."
-msgstr "La hicimos juntos cuando tus fluidos se fusionaron con los míos."
+msgstr "La hicimos juntos cuando tus fluidos corporales se fusionaron con los míos."
 
 #. Key:	0FDE723F46BC47FD23DB75A6EDA9C79C
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_BlueSmoke.Default__LeylannaDefault01_BlueSmoke_C.SessionData.Lines(2).Lines
@@ -816,63 +820,63 @@ msgstr "Ahhhh..."
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFuta(30).LinesToFuta
 msgctxt ",1019EEE14B67704DE6DE0B9FD7D0D596"
 msgid "If you want to learn about how to catch @MONSTER_RACE@, head to the town located up the plateau ahead and speak to my assistant Camilla. You can't miss her... actually wait you might, she's so tiny and cute hehehe."
-msgstr "Si quieres aprender cómo atrapar @MONSTER_RACE@, dirígete a la ciudad ubicada en la montaña de adelante y habla con mi asistente Camilla. No puedes perderla... en realidad espero que lo hagas, es tan pequeña y linda jejeje."
+msgstr "Si quieres aprender cómo atrapar @MONSTER_RACE@, dirígete a la ciudad ubicada en la meseta más adelante y habla con mi asistente Camilla. No puedes perderla... en realidad, espera, es posible, es tan pequeña y linda jejeje."
 
 #. Key:	106EA6A747A0901892BD12A925DA79A5
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy_RL_F.Default__MirruDefault01_BodySexToy_RL_F_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy_RL_F.Default__MirruDefault01_BodySexToy_RL_F_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",106EA6A747A0901892BD12A925DA79A5"
 msgid "Have your way with me!"
-msgstr "¡Ábrete camino conmigo!"
+msgstr "¡Haz lo que quieras conmigo!"
 
 #. Key:	1074EFCF47610848DA1E09AED2EF9B29
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault02.Default__EmissaryDefault02_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault02.Default__EmissaryDefault02_C.SessionData.Lines(2).Lines
 msgctxt ",1074EFCF47610848DA1E09AED2EF9B29"
 msgid "That disgusting creature will not see the light of day so long as this emissary remains."
-msgstr ""
+msgstr "Esa repugnante criatura no verá la luz del día mientras esta emisaria permanezca."
 
 #. Key:	107C6B8448B1F139A90AFDBD17AE1AA9
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(25).LinesToFemale
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(25).LinesToFemale
 msgctxt ",107C6B8448B1F139A90AFDBD17AE1AA9"
 msgid "However, some might be more playful about it and surprise you!"
-msgstr "Sin embargo, algunos podrían ser más juguetones y sorprenderte!"
+msgstr "¡Sin embargo, algunos podrían ser más juguetones y sorprenderte!"
 
 #. Key:	10B218DC466D7C9E5D99159D3C8C2B49
 #. SourceLocation:	/Game/Ranch/Upgrades/SylvanTreehouse.Default__SylvanTreehouse_C.Upgrade.DisplayName
 #: /Game/Ranch/Upgrades/SylvanTreehouse.Default__SylvanTreehouse_C.Upgrade.DisplayName
 msgctxt ",10B218DC466D7C9E5D99159D3C8C2B49"
 msgid "Sylvan Treehouse"
-msgstr "Casa del Árbol de Silvestres"
+msgstr "Casa del Árbol de Silvanos"
 
 #. Key:	10B6D2544B53FFD4CF0A1DA4375DF5B5
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_NoSpiritVariant.Default__LeylannaDefault01_NoSpiritVariant_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/Leylanna/Default/LeylannaDefault01_NoSpiritVariant.Default__LeylannaDefault01_NoSpiritVariant_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",10B6D2544B53FFD4CF0A1DA4375DF5B5"
 msgid "Return to me when you have caught a female Foxen."
-msgstr "Regresa a mí cuando hayas atrapado una Zorro hembra."
+msgstr "Vuelve a verme cuando hayas atrapado una hembra foxen."
 
 #. Key:	10E4A32B499DC549B6EE719D6FEAFD45
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleHaveKeystone.Default__KybeleHaveKeystone_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Kybele/Default/KybeleHaveKeystone.Default__KybeleHaveKeystone_C.SessionData.Lines(4).Lines
 msgctxt ",10E4A32B499DC549B6EE719D6FEAFD45"
 msgid "I want a strong mate large enough to please me, a Vulwarg fleshy in the right areas will do."
-msgstr ""
+msgstr "Quiero una pareja fuerte lo suficientemente grande para complacerme, un vulwarg carnoso en las áreas correctas servirá."
 
 #. Key:	1101687D48DB923571BCF99F288D40BC
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyGreeting01.Default__RomyGreeting01_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Romy/Default/RomyGreeting01.Default__RomyGreeting01_C.SessionData.Lines(3).Lines
 msgctxt ",1101687D48DB923571BCF99F288D40BC"
 msgid "Won't you stay in my loving embrace and feel my music?"
-msgstr "¿No te quedarás en mis amorosos brazos y sentirás mi música?"
+msgstr "¿No te quedarás en mi abrazo amoroso y sentirás mi música?"
 
 #. Key:	11020A854E2D02F780F8BEA52E1E313C
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryBlessedInquiry02_R01.Default__EmissaryBlessedInquiry02_R01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryBlessedInquiry02_R01.Default__EmissaryBlessedInquiry02_R01_C.SessionData.Lines(0).Lines
 msgctxt ",11020A854E2D02F780F8BEA52E1E313C"
 msgid "If it pleases you, do as you will."
-msgstr "Si te gusta, haz lo que quieras."
+msgstr "Si te complace, haz lo que gustes."
 
 #. Key:	1150B97A4723F9592EB22D9FDDA5B4AE
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(15).LinesToMale
@@ -886,56 +890,56 @@ msgstr "Quiero chupártela..."
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_AboutKrakens.Default__MirruDefault01_AboutKrakens_C.SessionData.Lines(3).Lines
 msgctxt ",115E28B04787E362B52C17AF826B86A5"
 msgid "You must understand human, our large fleshy bodies pulse with lust and are difficult to satisfy."
-msgstr "Debes entender humano, nuestros grandes cuerpos carnosos laten con lujuria y son difíciles de satisfacer."
+msgstr "Debes entender humano, nuestros grandes cuerpos carnosos palpitan con lujuria y son difíciles de satisfacer."
 
 #. Key:	1187860A495AEE8B52286F8DA6A1DF53
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01_RL_F.Default__FernDefault01_RL_F_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/Fern/Default/FernDefault01_RL_F.Default__FernDefault01_RL_F_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",1187860A495AEE8B52286F8DA6A1DF53"
 msgid "What a lovely talking fern..."
-msgstr "Qué encantadora helecho parlante..."
+msgstr "Qué encantador helecho parlante..."
 
 #. Key:	119BE39146D97EAD68AF26B063950DFD
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_Emissary.Default__LeylannaDefault01_Emissary_C.SessionData.Lines(6).Lines
 #: /Game/Dialogue/Leylanna/Default/LeylannaDefault01_Emissary.Default__LeylannaDefault01_Emissary_C.SessionData.Lines(6).Lines
 msgctxt ",119BE39146D97EAD68AF26B063950DFD"
 msgid "Forgive my daydreaming human, Emissary is your archangel. She will help you."
-msgstr "Perdona mi sueño despierto, humana, la Emisaria es tu arcángel. Ella te ayudará."
+msgstr "Perdona mis ensoñaciones humano, la Emisaria es tu arcángel. Ella te ayudará."
 
 #. Key:	11A588964451AB702EC48CA542D16E81
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToMale(6).LinesToMale
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToMale(6).LinesToMale
 msgctxt ",11A588964451AB702EC48CA542D16E81"
 msgid "Stick that lovely human dick deep into my Lamia body... yes..."
-msgstr "Mete esa encantadora polla humana en mi cuerpo de Lamia... sí..."
+msgstr "Mete ese encantador pene humano profundamente en mi cuerpo de lamia... sí..."
 
 #. Key:	11A9B90644E91677CD9DEFB4CC831C2C
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.CBGate_Jungle.PlaceMessage
 #: /Game/World/Overworld.Overworld:PersistentLevel.CBGate_Jungle.PlaceMessage
 msgctxt ",11A9B90644E91677CD9DEFB4CC831C2C"
 msgid "Sultry Plateau is now accessible."
-msgstr ""
+msgstr "La Meseta Sensual ahora es accesible."
 
 #. Key:	11B6FBE746EB52494E5B6E83052E0D98
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiCave.Default__FesssiCave_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiCave.Default__FesssiCave_C.SessionData.Lines(4).Lines
 msgctxt ",11B6FBE746EB52494E5B6E83052E0D98"
 msgid "Naturally I slithered my big butt in there and found myself right at home."
-msgstr ""
+msgstr "Naturalmente, deslicé mi gran trasero allí y me encontré como en casa."
 
 #. Key:	11BBEDC74B6704427E32B6A7F9FB5D77
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchStartShySex.Default__MonarchStartShySex_C.SessionData.LinesToFuta(2).LinesToFuta
 #: /Game/Dialogue/Monarch/Default/MonarchStartShySex.Default__MonarchStartShySex_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",11BBEDC74B6704427E32B6A7F9FB5D77"
 msgid "May I... ride you?"
-msgstr ""
+msgstr "¿Puedo... montarte?"
 
 #. Key:	11C0FBB845185DFCD5E67DA5B758B432
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon2.Default__AmberMaeLockedDungeon2_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon2.Default__AmberMaeLockedDungeon2_C.SessionData.Lines(2).Lines
 msgctxt ",11C0FBB845185DFCD5E67DA5B758B432"
 msgid "At me peak I could barely walk! The jugs 'an belly were mighty heavy."
-msgstr ""
+msgstr "¡En mi pico apenah podía caminar! Loh cántaroh de leshe y la barriga pesaban muchísimo."
 
 #. Key:	12036FB64912193341380BA267A64971
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernGreeting03.Default__FernGreeting03_C.SessionData.LinesToFemale(4).LinesToFemale
@@ -949,56 +953,57 @@ msgstr "Deslízate aquí conmigo, mi cuerpo es sedoso y lleno de dulce néctar. 
 #: /Game/Dialogue/Fern/Default/FernDefault01_RL_F.Default__FernDefault01_RL_F_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",123F93684828FFF522F86B84110A5712"
 msgid "Why did you call me master?"
-msgstr "¿Por qué me llamaste maestra?"
+msgstr "¿Por qué me llamaste, Master?"
 
 #. Key:	1240C441425085EA27ECBDBABB3C00AF
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R04.Default__FaleneDefault01_R04_C.SessionData.Lines(14).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R04.Default__FaleneDefault01_R04_C.SessionData.Lines(14).Lines
 msgctxt ",1240C441425085EA27ECBDBABB3C00AF"
 msgid "We really are just pleasure seekers at heart!"
-msgstr "¡Realmente solo somos buscadores de placer en el fondo!"
+msgstr "¡Realmente somos buscadores de placer en el corazón!"
 
 #. Key:	1276E5EB4781A0238A9705AC9FEE680E
 #. SourceLocation:	/Game/World/Events/EM_Keystone.EM_Keystone_C:ExecuteUbergraph_EM_Keystone [Script Bytecode]
-#: /Game/World/Events/EM_Keystone.EM_Keystone_C:ExecuteUbergraph_EM_Keystone [Script Bytecode]
+#: /Game/World/Events/EM_Keystone.EM_Keystone_C:ExecuteUbergraph_EM_Keystone
+#: [Script Bytecode]
 msgctxt ",1276E5EB4781A0238A9705AC9FEE680E"
 msgid "Keystone acquired."
-msgstr ""
+msgstr "Piedra-llave adquirida."
 
 #. Key:	129A33314E1BA60BA7698394A0DEDCD7
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieHadSex01.Default__CassieHadSex01_C.SessionData.LinesToFuta(3).LinesToFuta
 #: /Game/Dialogue/Cassie/Default/CassieHadSex01.Default__CassieHadSex01_C.SessionData.LinesToFuta(3).LinesToFuta
 msgctxt ",129A33314E1BA60BA7698394A0DEDCD7"
 msgid "So many splinters in my back, but it was worth it!"
-msgstr ""
+msgstr "Tantas astillas en mi espalda, ¡pero valió la pena!"
 
 #. Key:	129E92F14686D57C52A26598C5257AF6
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(12).LinesToFemale
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(12).LinesToFemale
 msgctxt ",129E92F14686D57C52A26598C5257AF6"
 msgid "You have a beautiful set of fertile hips and breasts... you will make a great mate!"
-msgstr "Tienes un hermoso conjunto de caderas y senos fértiles... ¡serás una gran pareja!"
+msgstr "Tienes un hermoso conjunto de caderas y pechos fértiles... ¡serás una gran pareja!"
 
 #. Key:	12AF2DD443EFD1CDF7E19291D7E49384
 #. SourceLocation:	/Game/Ranch/Upgrades/ThriaeHive.Default__ThriaeHive_C.Upgrade.Description
 #: /Game/Ranch/Upgrades/ThriaeHive.Default__ThriaeHive_C.Upgrade.Description
 msgctxt ",12AF2DD443EFD1CDF7E19291D7E49384"
 msgid "This allows you to catch and store all variants of Thriae."
-msgstr "Esto te permite capturar y almacenar todas las variantes de Thriaes."
+msgstr "Esto le permite capturar y almacenar todas las variantes de Thriaes."
 
 #. Key:	12D176A644633E97EDB77BAB882297E2
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_Forgot_RL.Default__ParvatiDefault01_Forgot_RL_C.ResponseData(3).ResponseData.BreederPrompt
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_Forgot_RL.Default__ParvatiDefault01_Forgot_RL_C.ResponseData(3).ResponseData.BreederPrompt
 msgctxt ",12D176A644633E97EDB77BAB882297E2"
 msgid "Reverse Cowgirl!"
-msgstr "¡Vaquera Invertida!"
+msgstr "¡Vaquera inversa!"
 
 #. Key:	12D3C80246AEABBC7C78CD8D7A2FD415
 #. SourceLocation:	/Game/Dialogue/Mirru/SexScenes/MirruSnatchT.Default__MirruSnatchT_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Mirru/SexScenes/MirruSnatchT.Default__MirruSnatchT_C.SessionData.Lines(2).Lines
 msgctxt ",12D3C80246AEABBC7C78CD8D7A2FD415"
 msgid "Do you like my thick deep vagina? Ahh... penetrate it with all your might..."
-msgstr "¿Te gusta mi vagina gruesa y profunda? Ahh... penetrarla con todas tus fuerzas..."
+msgstr "¿Te gusta mi vagina gruesa y profunda? Ahh... penétrala con todas tus fuerzas..."
 
 #. Key:	12F0D8C14278EB1A73FD4289B39B7E87
 #. SourceLocation:	/Game/Dialogue/Blossom/Default/BlossomDefault01_RL_F.Default__BlossomDefault01_RL_F_C.ResponseData(2).ResponseData.BreederPrompt
@@ -1019,105 +1024,105 @@ msgstr "Caverna de Titanes"
 #: /Game/Dialogue/Monarch/Default/MonarchShySexT_RL.Default__MonarchShySexT_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",1313BBB44A4D1E05E98E26A226B6226B"
 msgid "No!"
-msgstr ""
+msgstr "¡No!"
 
 #. Key:	1314F6404A2F1B2C9E0F9F856E1D18C6
 #. SourceLocation:	/Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToFuta(1).LinesToFuta
 #: /Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToFuta(1).LinesToFuta
 msgctxt ",1314F6404A2F1B2C9E0F9F856E1D18C6"
 msgid "Yes... oh yes, it feels so good! Penetrate me deeper!"
-msgstr "Sí... ¡oh sí, se siente tan bien! ¡Penétrame más profundo!"
+msgstr "¡Sí... oh sí, se siente tan bien! ¡Penétrame más profundo!"
 
 #. Key:	132FEAC24092921E25A0F68A9AA99D0B
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_RL.Default__NeelaDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_RL.Default__NeelaDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",132FEAC24092921E25A0F68A9AA99D0B"
 msgid "What is the Void?"
-msgstr "¿Qué es el vacío?"
+msgstr "¿Qué es el Vacío?"
 
 #. Key:	13523F8143CE0377FC6658A757678D38
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcAkabekoCheck.Default__OrcAkabekoCheck_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcAkabekoCheck.Default__OrcAkabekoCheck_C.SessionData.Lines(4).Lines
 msgctxt ",13523F8143CE0377FC6658A757678D38"
 msgid "Take stupid keystone if you haven't already."
-msgstr ""
+msgstr "Toma la estúpida piedra-llave si aún no lo has hecho."
 
 #. Key:	1375B52C45BC0C13C5B21D954838AE4B
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchQueen.Default__MonarchQueen_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Monarch/Default/MonarchQueen.Default__MonarchQueen_C.SessionData.Lines(3).Lines
 msgctxt ",1375B52C45BC0C13C5B21D954838AE4B"
 msgid "As a butterfly, my t-t-task is to fly around the world and collect exotic nectar."
-msgstr ""
+msgstr "Como mariposa, mi t-t-tarea es volar alrededor del mundo y recolectar néctar exótico."
 
 #. Key:	13E887904839CEF7B4D79EBD63EA0F05
 #. SourceLocation:	/Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToFuta(2).LinesToFuta
 #: /Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",13E887904839CEF7B4D79EBD63EA0F05"
 msgid "I don't care if you aren't a Titan! Ahhhhhhh... ohhh..."
-msgstr "¡No me importa si no eres una Titán! Ahhhhhhh... ohhh..."
+msgstr "¡No me importa si no eres un titán! Ahhhhhhh... ohhh..."
 
 #. Key:	13F822424D7968B826D8E79C10C52DBC
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03_R02_R01.Default__FernDefault03_R02_R01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03_R02_R01.Default__FernDefault03_R02_R01_C.SessionData.Lines(1).Lines
 msgctxt ",13F822424D7968B826D8E79C10C52DBC"
 msgid "But we can make love now! Let's do that. Maybe something magical will happen."
-msgstr "¡Pero podemos hacer el amor ahora! Hagámoslo. Tal vez algo mágico suceda."
+msgstr "¡Pero podemos hacer el amor ahora! Hagámoslo. Tal vez suceda algo mágico."
 
 #. Key:	14065F34477043D39DE5A2A95756167D
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowSpiders.Default__WidowSpiders_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Widow/Default/WidowSpiders.Default__WidowSpiders_C.SessionData.Lines(5).Lines
 msgctxt ",14065F34477043D39DE5A2A95756167D"
 msgid "Or a human in my case... a truly rare event. One tasty morsel I would never pass up."
-msgstr ""
+msgstr "O un humano en mi caso... un evento verdaderamente raro. Un bocado sabroso que nunca dejaría pasar."
 
 #. Key:	14597A3447ACFD81E4E72CB43D419E39
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_R01.Default__FernDefault02_R01_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02_R01.Default__FernDefault02_R01_C.SessionData.Lines(4).Lines
 msgctxt ",14597A3447ACFD81E4E72CB43D419E39"
 msgid "If I have to spend the rest of eternity in one spot, I wouldn't want it to be with anyone else..."
-msgstr "Si tuviera que pasar el resto de la eternidad en un lugar, no quisiera que fuera con nadie más..."
+msgstr "Si tuviera que pasar el resto de la eternidad en un lugar, no querría que fuera con nadie más..."
 
 #. Key:	146C8ABB4CFE56E192BE198657474339
 #. SourceLocation:	/Game/Dialogue/Blossom/Default/BlossomDefault01_R01.Default__BlossomDefault01_R01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Blossom/Default/BlossomDefault01_R01.Default__BlossomDefault01_R01_C.SessionData.Lines(0).Lines
 msgctxt ",146C8ABB4CFE56E192BE198657474339"
 msgid "You are... the one that pleasured Fern mother."
-msgstr "Tú eres... la que complació a madre Helecho."
+msgstr "Tú eres... el que complació a madre Fern."
 
 #. Key:	1494AA5040692D75A2E458AE890541FA
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_FloatRhyme.Default__ParvatiDefault01_FloatRhyme_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_FloatRhyme.Default__ParvatiDefault01_FloatRhyme_C.SessionData.Lines(3).Lines
 msgctxt ",1494AA5040692D75A2E458AE890541FA"
 msgid "Allow me to show you what She shared, if I may."
-msgstr "Permíteme mostrarte lo que Ella me compartió, si puedo en sumario."
+msgstr "Permítame mostrarte lo que Ella compartió, si se me permite."
 
 #. Key:	1495FB154E5C773C51452295CAF9F467
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R02.Default__FaleneDefault01_R02_C.SessionData.Lines(10).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R02.Default__FaleneDefault01_R02_C.SessionData.Lines(10).Lines
 msgctxt ",1495FB154E5C773C51452295CAF9F467"
 msgid "We are so happy when humans love us and fill our desires, and we will reward you."
-msgstr "Somos tan felices cuando los humanos nos aman y satisfacen nuestros deseos, y nosotras te recompensaremos."
+msgstr "Somos tan felices cuando los humanos nos aman y satisfacen nuestros deseos, y te recompensaremos."
 
 #. Key:	14E2045C4451D2597C51F4AAF56AE3B7
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_Teach.Default__ParvatiDefault01_Teach_C.SessionData.LinesToFuta(0).LinesToFuta
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_Teach.Default__ParvatiDefault01_Teach_C.SessionData.LinesToFuta(0).LinesToFuta
 msgctxt ",14E2045C4451D2597C51F4AAF56AE3B7"
 msgid "Remove your garments, for you must be nude."
-msgstr "Quítate la ropa, debes estar desnuda."
+msgstr "Quítate tus prendas, debes estar desnuda."
 
 #. Key:	14F5C7E34772BFD4F5E7039EF72ACF9E
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaGreeting01.Default__NeelaGreeting01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Neela/Default/NeelaGreeting01.Default__NeelaGreeting01_C.SessionData.Lines(1).Lines
 msgctxt ",14F5C7E34772BFD4F5E7039EF72ACF9E"
 msgid "Through all of my long years and endless travels, I never thought to cross paths with a human."
-msgstr "A través de todos mis largos años y viajes sin fin, nunca pensé aparearme con un humano."
+msgstr "A través de todos mis largos años y viajes interminables, nunca pensé cruzarme con un humano."
 
 #. Key:	1558B86B4DAABB7D51D53FB9D3508EBD
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiCave.Default__FesssiCave_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiCave.Default__FesssiCave_C.SessionData.Lines(5).Lines
 msgctxt ",1558B86B4DAABB7D51D53FB9D3508EBD"
 msgid "The surface is boring and full of self-righteous angels and simpletons. Hiss!"
-msgstr ""
+msgstr "La superficie es aburrida y está llena de ángeles farisaicos y simplones. ¡Ssss!"
 
 #. Key:	158D44FA46C00C7898EF1C99A9A99EA7
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_Leylanna.Default__EmissaryDefault01_Leylanna_C.SessionData.Lines(7).Lines
@@ -1131,7 +1136,7 @@ msgstr "Afirmando que \"los espíritus me dijeron que hiciera el amor con el án
 #: /Game/Dialogue/Petra/Default/PetraGreeting01.Default__PetraGreeting01_C.SessionData.Lines(2).Lines
 msgctxt ",15C00C874838EB1710DECF9C8F9A8AB0"
 msgid "Her name is Pawsmaati, she is not far from here. You should seek her wisdom."
-msgstr ""
+msgstr "Su nombre es Pawsmaati, no está lejos de aquí. Deberías buscar su sabiduría."
 
 #. Key:	16049E004B001A3FEF8E25BEBE498398
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_RL.Default__ParvatiDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
@@ -1145,91 +1150,91 @@ msgstr "Entonces, ¿solo meditas y rimas todo el día?"
 #: /Game/Dialogue/Leylanna/Default/LeylannaDefault01_HowToSpiritForm_RL_T.Default__LeylannaDefault01_HowToSpiritForm_RL_T_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",16099E454C927A69887E23955E893635"
 msgid "I am off to catch that variant."
-msgstr "Me voy a atrapar esa variante."
+msgstr "Me marcho para atrapar esa variante."
 
 #. Key:	16513C5A4632BB961094E887464CD1B1
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiAreYouOk.Default__FesssiAreYouOk_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiAreYouOk.Default__FesssiAreYouOk_C.SessionData.Lines(2).Lines
 msgctxt ",16513C5A4632BB961094E887464CD1B1"
 msgid "Hiss!"
-msgstr ""
+msgstr "¡Sss!"
 
 #. Key:	169058BF4DE41C3E4D03D0ABE7BC7F77
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_FloatRhyme.Default__ParvatiDefault01_FloatRhyme_C.SessionData.Lines(8).Lines
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_FloatRhyme.Default__ParvatiDefault01_FloatRhyme_C.SessionData.Lines(8).Lines
 msgctxt ",169058BF4DE41C3E4D03D0ABE7BC7F77"
 msgid "We can make love, for it is lonely at times."
-msgstr "Podemos hacer el amor, porque a veces es solitario."
+msgstr "Podemos hacer el amor, porque a veces nos sentimos solos."
 
 #. Key:	16E336BD48B5FD77EAAE96BC1BAAF7D4
 #. SourceLocation:	/Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToMale(2).LinesToMale
 #: /Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToMale(2).LinesToMale
 msgctxt ",16E336BD48B5FD77EAAE96BC1BAAF7D4"
 msgid "I don't care if you aren't a Titan! Ahhhhhhh... ohhh..."
-msgstr "¡No me importa si no eres un Titán! Ahhhhhhh... ohhh..."
+msgstr "¡No me importa si no eres un titán! Ahhhhhhh... ohhh..."
 
 #. Key:	16EC466F4A9673C3FA08CF9ED0AD4534
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeHowLong.Default__MegaSlimeHowLong_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeHowLong.Default__MegaSlimeHowLong_C.SessionData.Lines(2).Lines
 msgctxt ",16EC466F4A9673C3FA08CF9ED0AD4534"
 msgid "Until now! These last few days have been the happiest of my life."
-msgstr ""
+msgstr "¡Hasta ahora! Estos últimos días han sido los más felices de mi vida."
 
 #. Key:	17088A3C40A455B65AC29F8824A40BA1
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadDefault01_RL.Default__DryadDefault01_RL_C.ResponseData(6).ResponseData.BreederPrompt
 #: /Game/Dialogue/Autumn/Default/DryadDefault01_RL.Default__DryadDefault01_RL_C.ResponseData(6).ResponseData.BreederPrompt
 msgctxt ",17088A3C40A455B65AC29F8824A40BA1"
 msgid "Can you make flowers grow in the Hivelands?"
-msgstr ""
+msgstr "¿Puedes hacer crecer flores en las Tierras-Colmena?"
 
 #. Key:	170B9C2D49AD3C9EDFB2F98BB3947924
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(13).LinesToMale
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(13).LinesToMale
 msgctxt ",170B9C2D49AD3C9EDFB2F98BB3947924"
 msgid "My vagina is pulsing..."
-msgstr "Mi vagina esta latiendo..."
+msgstr "Mi vagina está palpitando..."
 
 #. Key:	17607CE74517243E14D7458209F5B954
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiHowLong.Default__FesssiHowLong_C.SessionData.Lines(6).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiHowLong.Default__FesssiHowLong_C.SessionData.Lines(6).Lines
 msgctxt ",17607CE74517243E14D7458209F5B954"
 msgid "Actually that wouldn't be useful now that I think about it, but anyway where was I..."
-msgstr ""
+msgstr "En realidad, eso no sería útil ahora que lo pienso, pero de todos modos, dónde estaba yo..."
 
 #. Key:	176F7A314E26B5F6293327AB991F4EAA
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcAkabekoCheck.Default__OrcAkabekoCheck_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcAkabekoCheck.Default__OrcAkabekoCheck_C.SessionData.Lines(0).Lines
 msgctxt ",176F7A314E26B5F6293327AB991F4EAA"
 msgid "*Snarl* Glorious!"
-msgstr ""
+msgstr "*Gruñe* ¡Glorioso!"
 
 #. Key:	17A76DB943E2CB6F9ACC2A823244D892
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMMuchEnergy.Default__DMMuchEnergy_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/DragonMatriarch/Default/DMMuchEnergy.Default__DMMuchEnergy_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",17A76DB943E2CB6F9ACC2A823244D892"
 msgid "Now I want to mate! I've been slumbering for many days, and I am extremely horny."
-msgstr ""
+msgstr "¡Ahora quiero aparearme! Llevo muchos días durmiendo y estoy muy cachonda."
 
 #. Key:	17D6A70C4116B743F6CB26ADEB18DFD0
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeHadSex01.Default__MegaSlimeHadSex01_C.SessionData.LinesToFuta(2).LinesToFuta
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeHadSex01.Default__MegaSlimeHadSex01_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",17D6A70C4116B743F6CB26ADEB18DFD0"
 msgid "It's been so long since I have tasted warm cum."
-msgstr ""
+msgstr "Ha pasado tanto tiempo desde que probé el semen caliente."
 
 #. Key:	186FDC7F49586189532EC29D0F8296D3
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMDefault_RL3.Default__DMDefault_RL3_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/DragonMatriarch/Default/DMDefault_RL3.Default__DMDefault_RL3_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",186FDC7F49586189532EC29D0F8296D3"
 msgid "It's presently grasslands and trees..."
-msgstr ""
+msgstr "Actualmente son pastizales y árboles..."
 
 #. Key:	18CAD01243ECA034DDADA1A0880C715D
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_Forgot.Default__ParvatiDefault01_Forgot_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_Forgot.Default__ParvatiDefault01_Forgot_C.SessionData.Lines(2).Lines
 msgctxt ",18CAD01243ECA034DDADA1A0880C715D"
 msgid "You are in the presence of Pawsmaati, and I am kind."
-msgstr "Estás en presencia de Pawsmaati, y soy un amor que poetiza."
+msgstr "Estás en presencia de Pawsmaati, y soy bondadosa."
 
 #. Key:	18D7599649118CDCF2E1C78FFB34E034
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_ChangeSpiritForm.Default__LeylannaDefault01_ChangeSpiritForm_C.SessionData.Lines(0).Lines
@@ -1243,63 +1248,64 @@ msgstr "A través de mí puedes comunicarte con los espíritus y cambiar tu form
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R01.Default__FaleneDefault01_R01_C.SessionData.Lines(10).Lines
 msgctxt ",18F557C243E97F6A690B608405D897DF"
 msgid "It's a fact that @MONSTER_RACE@ semen is a powerful substance--just applying it to your skin has all sorts of effects."
-msgstr "Es un hecho que el semen de @MONSTER_RACE@ es una sustancia muy poderosa, el solo hecho de aplicarlo en la piel tiene todo tipo de efectos."
+msgstr "Es un hecho que el semen de @MONSTER_RACE@ es una sustancia muy poderosa: el solo hecho de aplicarlo en tu piel tiene todo tipo de efectos."
 
 #. Key:	193B4CF045056BF6C0B7E0AF2A4A65FF
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(23 - Value).TraitIcons.HelpText
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(23 - Value).TraitIcons.HelpText
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(23 -
+#: Value).TraitIcons.HelpText
 msgctxt ",193B4CF045056BF6C0B7E0AF2A4A65FF"
 msgid "Valuable: Value is increased by 35%."
-msgstr "Valiosa/o: Su Valor se incrementa en un 35%."
+msgstr "Valioso: el Valor se incrementa en un 35%."
 
 #. Key:	193F948E4333F3741026EABB87402DD3
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToFuta(2).LinesToFuta
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",193F948E4333F3741026EABB87402DD3"
 msgid "A chance to mate with a human is making my hearts pound, and my tentacles slick..."
-msgstr "La oportunidad de aparearme con un humano hace que mi corazón palpite, y que mis tentáculos resbalen..."
+msgstr "Una oportunidad de aparearme con una humana está haciendo que mi corazón se acelere y que mis tentáculos resbalen..."
 
 #. Key:	195D4E38448666E82EA5BEA6A446E98A
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeSad_RL2.Default__MegaSlimeSad_RL2_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeSad_RL2.Default__MegaSlimeSad_RL2_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",195D4E38448666E82EA5BEA6A446E98A"
 msgid "What have I done..."
-msgstr ""
+msgstr "Qué he hecho..."
 
 #. Key:	19A2E9D044587CE3E0AC5B8D366B6974
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeDefault01.Default__AmberMaeDefault01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeDefault01.Default__AmberMaeDefault01_C.SessionData.Lines(0).Lines
 msgctxt ",19A2E9D044587CE3E0AC5B8D366B6974"
 msgid "Have ye come back to feel 'mai jugs?"
-msgstr "¿Hah vuerto pa sentih mih tetah?"
+msgstr "¿Hah vuerto pa sentih mih cántaroh de leshe?"
 
 #. Key:	19AB0BB8417E1310F35D1D922EF9CFD5
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadFatAssLamia.Default__DryadFatAssLamia_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Autumn/Default/DryadFatAssLamia.Default__DryadFatAssLamia_C.SessionData.Lines(5).Lines
 msgctxt ",19AB0BB8417E1310F35D1D922EF9CFD5"
 msgid "My fruit was all I had to give, and she loved it. So much in fact, she let me have full access to her body in return."
-msgstr ""
+msgstr "Mi fruta era todo lo que tenía para dar y a ella le encantaba. De hecho, ella me dejó tener acceso completo a su cuerpo a cambio."
 
 #. Key:	19C50B51465308E41B608B8EAE206DA7
 #. SourceLocation:	/Game/Dialogue/Neela/SexScenes/NeelaSnakeCuddleT.Default__NeelaSnakeCuddleT_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Neela/SexScenes/NeelaSnakeCuddleT.Default__NeelaSnakeCuddleT_C.SessionData.Lines(5).Lines
 msgctxt ",19C50B51465308E41B608B8EAE206DA7"
 msgid "*Pleasurable Moaning*"
-msgstr "*Gemidos Placenteros*"
+msgstr "*Gimiendo placenteramente*"
 
 #. Key:	1A04D48D493996FF8EDD59A9DDB7C1A6
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_R01.Default__FernDefault02_R01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02_R01.Default__FernDefault02_R01_C.SessionData.Lines(0).Lines
 msgctxt ",1A04D48D493996FF8EDD59A9DDB7C1A6"
 msgid "You are the lord of this soil--or owner of Homestead in the common tongue."
-msgstr "Tú eres el/la señor/a de esta tierra... o más bien el dueño/a del Caserío en la lengua común."
+msgstr "Eres el señor de este suelo: o más bien el dueño de la Granja en la lengua común."
 
 #. Key:	1A36435A4EC979C7162B59A0A03846B6
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeDefault01.Default__BeeDefault01_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/QueenBee/Default/BeeDefault01.Default__BeeDefault01_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",1A36435A4EC979C7162B59A0A03846B6"
 msgid "Soon my nectar collection will be complete, and I can return to the Hivelands."
-msgstr ""
+msgstr "Pronto mi colección de néctar estará completa y podré regresar a las Tierras-Colmena."
 
 #. Key:	1A66A5974B5893066D25B7A93AD8BA38
 #. SourceLocation:	/Game/Dialogue/AmberMae/SexScenes/AmberMilkyF.Default__AmberMilkyF_C.SessionData.Lines(4).Lines
@@ -1313,91 +1319,91 @@ msgstr "¿Sabe bien?"
 #: /Game/Dialogue/Cassie/SexScenes/CassieButterButtF.Default__CassieButterButtF_C.SessionData.Lines(2).Lines
 msgctxt ",1A7572BD4073E9E25BE3D1889A08E000"
 msgid "Experience my amazing butter stick human! Ahhhh..."
-msgstr "¡Experimenta mi increíble barra de mantequilla humana! Ahhhh..."
+msgstr "¡Experimenta mi increíble barra de mantequilla humano! Ahhhh..."
 
 #. Key:	1A7B16814705FD34BE5FF69AB7855D7B
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiGreeting01.Default__ParvatiGreeting01_C.SessionData.LinesToFuta(3).LinesToFuta
 #: /Game/Dialogue/Parvati/Default/ParvatiGreeting01.Default__ParvatiGreeting01_C.SessionData.LinesToFuta(3).LinesToFuta
 msgctxt ",1A7B16814705FD34BE5FF69AB7855D7B"
 msgid "You seek to learn a new way to use a pleasure hole."
-msgstr "Aprendiendo una nueva forma de usar un agujero de ese placer que es tan seminal."
+msgstr "Buscas aprender una nueva forma de usar un agujero del placer."
 
 #. Key:	1AF544224BFAECD89C2CE99B8EE6EB2D
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_Formuria.Default__MirruDefault01_Formuria_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_Formuria.Default__MirruDefault01_Formuria_C.SessionData.Lines(4).Lines
 msgctxt ",1AF544224BFAECD89C2CE99B8EE6EB2D"
 msgid "It is custom for future queens to make pilgrimage to the dry lands and..."
-msgstr "Es costumbre que las futuras reinas viajen a tierras secas y..."
+msgstr "Es costumbre que las futuras reinas peregrinen a suelo firme y..."
 
 #. Key:	1B5A3D3E4B34533CC5E7E599C01B1A38
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(30).LinesToFemale
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(30).LinesToFemale
 msgctxt ",1B5A3D3E4B34533CC5E7E599C01B1A38"
 msgid "If you want to learn about how to catch @MONSTER_RACE@, head to the town located up the plateau ahead and speak to my assistant Camilla. You can't miss her... actually wait you might, she's so tiny and cute hehehe."
-msgstr "Si quieres saber cómo atrapar a @MONSTER_RACE@, dirígete al pueblo situado en la montaña de delante y habla con mi ayudante Camilla. No puedes perdértela... en realidad espera que lo hagas, es tan pequeña y linda jejeje."
+msgstr "Si quieres aprender cómo atrapar @MONSTER_RACE@, dirígete a la ciudad ubicada en la meseta más adelante y habla con mi asistente Camilla. No puedes perderla... en realidad, espera, es posible, es tan pequeña y linda jejeje."
 
 #. Key:	1B9EA938413881EEDE041F85884A4BC3
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_RL.Default__FaleneDefault01_RL_C.ResponseData(8).ResponseData.BreederPrompt
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_RL.Default__FaleneDefault01_RL_C.ResponseData(8).ResponseData.BreederPrompt
 msgctxt ",1B9EA938413881EEDE041F85884A4BC3"
 msgid "How do I learn sex positions?"
-msgstr "¿Cómo puedo aprender las posiciones sexuales?"
+msgstr "¿Cómo aprendo las posiciones sexuales?"
 
 #. Key:	1BC964AA48FF5DA907B29295607F513D
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeHadSex01.Default__BeeHadSex01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/QueenBee/Default/BeeHadSex01.Default__BeeHadSex01_C.SessionData.Lines(1).Lines
 msgctxt ",1BC964AA48FF5DA907B29295607F513D"
 msgid "Now... ahhh... ohhh..."
-msgstr ""
+msgstr "Ahora... ahhh... ohhh..."
 
 #. Key:	1BD44FF4429194137A0C4CAF227F2CA1
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_Teach.Default__ParvatiDefault01_Teach_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_Teach.Default__ParvatiDefault01_Teach_C.SessionData.Lines(1).Lines
 msgctxt ",1BD44FF4429194137A0C4CAF227F2CA1"
 msgid "Contemplate for moment while I apply some lube."
-msgstr "Contempla por un momento mientras de un poco de lubricante aplico una muda."
+msgstr "Contempla por un momento mientras aplico un poco de lubricante."
 
 #. Key:	1BE1CDD644277334F98620A99521B9DC
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_HowToSpiritForm_RL_F.Default__LeylannaDefault01_HowToSpiritForm_RL_F_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/Leylanna/Default/LeylannaDefault01_HowToSpiritForm_RL_F.Default__LeylannaDefault01_HowToSpiritForm_RL_F_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",1BE1CDD644277334F98620A99521B9DC"
 msgid "I am off to catch that variant."
-msgstr "Me voy a atrapar esa variante."
+msgstr "Me marcho para atrapar esa variante."
 
 #. Key:	1BE4B0584A935AE797E21B89CFDDEBF9
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDungeon.Default__CassieDungeon_C.SessionData.Message
 #: /Game/Dialogue/Cassie/Default/CassieDungeon.Default__CassieDungeon_C.SessionData.Message
 msgctxt ",1BE4B0584A935AE797E21B89CFDDEBF9"
 msgid "A mechanism was repaired."
-msgstr ""
+msgstr "Se reparó un mecanismo."
 
 #. Key:	1C15952A4859910408BA90BF113F067B
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraTaskFulfilled.Default__PetraTaskFulfilled_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Petra/Default/PetraTaskFulfilled.Default__PetraTaskFulfilled_C.SessionData.Lines(3).Lines
 msgctxt ",1C15952A4859910408BA90BF113F067B"
 msgid "Maybe you and I could have some fun together with this dragon!"
-msgstr ""
+msgstr "¡Quizás tú y yo podríamos divertirnos un poco con este dragón!"
 
 #. Key:	1C3E96114020C3F1D5514C998DF520B9
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeHadSex01.Default__MegaSlimeHadSex01_C.SessionData.LinesToFuta(4).LinesToFuta
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeHadSex01.Default__MegaSlimeHadSex01_C.SessionData.LinesToFuta(4).LinesToFuta
 msgctxt ",1C3E96114020C3F1D5514C998DF520B9"
 msgid "So much excitement for one day, getting sleepy."
-msgstr ""
+msgstr "Tanta emoción por un día, me está dando sueño."
 
 #. Key:	1C71641945A1D7E57E40EEB16FB66E75
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMMuchEnergy.Default__DMMuchEnergy_C.SessionData.LinesToFemale(3).LinesToFemale
 #: /Game/Dialogue/DragonMatriarch/Default/DMMuchEnergy.Default__DMMuchEnergy_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",1C71641945A1D7E57E40EEB16FB66E75"
 msgid "The lucky Titan will not expect such a massive load!"
-msgstr ""
+msgstr "¡El afortunado titán no esperará una carga tan enorme!"
 
 #. Key:	1C771B6F4DD1FF210888A5BB37418D44
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMYourChildren.Default__DMYourChildren_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/DragonMatriarch/Default/DMYourChildren.Default__DMYourChildren_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",1C771B6F4DD1FF210888A5BB37418D44"
 msgid "Many of them, but like all wild ones, they frequently phase in and out of the Void."
-msgstr ""
+msgstr "Muchos de ellos, pero como todos los silvestres, con frecuencia entran y salen del Vacío."
 
 #. Key:	1C97795346C0DCFF24FCF7965DB04AFF
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R06.Default__FaleneDefault01_R06_C.SessionData.Lines(2).Lines
@@ -1411,14 +1417,14 @@ msgstr "Luego se aparearon con las criaturas naturales del mundo. Sí... lo prim
 #: /Game/Dialogue/Leylanna/Default/LeylannaDefault01_RechargeSpiritForm.Default__LeylannaDefault01_RechargeSpiritForm_C.SessionData.Lines(2).Lines
 msgctxt ",1C9CDC1147105A3D3F0A43BB6C94695C"
 msgid "Alternatively, you can recharge your spirit form partially by engaging in sex with blessed ones."
-msgstr "Alternativamente, puedes recargar tu forma espiritual parcialmente al tener sexo con bendecidos."
+msgstr "Alternativamente, puedes recargar tu forma espiritual parcialmente teniendo sexo con bendecidos."
 
 #. Key:	1CB51DBE4D43642F605E479B59AC73A0
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.EM_HedonDungeonSwitch.Message
 #: /Game/World/Overworld.Overworld:PersistentLevel.EM_HedonDungeonSwitch.Message
 msgctxt ",1CB51DBE4D43642F605E479B59AC73A0"
 msgid "A mechanism was activated."
-msgstr ""
+msgstr "Se activó un mecanismo."
 
 #. Key:	1CCC14A74CE9A9AC038704B5BCC41068
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(7).Lines
@@ -1432,7 +1438,7 @@ msgstr "Complacida con esto, la Diosa creó mundos para que Sus creaciones resid
 #: /Game/Dialogue/Autumn/Default/DryadAboutDryads.Default__DryadAboutDryads_C.SessionData.Lines(0).Lines
 msgctxt ",1CE3D3C14381A71E21FE5C9262A5AB20"
 msgid "Once every 1200 years, the Tree of Bliss will produce a fruit."
-msgstr ""
+msgstr "Una vez cada 1200 años, el Árbol de la Dicha producirá un fruto."
 
 #. Key:	1CF80140486F2A7F4E727D8E50B64B37
 #. SourceLocation:	/Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToFemale(7).LinesToFemale
@@ -1446,21 +1452,21 @@ msgstr "*Lame* *Lame*"
 #: /Game/Dialogue/Fesssi/Default/FesssiWantTongue.Default__FesssiWantTongue_C.SessionData.Lines(2).Lines
 msgctxt ",1D02B0E54A3658E393B6FFB20782E4EC"
 msgid "Come closer, this is going make you feel sssso good!"
-msgstr ""
+msgstr "¡Acércate, esto te hará sentir tan bien!"
 
 #. Key:	1D0542A344504517417F3A8F68348BA3
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowTaskFulfilled.Default__WidowTaskFulfilled_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Widow/Default/WidowTaskFulfilled.Default__WidowTaskFulfilled_C.SessionData.Lines(0).Lines
 msgctxt ",1D0542A344504517417F3A8F68348BA3"
 msgid "Oh my sweet little elf... I will cherish you forever."
-msgstr ""
+msgstr "Oh, mi dulce elfa... te apreciaré por siempre."
 
 #. Key:	1D0919E245DEEDE87FD63C8852480108
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault02.Default__CamillaDefault02_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaDefault02.Default__CamillaDefault02_C.SessionData.Lines(1).Lines
 msgctxt ",1D0919E245DEEDE87FD63C8852480108"
 msgid "I wonder what she brought me this time."
-msgstr ""
+msgstr "Me pregunto qué me trajo esta vez."
 
 #. Key:	1D44F1774A53A6682BEE0BB2C13C2732
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDefault01.Default__CassieDefault01_C.SessionData.Lines(0).Lines
@@ -1481,42 +1487,42 @@ msgstr "Mi pequeña y adorable asistente Camilla también puede ayudarte."
 #: /Game/Dialogue/Autumn/Default/DryadFatAssLamia.Default__DryadFatAssLamia_C.SessionData.Lines(8).Lines
 msgctxt ",1D5D92BD4B78C422411CC1AB0BD34552"
 msgid "Poor Fesssi is probably running low on bosom cherries by now!"
-msgstr ""
+msgstr "¡La pobre Fesssi probablemente ya se esté quedando sin cerezas de seno!"
 
 #. Key:	1D81ECE4468C6B5A5BE467964A7CFE43
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03_R02_R01.Default__FernDefault03_R02_R01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03_R02_R01.Default__FernDefault03_R02_R01_C.SessionData.Lines(0).Lines
 msgctxt ",1D81ECE4468C6B5A5BE467964A7CFE43"
 msgid "Sadly I can no longer help you harvest fluids from wild @MONSTER_RACE@."
-msgstr "Lamentablemente, ya no puedo ayudarte a recolectar fluidos silvestres de @MONSTER_RACE@."
+msgstr "Lamentablemente, ya no puedo ayudarte a recolectar fluidos de @MONSTER_RACE@ silvestres."
 
 #. Key:	1D9FC9EA4EBB827C25C418BF316240BB
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleDragonMatriarch.Default__KybeleDragonMatriarch_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Kybele/Default/KybeleDragonMatriarch.Default__KybeleDragonMatriarch_C.SessionData.Lines(4).Lines
 msgctxt ",1D9FC9EA4EBB827C25C418BF316240BB"
 msgid "This lust is driving me mad human! You have no idea."
-msgstr ""
+msgstr "¡Esta lujuria me está volviendo loca humano! No tienes idea."
 
 #. Key:	1DA742CA40AC6A3A7EC5B6834EEA93B8
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_AboutMusic.Default__RomyDefault01_AboutMusic_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Romy/Default/RomyDefault01_AboutMusic.Default__RomyDefault01_AboutMusic_C.SessionData.Lines(2).Lines
 msgctxt ",1DA742CA40AC6A3A7EC5B6834EEA93B8"
 msgid "Mermaids are unique Formurians, we hear frequencies most others cannot."
-msgstr "Las sirenas somos Formurianas únicas, podemos escuchar frecuencias que los demás no pueden."
+msgstr "Las sirenas son Formurianas únicas, escuchamos frecuencias que la mayoría no pueden."
 
 #. Key:	1DB7FBDD4A80D06FCF9019965B0E0008
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeHadSex01.Default__AmberMaeHadSex01_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/AmberMae/Default/AmberMaeHadSex01.Default__AmberMaeHadSex01_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",1DB7FBDD4A80D06FCF9019965B0E0008"
 msgid "Ye drank so much for a wee lass!"
-msgstr ""
+msgstr "¡Bebihte musho para una mosa pequeñita!"
 
 #. Key:	1E0C491A43E8C2F67FA568B20B5A6743
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_Teach.Default__ParvatiDefault01_Teach_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_Teach.Default__ParvatiDefault01_Teach_C.SessionData.Lines(5).Lines
 msgctxt ",1E0C491A43E8C2F67FA568B20B5A6743"
 msgid "Pay close attention to my form, and learn you should."
-msgstr "Presta mucha atención a mi forma y aprenderás como ningún quien."
+msgstr "Presta mucha atención a mi forma, y aprende lo que debas."
 
 #. Key:	1E23F2524EB7DC68DC07EC92E709C65F
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernGreeting03.Default__FernGreeting03_C.SessionData.LinesToFuta(4).LinesToFuta
@@ -1530,7 +1536,7 @@ msgstr "Deslízate aquí conmigo, mi cuerpo es sedoso y lleno de dulce néctar. 
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeVerySad.Default__MegaSlimeVerySad_C.SessionData.Lines(4).Lines
 msgctxt ",1E2A2FC04EF0D4BCC92A3A911348230A"
 msgid "I thought... finally... I would have friends again..."
-msgstr ""
+msgstr "Pensé que... finalmente... volvería a tener amigos..."
 
 #. Key:	1E3AD95641E1D41AAA9115A007EDC28A
 #. SourceLocation:	/Game/Dialogue/Cassie/SexScenes/CassieSplintersT.Default__CassieSplintersT_C.SessionData.Lines(2).Lines
@@ -1544,7 +1550,7 @@ msgstr "¡Tanto placer! Ahhh..."
 #: /Game/Dialogue/Emissary/Default/EmissaryGreeting01.Default__EmissaryGreeting01_C.SessionData.Lines(5).Lines
 msgctxt ",1E80A3A048E90BE3C26622BC4F2230F7"
 msgid "Bring them to me so that the Goddess can be reunited with her children. You shall be rewarded with the crystalized cum of the Goddess Herself."
-msgstr "Traemelos para que la Diosa pueda reunirse con sus hijos. Serás recompensado con el semen cristalizado de la Diosa."
+msgstr "Tráemelos para que la Diosa pueda reunirse con sus hijos. Serás recompensado con el semen cristalizado de la propia Diosa."
 
 #. Key:	1E9E8C004AF398F32ECD97B66BFC3438
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01_RL_M.Default__FernDefault01_RL_M_C.ResponseData(2).ResponseData.BreederPrompt
@@ -1558,42 +1564,42 @@ msgstr "¿Qué puedes hacer?"
 #: /Game/Dialogue/Cassie/Default/CassieHadSex01.Default__CassieHadSex01_C.SessionData.LinesToFemale(5).LinesToFemale
 msgctxt ",1EB41EAD40088E3874A4E0A7F3C437DC"
 msgid "I need to release again already... you humans have it so easy."
-msgstr ""
+msgstr "Necesito descargar otra vez de nuevo... vosotros los humanos lo tenéis muy fácil."
 
 #. Key:	1EB7986D40F6A7B90EB5ADB781104A11
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_RL.Default__LeylannaDefault01_RL_C.ResponseData(6).ResponseData.BreederPrompt
 #: /Game/Dialogue/Leylanna/Default/LeylannaDefault01_RL.Default__LeylannaDefault01_RL_C.ResponseData(6).ResponseData.BreederPrompt
 msgctxt ",1EB7986D40F6A7B90EB5ADB781104A11"
 msgid "How do I access the area under the temple?"
-msgstr ""
+msgstr "¿Cómo accedo al área debajo del templo?"
 
 #. Key:	1EBEB6D94E78F0B72A365EAD5BD52461
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeHadSex01.Default__MegaSlimeHadSex01_C.SessionData.LinesToFuta(5).LinesToFuta
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeHadSex01.Default__MegaSlimeHadSex01_C.SessionData.LinesToFuta(5).LinesToFuta
 msgctxt ",1EBEB6D94E78F0B72A365EAD5BD52461"
 msgid "*Yawn*"
-msgstr ""
+msgstr "*Bosteza*"
 
 #. Key:	1EC1BDF8474319018DE2CBA3602448F1
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryBlessedInquiry01_R01.Default__EmissaryBlessedInquiry01_R01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryBlessedInquiry01_R01.Default__EmissaryBlessedInquiry01_R01_C.SessionData.Lines(1).Lines
 msgctxt ",1EC1BDF8474319018DE2CBA3602448F1"
 msgid "I have overcome all desire and emotion. Such is a requirement to become an archangel of the Goddess, for she wants nothing to distract me from my task."
-msgstr "He superado todo deseo y emoción. Lo cual es un requisito para convertirse en un arcángel de la Diosa, porque ella no quiere que nada me distraiga de mi tarea."
+msgstr "He superado todo deseo y emoción. Tal es un requisito para convertirme en arcángel de la Diosa, porque ella no quiere que nada me distraiga de mi tarea."
 
 #. Key:	1EC307F7473EF201F5433B8DCF40B401
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeTaskFulfilled.Default__BeeTaskFulfilled_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/QueenBee/Default/BeeTaskFulfilled.Default__BeeTaskFulfilled_C.SessionData.Lines(1).Lines
 msgctxt ",1EC307F7473EF201F5433B8DCF40B401"
 msgid "My girls are already hard at work harvesting them."
-msgstr ""
+msgstr "Mis chicas ya están trabajando duro para cosecharlas."
 
 #. Key:	1EC6ED68400A0EEDE25F8BA9CAB37F8E
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchHaveKeystone2.Default__MonarchHaveKeystone2_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Monarch/Default/MonarchHaveKeystone2.Default__MonarchHaveKeystone2_C.SessionData.Lines(2).Lines
 msgctxt ",1EC6ED68400A0EEDE25F8BA9CAB37F8E"
 msgid "T-t-thank you human!"
-msgstr ""
+msgstr "¡G-g-gracias humano!"
 
 #. Key:	1EDF51EB413B2D360FB8C6B5AD2E62ED
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_Forgot_RL.Default__ParvatiDefault01_Forgot_RL_C.ResponseData(1).ResponseData.BreederPrompt
@@ -1607,28 +1613,28 @@ msgstr "¡Mariposa!"
 #: /Game/World/Events/EM_Keystone.Default__EM_Keystone_C.ActivateMessage
 msgctxt ",1F1CAEA0490338B83DFFE19139FBE3C2"
 msgid "Take Keystone"
-msgstr ""
+msgstr "Toma la piedra-llave"
 
 #. Key:	1F2830D14059782BF943B5BD1F8A5942
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleTaskFulfilled.Default__KybeleTaskFulfilled_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/Kybele/Default/KybeleTaskFulfilled.Default__KybeleTaskFulfilled_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",1F2830D14059782BF943B5BD1F8A5942"
 msgid "Ah such a glorious mate you have given me!"
-msgstr ""
+msgstr "¡Ah, una pareja tan gloriosa que me has dado!"
 
 #. Key:	1F39C5E04BCD3150F989F3994E948682
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeHaveKeystone.Default__BeeHaveKeystone_C.SessionData.Lines(7).Lines
 #: /Game/Dialogue/QueenBee/Default/BeeHaveKeystone.Default__BeeHaveKeystone_C.SessionData.Lines(7).Lines
 msgctxt ",1F39C5E04BCD3150F989F3994E948682"
 msgid "We shall continue to wait for our savior. Someone who is one with the soil itself, a true maiden of nature."
-msgstr ""
+msgstr "Seguiremos esperando a nuestra salvadora. Alguien que es una con el suelo mismo, una verdadera doncella de la naturaleza."
 
 #. Key:	1F41165A452FBA12C2CF81A71C1DE5AC
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadFatAssLamia.Default__DryadFatAssLamia_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Autumn/Default/DryadFatAssLamia.Default__DryadFatAssLamia_C.SessionData.Lines(1).Lines
 msgctxt ",1F41165A452FBA12C2CF81A71C1DE5AC"
 msgid "I wandered into that cave at the far end of the pastures, and that's where I met her."
-msgstr ""
+msgstr "Entré en esa cueva en el extremo más alejado de los pastos, y ahí es donde la conocí."
 
 #. Key:	1FA8B3E8448F66CB1045EAB3F54ADE2B
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDefault01_Meow.Default__CassieDefault01_Meow_C.SessionData.LinesToFemale(5).LinesToFemale
@@ -1639,24 +1645,25 @@ msgstr "¿Podrías... miau... ayudar a la pobre Cassie con este problema?"
 
 #. Key:	1FC53FEF4A2414ADEC40FA84C1B8848D
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(16 - Value).TraitIcons.HelpText
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(16 - Value).TraitIcons.HelpText
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(16 -
+#: Value).TraitIcons.HelpText
 msgctxt ",1FC53FEF4A2414ADEC40FA84C1B8848D"
 msgid "Kindhearted: Grants twice as much XP to mates but only receives half as much."
-msgstr "Amable: Otorga el doble de EXP a las/os compañeras/os pero sólo recibe la mitad."
+msgstr "Bondadoso: otorga el doble de EXP a los compañeros pero sólo recibe la mitad."
 
 #. Key:	1FEA2992437543C7A8B378B9046E4AE5
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieHadSex01.Default__CassieHadSex01_C.SessionData.LinesToFemale(2).LinesToFemale
 #: /Game/Dialogue/Cassie/Default/CassieHadSex01.Default__CassieHadSex01_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",1FEA2992437543C7A8B378B9046E4AE5"
 msgid "Such sweet release for Cassie!"
-msgstr ""
+msgstr "¡Qué dulce descarga para Cassie!"
 
 #. Key:	20149E5046FF32B65667FBA243C9BED4
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_HowToSpiritForm.Default__LeylannaDefault01_HowToSpiritForm_C.SessionData.LinesToFemale(2).LinesToFemale
 #: /Game/Dialogue/Leylanna/Default/LeylannaDefault01_HowToSpiritForm.Default__LeylannaDefault01_HowToSpiritForm_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",20149E5046FF32B65667FBA243C9BED4"
 msgid "Catch a female Foxen if you have not done so, and then return to me. We will then make love and form a covenant."
-msgstr "Atrapa una Zorro hembra si aún no lo has hecho, y luego regresa a mí. Entonces haremos el amor y formaremos un pacto."
+msgstr "Atrapa una hembra foxen si aún no lo has hecho, y luego vuelve a mí. Luego haremos el amor y formaremos un pacto."
 
 #. Key:	201B358D4CE5E4D894910C97F98AA433
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_EnlightenedOne.Default__NeelaDefault01_EnlightenedOne_C.SessionData.Lines(5).Lines
@@ -1677,56 +1684,56 @@ msgstr "Caseta de Vulwargs"
 #: /Game/Dialogue/Fern/SexScenes/FernMilk_01.Default__FernMilk_01_C.SessionData.Lines(6).Lines
 msgctxt ",2087D4A34628AB4B8A51C4827BDC8AA0"
 msgid "Fern hope this pleases mastah greatly..."
-msgstr "Helecho espera que esto le guste mucho al maeztra..."
+msgstr "Fern espera que esto complazca mucho a Mastah..."
 
 #. Key:	20A752DD41AFEBDD2A4852BD029B894E
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(2).LinesToFemale
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",20A752DD41AFEBDD2A4852BD029B894E"
 msgid "You have just become @WORLD_NAME@'s newest resident!"
-msgstr "¡Acabas de convertirte en la nueva residente de @WORLD_NAME@!"
+msgstr "¡Te acabas de convertir en el residente más nuevo de @WORLD_NAME@!"
 
 #. Key:	20BEB0FA47066DBAB732F68642C6BAC3
 #. SourceLocation:	/Game/Breeding/Positions/Test5.Default__Test5_C.SessionData.PositionName
 #: /Game/Breeding/Positions/Test5.Default__Test5_C.SessionData.PositionName
 msgctxt ",20BEB0FA47066DBAB732F68642C6BAC3"
 msgid "Test5"
-msgstr "Test5"
+msgstr ""
 
 #. Key:	20D02E2F4C47F242698FA2B18D41F1BE
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcTribeSucks.Default__OrcTribeSucks_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcTribeSucks.Default__OrcTribeSucks_C.SessionData.Lines(2).Lines
 msgctxt ",20D02E2F4C47F242698FA2B18D41F1BE"
 msgid "Need mighty fertile mates to make strong daughters."
-msgstr ""
+msgstr "Necesito poderosos compañeros fértiles para hacer hijas fuertes."
 
 #. Key:	20D5FBB14DDFF45AA9B224862543CAFD
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadGreeting01.Default__DryadGreeting01_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Autumn/Default/DryadGreeting01.Default__DryadGreeting01_C.SessionData.Lines(3).Lines
 msgctxt ",20D5FBB14DDFF45AA9B224862543CAFD"
 msgid "Sweet and juicy... oh!"
-msgstr ""
+msgstr "Dulce y jugosa... ¡oh!"
 
 #. Key:	20FEDBA24B5C623E162B85A3D6ACF514
 #. SourceLocation:	/Game/Ranch/Upgrades/StarfallenMonolith.Default__StarfallenMonolith_C.Upgrade.DisplayName
 #: /Game/Ranch/Upgrades/StarfallenMonolith.Default__StarfallenMonolith_C.Upgrade.DisplayName
 msgctxt ",20FEDBA24B5C623E162B85A3D6ACF514"
 msgid "Starfallen Monolith"
-msgstr "Monolito de Caídos de las Estrellas"
+msgstr "Monolito de los Starfallens"
 
 #. Key:	210B50F94F9FCF3416F33C880389C277
 #. SourceLocation:	/Game/Dialogue/Blossom/Default/BlossomDefault01_R01.Default__BlossomDefault01_R01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Blossom/Default/BlossomDefault01_R01.Default__BlossomDefault01_R01_C.SessionData.Lines(1).Lines
 msgctxt ",210B50F94F9FCF3416F33C880389C277"
 msgid "With Mastah's body fluid... mother made me. Still sapling... want fluidsss!"
-msgstr "Con los fluidos corporales de Maeztra... madre me hizo. Todavía retoño... ¡quiero fluidossss!"
+msgstr "Con los fluidos corporales de Mastah... madre me hizo. Todavía retoño... ¡quiero fluidosss!"
 
 #. Key:	21152EB846587AFAAB8809931357BD5F
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowSpiders.Default__WidowSpiders_C.SessionData.Lines(7).Lines
 #: /Game/Dialogue/Widow/Default/WidowSpiders.Default__WidowSpiders_C.SessionData.Lines(7).Lines
 msgctxt ",21152EB846587AFAAB8809931357BD5F"
 msgid "Those sweet little magical creatures taste so good... even if they run dry too quickly."
-msgstr ""
+msgstr "Esas pequeñas y dulces criaturas mágicas saben tan bien... incluso si se secan demasiado rápido."
 
 #. Key:	2126F09F4B710631419B5DABA6528521
 #. SourceLocation:	/Game/Dialogue/Fern/SexScenes/FernMilk_01.Default__FernMilk_01_C.SessionData.Lines(5).Lines
@@ -1740,42 +1747,43 @@ msgstr "*Chupa* *Chupa*"
 #: /Game/Dialogue/Fern/DefaultP3/FernHadSex03.Default__FernHadSex03_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",212DDF504562E903B436369721416CBC"
 msgid "This flower body is great, I hope you enjoyed it too master."
-msgstr ""
+msgstr "Este cuerpo de flor es genial, espero que lo hayas disfrutado también Master."
 
 #. Key:	213C826F44FC31430F08EE8F97663F9A
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMGreeting01.Default__DMGreeting01_C.SessionData.Lines(6).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMGreeting01.Default__DMGreeting01_C.SessionData.Lines(6).Lines
 msgctxt ",213C826F44FC31430F08EE8F97663F9A"
 msgid "Go play with the wild dragons, I'm sure they would love to get to know you better."
-msgstr ""
+msgstr "Ve a jugar con los dragones silvestres, estoy seguro de que les encantaría conocerte mejor."
 
 #. Key:	214776AF4C822D0B66293DB4BC1D955C
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiDefault03_RL_F.Default__FesssiDefault03_RL_F_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/Fesssi/Default/FesssiDefault03_RL_F.Default__FesssiDefault03_RL_F_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",214776AF4C822D0B66293DB4BC1D955C"
 msgid "How long have you been stuck?"
-msgstr ""
+msgstr "¿Cuánto tiempo has estado atascada?"
 
 #. Key:	217058F6486D81B1085B329585491A13
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(14 - Value).TraitIcons.HelpText
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(14 - Value).TraitIcons.HelpText
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(14 -
+#: Value).TraitIcons.HelpText
 msgctxt ",217058F6486D81B1085B329585491A13"
 msgid "Hornball: Loses 35% less lust during breeding."
-msgstr "Pervertida/o: Pierde un 35% menos de lujuria durante la reproducción."
+msgstr "Pervertido: pierde un 35% menos de lujuria durante la reproducción."
 
 #. Key:	219DB5F74ED7CB5AAC90FA94BF883682
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMGreeting01.Default__DMGreeting01_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMGreeting01.Default__DMGreeting01_C.SessionData.Lines(2).Lines
 msgctxt ",219DB5F74ED7CB5AAC90FA94BF883682"
 msgid "How interesting... *yawn*"
-msgstr ""
+msgstr "Que interesante... *bosteza*"
 
 #. Key:	21A08FF347BC7DE708B258BAD0F4BEF3
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(22).LinesToMale
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(22).LinesToMale
 msgctxt ",21A08FF347BC7DE708B258BAD0F4BEF3"
 msgid "You will only catch wild @MONSTER_RACE@, which have roughly the intelligence of animals."
-msgstr "Sólo atraparás @MONSTER_RACE@ salvajes, que tienen más o menos la inteligencia de los animales."
+msgstr "Solo atraparás @MONSTER_RACE@ silvestres, que tienen aproximadamente la inteligencia de animales."
 
 #. Key:	21D4E1714A491D7CAA40E99AA6D354E8
 #. SourceLocation:	/Game/Breeding/Positions/ReverseCowgirl.Default__ReverseCowgirl_C.SessionData.PositionName
@@ -1789,14 +1797,14 @@ msgstr "Vaquera Inversa"
 #: /Game/Dialogue/Leylanna/Default/LeylannaOldTempleDungeon1.Default__LeylannaOldTempleDungeon1_C.SessionData.Lines(2).Lines
 msgctxt ",21F3FE504159303A7B601594A76A9D1D"
 msgid "Have you come here to make love with me?"
-msgstr ""
+msgstr "¿Has venido aquí a hacer el amor conmigo?"
 
 #. Key:	221EB3E64F8474A44715CA969A344204
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchHaveKeystone.Default__MonarchHaveKeystone_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Monarch/Default/MonarchHaveKeystone.Default__MonarchHaveKeystone_C.SessionData.Lines(3).Lines
 msgctxt ",221EB3E64F8474A44715CA969A344204"
 msgid "The wild @MONSTER_RACE@ around here are so big and s-s-strong."
-msgstr ""
+msgstr "Los @MONSTER_RACE@ silvestres por aquí son tan grandes y f-f-fuertes."
 
 #. Key:	2232F66F4BB565CC2A75538123292067
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(19).LinesToMale
@@ -1810,28 +1818,28 @@ msgstr "¡Eso hace tu trabajo mucho más fácil!"
 #: /Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFuta(1).LinesToFuta
 msgctxt ",2262A6F64B6CB59E0A4D93A13609ED6A"
 msgid "Human cum tastes just like I dreamt it would!"
-msgstr ""
+msgstr "¡El semen humano sabe exactamente como lo había soñado!"
 
 #. Key:	22657D9344EA0FA193ED4BB66564D308
 #. SourceLocation:	/Game/Characters/Procedural/Variants/Risu/Harvest/RisuHarvest.Default__RisuHarvest_C.Harvest.Description
 #: /Game/Characters/Procedural/Variants/Risu/Harvest/RisuHarvest.Default__RisuHarvest_C.Harvest.Description
 msgctxt ",22657D9344EA0FA193ED4BB66564D308"
 msgid "Risu body fluids."
-msgstr ""
+msgstr "Fluidos corporales de Risu."
 
 #. Key:	226CAB5E40652DCF455036A02B7F0BEF
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyGreeting01.Default__RomyGreeting01_C.SessionData.LinesGrungy(3).LinesGrungy
 #: /Game/Dialogue/Romy/Default/RomyGreeting01.Default__RomyGreeting01_C.SessionData.LinesGrungy(3).LinesGrungy
 msgctxt ",226CAB5E40652DCF455036A02B7F0BEF"
 msgid "Human, look how dirty you have become. No, no, this won't do."
-msgstr "Humana, mira lo pervertida que te has vuelto. No, no, esto no servirá."
+msgstr "Humano, mira lo sucio que te has vuelto. No, no, esto no servirá."
 
 #. Key:	22721E7243A0F89426773BB6C47E987A
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03_R02.Default__FernDefault03_R02_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03_R02.Default__FernDefault03_R02_C.SessionData.Lines(2).Lines
 msgctxt ",22721E7243A0F89426773BB6C47E987A"
 msgid "We can have a lot of fun with my flower body! I have wanted to make love with you Master..."
-msgstr "Podemos divertirnos mucho con mi cuerpo floral! He querido hacer el amor contigo, Maestra..."
+msgstr "¡Podemos divertirnos mucho con mi cuerpo de flor! He querido hacer el amor contigo, Master..."
 
 #. Key:	22A642E14AB14A866F4A749782B623B0
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToFemale(3).LinesToFemale
@@ -1845,56 +1853,56 @@ msgstr "Ahhh... sí. Mis deseos están aumentando, ¿no te complacerás con mi c
 #: /Game/World/Overworld.Overworld:PersistentLevel.BovaurShed.ManageActionMessage
 msgctxt ",22DBDC6341C9C5D8D427F0A18A87ED40"
 msgid "Manage your Bovaur"
-msgstr "Gestiona tus Bouvaur"
+msgstr "Gestiona tus Bovaurs"
 
 #. Key:	233ACAAA4B9A80E38B57579ACF78F5DF
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaOldTempleDungeon1.Default__LeylannaOldTempleDungeon1_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Leylanna/Default/LeylannaOldTempleDungeon1.Default__LeylannaOldTempleDungeon1_C.SessionData.Lines(0).Lines
 msgctxt ",233ACAAA4B9A80E38B57579ACF78F5DF"
 msgid "Sooooo very high human."
-msgstr ""
+msgstr "Taaaaan muy alto humano."
 
 #. Key:	2341F9304FDFA81B77486F840A0E749C
 #. SourceLocation:	/Game/Ranch/Upgrades/MuttHut.Default__MuttHut_C.Upgrade.Description
 #: /Game/Ranch/Upgrades/MuttHut.Default__MuttHut_C.Upgrade.Description
 msgctxt ",2341F9304FDFA81B77486F840A0E749C"
 msgid "This allows you to breed and store all hybrids."
-msgstr "Esto te permite reproducir y almacenar todas las híbridas."
+msgstr "Esto te permite criar y almacenar todos los Híbridos."
 
 #. Key:	235E743740D1DB78A77472BFB5D5C1A8
 #. SourceLocation:	/Game/Ranch/Upgrades/SylvanTreehouse.Default__SylvanTreehouse_C.Upgrade.Description
 #: /Game/Ranch/Upgrades/SylvanTreehouse.Default__SylvanTreehouse_C.Upgrade.Description
 msgctxt ",235E743740D1DB78A77472BFB5D5C1A8"
 msgid "This allows you to catch and store all variants of Sylvan."
-msgstr "Esto te permite capturar y almacenar todas las variantes de Silvestres."
+msgstr "Esto le permite capturar y almacenar todas las variantes de Silvanos."
 
 #. Key:	236BBFF14A62BA287C86179E8ACDDCA9
 #. SourceLocation:	/Game/Dialogue/Fern/SexScenes/FernCum_01.Default__FernCum_01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Fern/SexScenes/FernCum_01.Default__FernCum_01_C.SessionData.Lines(0).Lines
 msgctxt ",236BBFF14A62BA287C86179E8ACDDCA9"
 msgid "Mastah... your dick so big! Many fluids will it give me."
-msgstr "Maeztra... ¡tu polla tan grande! Muchos fluidos me dará."
+msgstr "¡Mastah... tu pene es tan grande! Me dará muchos fluidos."
 
 #. Key:	2373050C45C9AA9783D038B170402B88
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_R02_R01.Default__FernDefault02_R02_R01_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02_R02_R01.Default__FernDefault02_R02_R01_C.SessionData.Lines(2).Lines
 msgctxt ",2373050C45C9AA9783D038B170402B88"
 msgid "You could... always keep giving me your fluids. I will reward you with intense pleasure and that shiny stuff you like so much."
-msgstr "Podrías... seguir dándome tus fluidos. Te recompensaré con un intenso placer y esas cosas brillantes que tanto te gusta."
+msgstr "Podrías... siempre seguir dándome tus fluidos. Te recompensaré con un placer intenso y esas cosas brillantes que tanto te gustan."
 
 #. Key:	239678F6481C22C297A01BAF6A94E397
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy_RL_T.Default__MirruDefault01_BodySexToy_RL_T_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy_RL_T.Default__MirruDefault01_BodySexToy_RL_T_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",239678F6481C22C297A01BAF6A94E397"
 msgid "I want to experience Kraken vagina..."
-msgstr "Quiero experimentar vagina Kraken..."
+msgstr "Quiero experimentar la vagina kraken..."
 
 #. Key:	23A18A464B463F98B66625813C8B1459
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiStuck.Default__FesssiStuck_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiStuck.Default__FesssiStuck_C.SessionData.Lines(3).Lines
 msgctxt ",23A18A464B463F98B66625813C8B1459"
 msgid "She should have known of the gluttony inherent within serpentssss."
-msgstr ""
+msgstr "Ella debería haber sabido de la glotonería inherente en las serpientessss."
 
 #. Key:	23BDA20D4CE368D882C153A4AF960F3B
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_Leylanna.Default__EmissaryDefault01_Leylanna_C.SessionData.Lines(5).Lines
@@ -1908,70 +1916,71 @@ msgstr "La hace actuar... bastante extraña."
 #: /Game/Dialogue/Fern/DefaultP2/FernGreeting02.Default__FernGreeting02_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",23E7B88A464A51712A11B1A07FE361A3"
 msgid "I am a growing Alraune, perhaps you have fluids to spare?"
-msgstr "Soy una Mandrágora en crecimiento, ¿tal vez te sobren fluidos?"
+msgstr "Soy una alraune en crecimiento, ¿tal vez te sobran fluidos?"
 
 #. Key:	23F2F9554DE5B355FC5887BC91313DC2
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcBrashDumb.Default__OrcBrashDumb_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcBrashDumb.Default__OrcBrashDumb_C.SessionData.Lines(3).Lines
 msgctxt ",23F2F9554DE5B355FC5887BC91313DC2"
 msgid "*Snarl*"
-msgstr ""
+msgstr "*Gruñe*"
 
 #. Key:	240A4A634DB7018141BD60B5A94B716C
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeDefault01_Accent.Default__AmberMaeDefault01_Accent_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeDefault01_Accent.Default__AmberMaeDefault01_Accent_C.SessionData.Lines(0).Lines
 msgctxt ",240A4A634DB7018141BD60B5A94B716C"
 msgid "Oh no! Me hopes ye can understand."
-msgstr "¡Oh no! Espero que puedah entendehlo."
+msgstr "¡Oh, no! Espero que lo entiendah."
 
 #. Key:	240E4A09421F907A3C7714B84A5BF051
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiHowLong.Default__FesssiHowLong_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiHowLong.Default__FesssiHowLong_C.SessionData.Lines(1).Lines
 msgctxt ",240E4A09421F907A3C7714B84A5BF051"
 msgid "At first I was annoyed, but then it became fun... hiss!"
-msgstr ""
+msgstr "Al principio estaba molesta, pero luego se volvió divertido... ¡sss!"
 
 #. Key:	244693F347E948FB69765A8A6CFF9E08
 #. SourceLocation:	/Game/Dialogue/Fern/SexScenes/FernCum_01.Default__FernCum_01_C.SessionData.Lines(6).Lines
 #: /Game/Dialogue/Fern/SexScenes/FernCum_01.Default__FernCum_01_C.SessionData.Lines(6).Lines
 msgctxt ",244693F347E948FB69765A8A6CFF9E08"
 msgid "Ohhh... mastah... ahhh... taste your fluids please. Fern feels them coming..."
-msgstr "Ohhh... maeztra... ahhh... saca tus fluidos por favor. Helecho los siente venir..."
+msgstr "Ohhh... Mastah... ahhh... el sabor de tus fluidos por favor. Fern los siente venir..."
 
 #. Key:	244C8E5D4982978D00C8C4AD305CB067
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcDefault03_RL.Default__OrcDefault03_RL_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/OrcChief/Default/OrcDefault03_RL.Default__OrcDefault03_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",244C8E5D4982978D00C8C4AD305CB067"
 msgid "I'm still not fixing your damn gate."
-msgstr ""
+msgstr "Todavía no estoy arreglando tu maldito portón."
 
 #. Key:	245BCC9A45EB7B47E46534A6AE4EE9CF
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowDefault01.Default__WidowDefault01_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Widow/Default/WidowDefault01.Default__WidowDefault01_C.SessionData.Lines(3).Lines
 msgctxt ",245BCC9A45EB7B47E46534A6AE4EE9CF"
 msgid "In exchange for your fluids that is... oh how delicious you look."
-msgstr ""
+msgstr "A cambio de tus fluidos eso es... oh qué delicioso te ves."
 
 #. Key:	24679A7147C3C737DE65DBA1F7CE9FAB
 #. SourceLocation:	/Game/Ranch/Upgrades/NekoCondo.Default__NekoCondo_C.Upgrade.DisplayName
 #: /Game/Ranch/Upgrades/NekoCondo.Default__NekoCondo_C.Upgrade.DisplayName
 msgctxt ",24679A7147C3C737DE65DBA1F7CE9FAB"
 msgid "Neko Condo"
-msgstr "Árbol Rascador de Nekos"
+msgstr "Condominio de Nekos"
 
 #. Key:	249E987842C35A9986491A967E86BEC3
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(21 - Value).TraitIcons.HelpText
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(21 - Value).TraitIcons.HelpText
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(21 -
+#: Value).TraitIcons.HelpText
 msgctxt ",249E987842C35A9986491A967E86BEC3"
 msgid "Stoic: Increases maximum lust by 20%."
-msgstr "Estoica/o: Aumenta la lujuria máxima en un 20%."
+msgstr "Estoico: aumenta la lujuria máxima en un 20%."
 
 #. Key:	2501139743DDD3B68A226FB25573A87A
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadDefault01_RL.Default__DryadDefault01_RL_C.ResponseData(5).ResponseData.BreederPrompt
 #: /Game/Dialogue/Autumn/Default/DryadDefault01_RL.Default__DryadDefault01_RL_C.ResponseData(5).ResponseData.BreederPrompt
 msgctxt ",2501139743DDD3B68A226FB25573A87A"
 msgid "Yum... can I have the keystone now?"
-msgstr ""
+msgstr "Hum... ¿puedo tener la piedra-llave ahora?"
 
 #. Key:	25085F2F407D8D979CA1B39E030426E5
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_RL.Default__LeylannaDefault01_RL_C.ResponseData(3).ResponseData.BreederPrompt
@@ -1985,217 +1994,219 @@ msgstr "Cambiar mi forma espiritual."
 #: /Game/Dialogue/Monarch/Default/MonarchPrettyButterfly.Default__MonarchPrettyButterfly_C.SessionData.Lines(4).Lines
 msgctxt ",253A15E2499151C9550E6A80742E78B6"
 msgid "We love it, but every butterfly's dream is... w-w-well..."
-msgstr ""
+msgstr "Nos encanta, pero el sueño de toda mariposa es... b-b-bueno..."
 
 #. Key:	25580E6145BF9216DA12689E0973DCD0
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleAnyMeans.Default__KybeleAnyMeans_C.SessionData.LinesToFemale(2).LinesToFemale
 #: /Game/Dialogue/Kybele/Default/KybeleAnyMeans.Default__KybeleAnyMeans_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",25580E6145BF9216DA12689E0973DCD0"
 msgid "I am a well trained centaur warmaiden, you would not stand a chance."
-msgstr ""
+msgstr "Soy una doncella de guerra centauro bien entrenada, no tendrías ninguna posibilidad."
 
 #. Key:	255D031B4240EE3EF4E557AE245DE751
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiHadSex01.Default__FesssiHadSex01_C.SessionData.LinesToFuta(1).LinesToFuta
 #: /Game/Dialogue/Fesssi/Default/FesssiHadSex01.Default__FesssiHadSex01_C.SessionData.LinesToFuta(1).LinesToFuta
 msgctxt ",255D031B4240EE3EF4E557AE245DE751"
 msgid "I'm certain you found it quite pleasurable."
-msgstr ""
+msgstr "Estoy seguro de que te pareció bastante placentero."
 
 #. Key:	2562C2DF4A1E2558709AB9BF6D7F7974
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaHadSex01.Default__NeelaHadSex01_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Neela/Default/NeelaHadSex01.Default__NeelaHadSex01_C.SessionData.Lines(3).Lines
 msgctxt ",2562C2DF4A1E2558709AB9BF6D7F7974"
 msgid "You don't have to run off now do you? Stay awhile... and..."
-msgstr ""
+msgstr "No tienes que salir corriendo ahora, ¿verdad? Quédate un rato... y..."
 
 #. Key:	25A665DA43117878012D26AE56A39F23
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_AboutLamias.Default__NeelaDefault01_AboutLamias_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_AboutLamias.Default__NeelaDefault01_AboutLamias_C.SessionData.Lines(5).Lines
 msgctxt ",25A665DA43117878012D26AE56A39F23"
 msgid "Maybe if you see my fat ass younger sister, she could tell you more."
-msgstr ""
+msgstr "Tal vez si ves al culo gordo de mi hermana menor, ella podría contarte más."
 
 #. Key:	25D626114231ECB08961C6AB69737AE1
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_UpHere.Default__RomyDefault01_UpHere_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Romy/Default/RomyDefault01_UpHere.Default__RomyDefault01_UpHere_C.SessionData.Lines(1).Lines
 msgctxt ",25D626114231ECB08961C6AB69737AE1"
 msgid "You must think it's odd that you are the only one of your kind, never I have I heard your tune before."
-msgstr "Debes pensar que es extraño que seas el único de tu clase, nunca antes había escuchado de ti."
+msgstr "Debes pensar que es extraño que seas el único de tu especie, nunca antes había escuchado tu melodía."
 
 #. Key:	25F0F67B48B7F4AEF73F849ED76DC655
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.CBGate_Cove.BlockMessage
 #: /Game/World/Overworld.Overworld:PersistentLevel.CBGate_Cove.BlockMessage
 msgctxt ",25F0F67B48B7F4AEF73F849ED76DC655"
 msgid "Roots block this gate."
-msgstr ""
+msgstr "Las raíces bloquean este portón."
 
 #. Key:	2632B36446A9D5F9E018209CB73837B8
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(4 - Value).TraitIcons.DisplayName
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(4 - Value).TraitIcons.DisplayName
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(4 -
+#: Value).TraitIcons.DisplayName
 msgctxt ",2632B36446A9D5F9E018209CB73837B8"
 msgid "Massive Size"
-msgstr "Tamaño Gigante"
+msgstr "Tamaño Inmenso"
 
 #. Key:	268AD0D344A4D1238CEC5798F2ED5EF0
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaHadSex02.Default__CamillaHadSex02_C.SessionData.LinesToFuta(3).LinesToFuta
 #: /Game/Dialogue/Camilla/Default/CamillaHadSex02.Default__CamillaHadSex02_C.SessionData.LinesToFuta(3).LinesToFuta
 msgctxt ",268AD0D344A4D1238CEC5798F2ED5EF0"
 msgid "If you... uh... ever get desperate again, you know where to find me!"
-msgstr ""
+msgstr "Si... eh... alguna vez te desesperas de nuevo, ¡ya sabes dónde encontrarme!"
 
 #. Key:	26BF34E64E91FAF8BA6ACF94AB76AB90
 #. SourceLocation:	/Game/Dialogue/Emissary/SexScenes/EmissaryAngelGroinLove.Default__EmissaryAngelGroinLove_C.SessionData.LinesToMale(2).LinesToMale
 #: /Game/Dialogue/Emissary/SexScenes/EmissaryAngelGroinLove.Default__EmissaryAngelGroinLove_C.SessionData.LinesToMale(2).LinesToMale
 msgctxt ",26BF34E64E91FAF8BA6ACF94AB76AB90"
 msgid "Does my soft golden skin please you @BREEDER_NAME@?"
-msgstr "¿Te gusta mi suave piel dorada, @BREEDER_NAME@?"
+msgstr "¿Mi suave piel dorada te complace, @BREEDER_NAME@?"
 
 #. Key:	26D2F9824AAF8A08377F478BB7C771AB
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy_RL_T.Default__MirruDefault01_BodySexToy_RL_T_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy_RL_T.Default__MirruDefault01_BodySexToy_RL_T_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",26D2F9824AAF8A08377F478BB7C771AB"
 msgid "Have your way with me!"
-msgstr "¡Ábrete camino conmigo!"
+msgstr "¡Haz lo que quieras conmigo!"
 
 #. Key:	26DAA5B74F8BBB68C15E26ADBB255431
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadHadSex01.Default__DryadHadSex01_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Autumn/Default/DryadHadSex01.Default__DryadHadSex01_C.SessionData.Lines(2).Lines
 msgctxt ",26DAA5B74F8BBB68C15E26ADBB255431"
 msgid "It's true what they say about humans, you really can please us like nothing else."
-msgstr ""
+msgstr "Es cierto lo que dicen de los humanos, realmente puedes complacernos como nada más."
 
 #. Key:	26DCB9EA476437386094CA87FFE3E422
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryBlessedInquiry01_R02.Default__EmissaryBlessedInquiry01_R02_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryBlessedInquiry01_R02.Default__EmissaryBlessedInquiry01_R02_C.SessionData.Lines(0).Lines
 msgctxt ",26DCB9EA476437386094CA87FFE3E422"
 msgid "How may I further assist you human?"
-msgstr "¿Cómo puedo ayudarte, humano?"
+msgstr "¿Qué más puedo asistirte, humano?"
 
 #. Key:	274F1AF94ECA42FE2B8A2E8E36BB6611
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchHadSex01.Default__MonarchHadSex01_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/Monarch/Default/MonarchHadSex01.Default__MonarchHadSex01_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",274F1AF94ECA42FE2B8A2E8E36BB6611"
 msgid "*Blush*"
-msgstr ""
+msgstr "*Sonrojo*"
 
 #. Key:	2754CCC847A38E21CD70C58BFAE0F514
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernBeeFlowers3.Default__FernBeeFlowers3_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Fern/DefaultP3/FernBeeFlowers3.Default__FernBeeFlowers3_C.SessionData.Lines(2).Lines
 msgctxt ",2754CCC847A38E21CD70C58BFAE0F514"
 msgid "The soil tells me a dyrad is not that far away... in Pleasure Pastures!"
-msgstr ""
+msgstr "El suelo me dice que una dríada no está tan lejos... ¡en los Pastos del Placer!"
 
 #. Key:	27565BD64B41A94885451F8607E68D2F
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.CBGate_Pastures.PlaceMessage
 #: /Game/World/Overworld.Overworld:PersistentLevel.CBGate_Pastures.PlaceMessage
 msgctxt ",27565BD64B41A94885451F8607E68D2F"
 msgid "Pleasure Pastures is now accessible."
-msgstr ""
+msgstr "Los Pastos del Placer ahora son accesibles."
 
 #. Key:	276B525843A991FAE2D5FAAE9243EFC9
 #. SourceLocation:	/Game/Dialogue/Blossom/Default/BlossomDefault01.Default__BlossomDefault01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Blossom/Default/BlossomDefault01.Default__BlossomDefault01_C.SessionData.Lines(0).Lines
 msgctxt ",276B525843A991FAE2D5FAAE9243EFC9"
 msgid "Mastah! Blossom love you."
-msgstr "¡Maeztra! Flor te quiere."
+msgstr "¡Mastah! Blossom te ama."
 
 #. Key:	2792356C47CF43619493DA8F71F0D9A0
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(29).LinesToMale
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(29).LinesToMale
 msgctxt ",2792356C47CF43619493DA8F71F0D9A0"
 msgid "A world of sex and adventures awaits!"
-msgstr "¡Un mundo de sexo y aventuras te espera!"
+msgstr "¡Te espera un mundo de sexo y aventuras!"
 
 #. Key:	27AA07F64D837ABACCDEF6902D0199A2
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_Leylanna.Default__EmissaryDefault01_Leylanna_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_Leylanna.Default__EmissaryDefault01_Leylanna_C.SessionData.Lines(1).Lines
 msgctxt ",27AA07F64D837ABACCDEF6902D0199A2"
 msgid "When I first arrived, she embraced me, and made great attempts to please my vessel."
-msgstr "Cuando llegué por primera vez aquí, me abrazó e hizo grandes intentos por complacer a mi barco."
+msgstr "Cuando llegué por primera vez aquí, me abrazó e hizo grandes intentos por complacer a mi recipiente."
 
 #. Key:	27BEBE1A44FE66BEF9575592E9C7F573
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchQueen.Default__MonarchQueen_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Monarch/Default/MonarchQueen.Default__MonarchQueen_C.SessionData.Lines(5).Lines
 msgctxt ",27BEBE1A44FE66BEF9575592E9C7F573"
 msgid "Once she metamorphosizes, we are going to fly to Sensual Heavens together."
-msgstr ""
+msgstr "Una vez que se metamorfosee, volaremos juntas a los Cielos Sensuales."
 
 #. Key:	27CC628A41235ABEF7B863AD06577CD3
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01_RL_F.Default__FernDefault01_RL_F_C.ResponseData(3).ResponseData.BreederPrompt
 #: /Game/Dialogue/Fern/Default/FernDefault01_RL_F.Default__FernDefault01_RL_F_C.ResponseData(3).ResponseData.BreederPrompt
 msgctxt ",27CC628A41235ABEF7B863AD06577CD3"
 msgid "You may have my breast milk!"
-msgstr "¡Puedes tomar mi leche materna!"
+msgstr "¡Puedes tener mi leche materna!"
 
 #. Key:	27DC0A5545483DF96A1A72B802E0F3A6
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaHadSex01.Default__NeelaHadSex01_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Neela/Default/NeelaHadSex01.Default__NeelaHadSex01_C.SessionData.Lines(4).Lines
 msgctxt ",27DC0A5545483DF96A1A72B802E0F3A6"
 msgid "Well you know... it gets lonely being the portal warden."
-msgstr ""
+msgstr "Bueno, ya sabes... se vuelve solitario ser la guardiana del portal."
 
 #. Key:	2811094D446D211B1E656D8729FC40AD
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMMuchEnergy.Default__DMMuchEnergy_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/DragonMatriarch/Default/DMMuchEnergy.Default__DMMuchEnergy_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",2811094D446D211B1E656D8729FC40AD"
 msgid "Indeed, so much newfound energy!"
-msgstr ""
+msgstr "De hecho, ¡tanta energía recién descubierta!"
 
 #. Key:	28327C5645A9138AE8E04488402E4848
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeHaveKeystone.Default__BeeHaveKeystone_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/QueenBee/Default/BeeHaveKeystone.Default__BeeHaveKeystone_C.SessionData.Lines(2).Lines
 msgctxt ",28327C5645A9138AE8E04488402E4848"
 msgid "Legends say, it must be given in exchange to the one who will once again make these lands fertile."
-msgstr ""
+msgstr "Las leyendas dicen que debe ser entregada a cambio de quien vuelva a hacer fértiles estas tierras."
 
 #. Key:	286C68074B4BC23284A19AB99A24049A
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadCherryHelp.Default__DryadCherryHelp_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/Autumn/Default/DryadCherryHelp.Default__DryadCherryHelp_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",286C68074B4BC23284A19AB99A24049A"
 msgid "A chance to make a cherry with a human..."
-msgstr ""
+msgstr "Una oportunidad de hacer una cereza con un humano..."
 
 #. Key:	288DF95142A24F16C989F78DB564A8B0
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.EM_Keystone_Orc.FailMessage
 #: /Game/World/Overworld.Overworld:PersistentLevel.EM_Keystone_Orc.FailMessage
 msgctxt ",288DF95142A24F16C989F78DB564A8B0"
 msgid "Xena glares at you."
-msgstr ""
+msgstr "Xena te fulmina con la mirada."
 
 #. Key:	28D2D40946F49E829D7D26B007908332
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieGreeting01.Default__CassieGreeting01_C.SessionData.Lines(8).Lines
 #: /Game/Dialogue/Cassie/Default/CassieGreeting01.Default__CassieGreeting01_C.SessionData.Lines(8).Lines
 msgctxt ",28D2D40946F49E829D7D26B007908332"
 msgid "Oh gosh darn it, I've said too much!"
-msgstr "¡Oh, maldición, he dicho demasiado!"
+msgstr "¡Oh, maldita sea, he dicho demasiado!"
 
 #. Key:	293B31924F2C8CE36DB46AB48441D958
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiHowLong.Default__FesssiHowLong_C.SessionData.Lines(10).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiHowLong.Default__FesssiHowLong_C.SessionData.Lines(10).Lines
 msgctxt ",293B31924F2C8CE36DB46AB48441D958"
 msgid "They found every way to make me climax, and it wassss glorious!"
-msgstr ""
+msgstr "Encontraron todassss lassss formassss de hacerme llegar al clímax, ¡y fue glorioso!"
 
 #. Key:	29A421FC41D83A2B9DCC669ECA1F708D
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(34 - Value).TraitIcons.HelpText
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(34 - Value).TraitIcons.HelpText
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(34 -
+#: Value).TraitIcons.HelpText
 msgctxt ",29A421FC41D83A2B9DCC669ECA1F708D"
 msgid "Buxom: Inherited a very large ass."
-msgstr "Exuberante: Heredó un culo muy grande."
+msgstr "Exuberante: heredó un culo muy grande."
 
 #. Key:	29D016C340DC8B3F658D1A81BD0D7C54
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_RL.Default__EmissaryDefault01_RL_C.ResponseData(8).ResponseData.BreederPrompt
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_RL.Default__EmissaryDefault01_RL_C.ResponseData(8).ResponseData.BreederPrompt
 msgctxt ",29D016C340DC8B3F658D1A81BD0D7C54"
 msgid "Are you a Blessed @MONSTER_RACE@?"
-msgstr "¿Eres una bendecida @MONSTER_RACE@?"
+msgstr "¿Eres una @MONSTER_RACE@ Bendecida?"
 
 #. Key:	2A2C90CA4F62D70955E3F3A98524FEAA
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDungeon.Default__CassieDungeon_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Cassie/Default/CassieDungeon.Default__CassieDungeon_C.SessionData.Lines(5).Lines
 msgctxt ",2A2C90CA4F62D70955E3F3A98524FEAA"
 msgid "*Purr* You made me feel so good... Cassie wants to fix it for you!"
-msgstr ""
+msgstr "*Ronronea* Me hiciste sentir tan bien... ¡Cassie quiere arreglarlo para ti!"
 
 #. Key:	2AA4EC89483BB63996FEBE9BC4E4055A
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDefault01_Meow_RL_T.Default__CassieDefault01_Meow_RL_T_C.ResponseData(1).ResponseData.BreederPrompt
@@ -2209,21 +2220,22 @@ msgstr "¿Barra de mantequilla? ¿En serio?"
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_SexPositions.Default__FaleneDefault01_SexPositions_C.SessionData.Lines(1).Lines
 msgctxt ",2AAA21F34762CDB90A4C749B986B1874"
 msgid "Of course I could go see for myself, but I am too lazy to climb the stairs!!!"
-msgstr "¡¡¡Por supuesto que podría ir a ver por mí misma, pero soy demasiado perezosa para subir las escaleras!!!"
+msgstr "Por supuesto que podría ir a ver por mí misma, ¡¡¡pero soy demasiado perezosa para subir las escaleras!!!"
 
 #. Key:	2ABC84814DE5DC3039A61BBA0723AF73
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(7 - Value).TraitIcons.HelpText
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(7 - Value).TraitIcons.HelpText
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(7 -
+#: Value).TraitIcons.HelpText
 msgctxt ",2ABC84814DE5DC3039A61BBA0723AF73"
 msgid "Tiny: Roughly 4ft in height."
-msgstr "Minúscula/o: Aproximadamente 1,2m de altura."
+msgstr "Menudo: aproximadamente 4 pies (1,2 m) de altura."
 
 #. Key:	2AE92EB74AEF856F0FE56487E2289FD2
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeAboutOrb.Default__MegaSlimeAboutOrb_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeAboutOrb.Default__MegaSlimeAboutOrb_C.SessionData.Lines(1).Lines
 msgctxt ",2AE92EB74AEF856F0FE56487E2289FD2"
 msgid "My life was empty and meaningless without it."
-msgstr ""
+msgstr "Mi vida estaba vacía y sin sentido sin él."
 
 #. Key:	2B2323B74BC7F2E6E2CF40A3E50FEFC2
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_RL_M.Default__FernDefault02_RL_M_C.ResponseData(3).ResponseData.BreederPrompt
@@ -2237,7 +2249,7 @@ msgstr "¡Puedes tener mi semen!"
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02_RL_T.Default__FernDefault02_RL_T_C.ResponseData(5).ResponseData.BreederPrompt
 msgctxt ",2B4C510D4A32384C298984BDD667C93E"
 msgid "The Queen Bee demands flowers."
-msgstr ""
+msgstr "La Abeja Reina exige flores."
 
 #. Key:	2B4CCE054929809171D1D88C30341FB2
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_Princess.Default__MirruDefault01_Princess_C.SessionData.Lines(3).Lines
@@ -2258,35 +2270,35 @@ msgstr "Sorpresa"
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_SellMonsters.Default__EmissaryDefault01_SellMonsters_C.SessionData.Lines(0).Lines
 msgctxt ",2BA86FB140866995E4F323B86DA72C9A"
 msgid "The Goddess is pleased and will grant you Her favor."
-msgstr "La Diosa está complacida y te otorgará Su favor."
+msgstr "La Diosa está complacida y te concederá Su favor."
 
 #. Key:	2BB3415840A0FA9A2D3EF98079751D8D
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcDefault03_RL.Default__OrcDefault03_RL_C.ResponseData(2).ResponseData.BreederPrompt
 #: /Game/Dialogue/OrcChief/Default/OrcDefault03_RL.Default__OrcDefault03_RL_C.ResponseData(2).ResponseData.BreederPrompt
 msgctxt ",2BB3415840A0FA9A2D3EF98079751D8D"
 msgid "Can I have your keystone?"
-msgstr ""
+msgstr "¿Puedo tener tu piedra-llave?"
 
 #. Key:	2BCA631C4BEC509E1B1DAC824001A31A
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_YourMusic_RL.Default__RomyDefault01_YourMusic_RL_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/Romy/Default/RomyDefault01_YourMusic_RL.Default__RomyDefault01_YourMusic_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",2BCA631C4BEC509E1B1DAC824001A31A"
 msgid "Whoa, actually I'm tone-deaf."
-msgstr "Wow, en realidad estoy sordo."
+msgstr "Vaya, realmente estoy sorda."
 
 #. Key:	2BD0260D4AF5544E8E7FEE98A41B8289
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchDefault01.Default__MonarchDefault01_C.SessionData.LinesToFemale(3).LinesToFemale
 #: /Game/Dialogue/Monarch/Default/MonarchDefault01.Default__MonarchDefault01_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",2BD0260D4AF5544E8E7FEE98A41B8289"
 msgid "If I wiggle it the right way, it w-w-will distract any potential... mates."
-msgstr ""
+msgstr "Si lo muevo de la manera correcta, d-d-distraerá a cualquier potencial... pareja."
 
 #. Key:	2BF4676042EE4C0FA5B54F8CDCD3C5A6
 #. SourceLocation:	/Game/Dialogue/Cassie/SexScenes/CassieSplintersT.Default__CassieSplintersT_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Cassie/SexScenes/CassieSplintersT.Default__CassieSplintersT_C.SessionData.Lines(1).Lines
 msgctxt ",2BF4676042EE4C0FA5B54F8CDCD3C5A6"
 msgid "*Purr*"
-msgstr "*Ronroneo*"
+msgstr "*Ronronea*"
 
 #. Key:	2C3AAB1041FC7DDA3F11DBBAACA151F1
 #. SourceLocation:	/Game/Characters/Procedural/Variants/Dragon/Harvest/DragonHarvest.Default__DragonHarvest_C.Harvest.Description
@@ -2300,84 +2312,84 @@ msgstr "Fluidos corporales de Dragón."
 #: /Game/Dialogue/Autumn/Default/DryadDefault01.Default__DryadDefault01_C.SessionData.Lines(1).Lines
 msgctxt ",2C4B1039457C01738B40D6AC73FC0E41"
 msgid "Oh how good it feels to make each one..."
-msgstr ""
+msgstr "Oh, que bien se siente hacer cada una..."
 
 #. Key:	2C6E28494FB2D15A239584A77B01FA67
 #. SourceLocation:	/Game/Ranch/Upgrades/FoxenHouse.Default__FoxenHouse_C.Upgrade.DisplayName
 #: /Game/Ranch/Upgrades/FoxenHouse.Default__FoxenHouse_C.Upgrade.DisplayName
 msgctxt ",2C6E28494FB2D15A239584A77B01FA67"
 msgid "Foxen House"
-msgstr "Casa de Zorros"
+msgstr "Casa de Foxens"
 
 #. Key:	2C85485F41A9CB181E6BF3A7AFBAD94C
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadAboutDryads.Default__DryadAboutDryads_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Autumn/Default/DryadAboutDryads.Default__DryadAboutDryads_C.SessionData.Lines(5).Lines
 msgctxt ",2C85485F41A9CB181E6BF3A7AFBAD94C"
 msgid "Perhaps a little too much... they sure get chubby. Aww... but look how cute they are!"
-msgstr ""
+msgstr "Quizás un poco demasiado... seguro que se vuelven gorditas. Amm... ¡pero mira qué lindas son!"
 
 #. Key:	2CBC22E04FC3D2621685D7A54A4B69A8
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleGreeting01.Default__KybeleGreeting01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Kybele/Default/KybeleGreeting01.Default__KybeleGreeting01_C.SessionData.Lines(0).Lines
 msgctxt ",2CBC22E04FC3D2621685D7A54A4B69A8"
 msgid "None may pass!"
-msgstr ""
+msgstr "¡Nadie puede pasar!"
 
 #. Key:	2CCE0ADD406CF961196E5BAEDA387652
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_AboutMusic.Default__RomyDefault01_AboutMusic_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Romy/Default/RomyDefault01_AboutMusic.Default__RomyDefault01_AboutMusic_C.SessionData.Lines(0).Lines
 msgctxt ",2CCE0ADD406CF961196E5BAEDA387652"
 msgid "Can you not hear it?"
-msgstr "¿No lo oyes?"
+msgstr "¿No puedes oírlo?"
 
 #. Key:	2D2E42E44183AC98D3F98B8BCC03296A
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraAboutPawsmaati.Default__PetraAboutPawsmaati_C.SessionData.Lines(8).Lines
 #: /Game/Dialogue/Petra/Default/PetraAboutPawsmaati.Default__PetraAboutPawsmaati_C.SessionData.Lines(8).Lines
 msgctxt ",2D2E42E44183AC98D3F98B8BCC03296A"
 msgid "If you wish to learn new ways to have sex, go visit Pawmaati. You will not regret it!"
-msgstr ""
+msgstr "Si deseas aprender nuevas formas de tener sexo, ve a visitar Pawmaati. ¡No te arrepentirás!"
 
 #. Key:	2D3C1B2D468CB7B71E995CBC072D4767
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeDefault01_RL.Default__BeeDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/QueenBee/Default/BeeDefault01_RL.Default__BeeDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",2D3C1B2D468CB7B71E995CBC072D4767"
 msgid "Uh... no?"
-msgstr ""
+msgstr "Uh... ¿no?"
 
 #. Key:	2D40A8404D1D3D0D2D24B49349427E5A
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernGreeting03.Default__FernGreeting03_C.SessionData.LinesToFemale(3).LinesToFemale
 #: /Game/Dialogue/Fern/DefaultP3/FernGreeting03.Default__FernGreeting03_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",2D40A8404D1D3D0D2D24B49349427E5A"
 msgid "I suppose there is no need to feed me anymore, but we can always do other things with my amazing flower body!"
-msgstr "Supongo que ya no hay necesidad de alimentarme, ¡pero siempre podemos hacer otras cosas con mi increíble cuerpo floral!"
+msgstr "Supongo que ya no hay necesidad de alimentarme nunca más, ¡pero siempre podemos hacer otras cosas con mi increíble cuerpo de flor!"
 
 #. Key:	2D636C78456A78C86B5305B72E889E11
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",2D636C78456A78C86B5305B72E889E11"
 msgid "Human pussy tastes just like I dreamt it would!"
-msgstr ""
+msgstr "¡El coño humano sabe exactamente como lo había soñado!"
 
 #. Key:	2D7FF6A641C8DE1EC57F84A825BA2219
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMWantHuman.Default__DMWantHuman_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMWantHuman.Default__DMWantHuman_C.SessionData.Lines(3).Lines
 msgctxt ",2D7FF6A641C8DE1EC57F84A825BA2219"
 msgid "To think I can mate with one... ah... yesss."
-msgstr ""
+msgstr "Pensar que puedo aparearme con uno... ah... sssí."
 
 #. Key:	2DBE58DB4B0AEBCB9FDD04BC94C039BD
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R04.Default__FaleneDefault01_R04_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R04.Default__FaleneDefault01_R04_C.SessionData.Lines(5).Lines
 msgctxt ",2DBE58DB4B0AEBCB9FDD04BC94C039BD"
 msgid "I frequently must change my lower garments since my vagina is always very wet--it's a common problem for blessed @MONSTER_RACE@ that wear clothes."
-msgstr "Con frecuencia debo cambiar mis prendas inferiores ya que mi vagina siempre está muy mojada - es un problema común para los @MONSTER_RACE@ celestiales que usan ropa."
+msgstr "Con frecuencia debo cambiar mis prendas inferiores ya que mi vagina siempre está muy mojada: es un problema común para los @MONSTER_RACE@ bendecidos que usan ropa."
 
 #. Key:	2DC7EABB434FE7136DE3498D19A6B8B9
 #. SourceLocation:	/Game/Dialogue/Fern/SexScenes/FernMilk_01.Default__FernMilk_01_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Fern/SexScenes/FernMilk_01.Default__FernMilk_01_C.SessionData.Lines(4).Lines
 msgctxt ",2DC7EABB434FE7136DE3498D19A6B8B9"
 msgid "Give Fern all milky... hiss! Grow faster with more milky."
-msgstr "Dale a Helecho toda la leche... ¡silbido! Crezco más rápido con más leche."
+msgstr "Dale a Fern toda lo lechoso... ¡Sss! Crezco más rápido con más lechoso."
 
 #. Key:	2DF7474B4ED132A075973ABFA667399C
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_RL.Default__RomyDefault01_RL_C.ResponseData(4).ResponseData.BreederPrompt
@@ -2391,14 +2403,14 @@ msgstr "Quiero escuchar tu música."
 #: /Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",2E166A6948BC2569CE3FCAB659B7FE7D"
 msgid "Maybe my nipples?"
-msgstr ""
+msgstr "¿Quizás mis pezones?"
 
 #. Key:	2E18B0B24CC860D3136F0CA493EDDD3B
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R04.Default__FaleneDefault01_R04_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R04.Default__FaleneDefault01_R04_C.SessionData.Lines(0).Lines
 msgctxt ",2E18B0B24CC860D3136F0CA493EDDD3B"
 msgid "Ohhh... that's going to be tough to talk about without cumming right here..."
-msgstr "Ohhh... va a ser difícil hablar de eso sin correrse en el intento..."
+msgstr "Ohhh ... será difícil hablar de eso sin correrte aquí mismo..."
 
 #. Key:	2E25C7F94C5F91F1328BC39C52574333
 #. SourceLocation:	/Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToMale(1).LinesToMale
@@ -2412,217 +2424,217 @@ msgstr "*Chupa* *Chupa*"
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R02.Default__FaleneDefault01_R02_C.SessionData.Lines(2).Lines
 msgctxt ",2E354C3547A22A28F21C20ABC438099D"
 msgid "Blessed @MONSTER_RACE@ are like you humans--we are self aware and intelligent."
-msgstr "Los @MONSTER_RACE@ Celestiales son como ustedes los humanos - somos autoconscientes e inteligentes."
+msgstr "Los @MONSTER_RACE@ bendecidos somos como vosotros los humanos: somos conscientes de nosotros mismos e inteligentes."
 
 #. Key:	2E3E08D0489FB126A2E91CAA491280F4
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.CBGate_Hivelands.PlaceMessage
 #: /Game/World/Overworld.Overworld:PersistentLevel.CBGate_Hivelands.PlaceMessage
 msgctxt ",2E3E08D0489FB126A2E91CAA491280F4"
 msgid "Hivelands is now accessible."
-msgstr ""
+msgstr "Las Tierras-Colmena ahora son accesibles."
 
 #. Key:	2E7BB9B84F5D0CB4DA2DF986BEFCB857
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFuta(0).LinesToFuta
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFuta(0).LinesToFuta
 msgctxt ",2E7BB9B84F5D0CB4DA2DF986BEFCB857"
 msgid "Wow! It can't be!"
-msgstr "¡Wow! ¡No puede ser!"
+msgstr "¡Guau! ¡No puede ser!"
 
 #. Key:	2E8395B6412987FEE6DC3E8FE37DC549
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyLockedDungeon.Default__RomyLockedDungeon_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Romy/Default/RomyLockedDungeon.Default__RomyLockedDungeon_C.SessionData.Lines(2).Lines
 msgctxt ",2E8395B6412987FEE6DC3E8FE37DC549"
 msgid "One of extraordinary loneliness and self-loathing."
-msgstr ""
+msgstr "Una de extraordinaria soledad y autodesprecio."
 
 #. Key:	2E8D7983446334A29BB4E0BCEFBBC092
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(4).Lines
 msgctxt ",2E8D7983446334A29BB4E0BCEFBBC092"
 msgid "Soon She realized something was missing, for the light had no meaning in the universe."
-msgstr "Pronto Ella se dio cuenta de que faltaba algo, porque la luz no tenía sentido en el universo."
+msgstr "Pronto Ella se dio cuenta de que faltaba algo, porque la luz no tenía ningún significado en el universo."
 
 #. Key:	2E926B8847D675F1C4CAAFAC2732930B
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01_R04.Default__FernDefault01_R04_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Fern/Default/FernDefault01_R04.Default__FernDefault01_R04_C.SessionData.Lines(1).Lines
 msgctxt ",2E926B8847D675F1C4CAAFAC2732930B"
 msgid "Fern need human milk to grow into big Alraune! Hissss, Fern suck nipples now!"
-msgstr "¡Helecho necesita leche humana para convertirse en una gran Mandrágora! ¡Ssss, Helecho chupa pezones ahora!"
+msgstr "¡Fern necesita leche materna para convertirse en una gran alraune! ¡Sssss, Fern ahora chupa pezones!"
 
 #. Key:	2EDA99CC46CBEB3206A527B95F55FAB9
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMDefault01.Default__DMDefault01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMDefault01.Default__DMDefault01_C.SessionData.Lines(1).Lines
 msgctxt ",2EDA99CC46CBEB3206A527B95F55FAB9"
 msgid "Go away human, this is my comfy spot and you can't have it."
-msgstr ""
+msgstr "Vete humano, este es mi sitio confortable y no puedes tomarlo."
 
 #. Key:	2EF1966C455529B6A75289AD5EF81C2E
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleTittyPony.Default__KybeleTittyPony_C.SessionData.LinesToFuta(0).LinesToFuta
 #: /Game/Dialogue/Kybele/Default/KybeleTittyPony.Default__KybeleTittyPony_C.SessionData.LinesToFuta(0).LinesToFuta
 msgctxt ",2EF1966C455529B6A75289AD5EF81C2E"
 msgid "That's it human, you have annoyed me long enough. Get against that rock and prepare to be smashed."
-msgstr ""
+msgstr "Eso es humano, me has molestado lo suficiente. Ponte contra esa roca y prepárate para ser aplastado."
 
 #. Key:	2EF454D94FCEA805F55F20A94627C808
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiGreeting01.Default__ParvatiGreeting01_C.SessionData.LinesToFuta(6).LinesToFuta
 #: /Game/Dialogue/Parvati/Default/ParvatiGreeting01.Default__ParvatiGreeting01_C.SessionData.LinesToFuta(6).LinesToFuta
 msgctxt ",2EF454D94FCEA805F55F20A94627C808"
 msgid "Give your body to me, and in ecstasy we will work around the clock."
-msgstr "Dame tu cuerpo, y en éxtasis trabajaremos el día entero."
+msgstr "Entrégame tu cuerpo, y en éxtasis trabajaremos el día entero."
 
 #. Key:	2F11F20945669A4E95B79EA1B7856C2A
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadAboutDryads.Default__DryadAboutDryads_C.SessionData.Lines(7).Lines
 #: /Game/Dialogue/Autumn/Default/DryadAboutDryads.Default__DryadAboutDryads_C.SessionData.Lines(7).Lines
 msgctxt ",2F11F20945669A4E95B79EA1B7856C2A"
 msgid "A dryad's power reaches its peak at the moment of orgasm."
-msgstr ""
+msgstr "El poder de una dríada alcanza su cumbre en el momento del orgasmo."
 
 #. Key:	2F5513164D00080A441C1292E501C786
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(4).Lines
 msgctxt ",2F5513164D00080A441C1292E501C786"
 msgid "If ye have @MONSTER_RACE@ milk to sell, or if ye want te buy some then I'm yer gal!"
-msgstr "Si tieneh leshe de @MONSTER_RACE@ pa vendeh, o si quiereh comprah un poco entonseh ¡soy tu shica!"
+msgstr "Si tieneh leshe de @MONSTER_RACE@ pa' vendeh, o si quiereh comprah un poco, en ese caso ¡soy tu shica!"
 
 #. Key:	2F7D02EE4B2C5C30E72919BE9D83BD1F
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleDragonMatriarch.Default__KybeleDragonMatriarch_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Kybele/Default/KybeleDragonMatriarch.Default__KybeleDragonMatriarch_C.SessionData.Lines(5).Lines
 msgctxt ",2F7D02EE4B2C5C30E72919BE9D83BD1F"
 msgid "As reward, the Dragon Matriarch promised me a chance to mate with her, and I can't wait!"
-msgstr ""
+msgstr "Como recompensa, la Matriarca Dragón me prometió la oportunidad de aparearme con ella, ¡y no puedo esperar!"
 
 #. Key:	2F988E7B4E35BA65FB81488EC3339C51
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(2).Lines
 msgctxt ",2F988E7B4E35BA65FB81488EC3339C51"
 msgid "First, She made love with Herself to bring forth light and the Seraphim, my kin, were born."
-msgstr "Primero, Ella hizo el amor con Ella misma para dar a luz y las Serafines, mis parientes, nacieron."
+msgstr "Primero, Ella hizo el amor con Ella misma para dar a luz y las serafines, mis parientes, nacieron."
 
 #. Key:	2FA4621047A86335175276AF22BFDE52
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon2.Default__AmberMaeLockedDungeon2_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon2.Default__AmberMaeLockedDungeon2_C.SessionData.Lines(0).Lines
 msgctxt ",2FA4621047A86335175276AF22BFDE52"
 msgid "If ye think I'm a big cow today, 'mai goodness was I larger in me younger days!"
-msgstr ""
+msgstr "Si piensah que soy una vaca grande hoy, ¡Santo cielo, era máh grande en mi juventuh!"
 
 #. Key:	2FA59C8A48A63BD0FE6D0289A8AF9587
 #. SourceLocation:	/Game/Dialogue/Yasmine/Default/YasmineDefault02_RL.Default__YasmineDefault02_RL_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/Yasmine/Default/YasmineDefault02_RL.Default__YasmineDefault02_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",2FA59C8A48A63BD0FE6D0289A8AF9587"
 msgid "This world gets stranger everyday..."
-msgstr ""
+msgstr "Este mundo se vuelve más extraño cada día..."
 
 #. Key:	2FC584B146298BF0F75983AB7F59C5E1
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadBossomCherries.Default__DryadBossomCherries_C.SessionData.Lines(7).Lines
 #: /Game/Dialogue/Autumn/Default/DryadBossomCherries.Default__DryadBossomCherries_C.SessionData.Lines(7).Lines
 msgctxt ",2FC584B146298BF0F75983AB7F59C5E1"
 msgid "Don't look at me like that, a dryad needs a break once in awhile!"
-msgstr ""
+msgstr "No me mires así, ¡una dríada necesita un descanso de vez en cuando!"
 
 #. Key:	2FFC051448D7AD3EA274FF8D334EE641
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeHadSex02.Default__MegaSlimeHadSex02_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeHadSex02.Default__MegaSlimeHadSex02_C.SessionData.Lines(1).Lines
 msgctxt ",2FFC051448D7AD3EA274FF8D334EE641"
 msgid "*She is fast asleep, her slime has relaxed*"
-msgstr ""
+msgstr "*Está profundamente dormida, su limo se ha relajado*"
 
 #. Key:	3002153B48BD52898AEAE78030617CF7
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_R01.Default__FernDefault02_R01_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02_R01.Default__FernDefault02_R01_C.SessionData.Lines(2).Lines
 msgctxt ",3002153B48BD52898AEAE78030617CF7"
 msgid "Once an Alraune has consumed enough reproductive fluid, she will grow into a massive stationary flower."
-msgstr "Una vez que una Mandrágora ha consumido suficientes fluidos reproductores, crecerá hasta convertirse en una gigantesca flor estacionaria."
+msgstr "Una vez que una alraune ha consumido suficiente fluido reproductivo, crecerá hasta convertirse en una enorme flor estacionaria."
 
 #. Key:	3033B03F4617AF302335059B87E769FB
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_TheVoid.Default__NeelaDefault01_TheVoid_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_TheVoid.Default__NeelaDefault01_TheVoid_C.SessionData.Lines(1).Lines
 msgctxt ",3033B03F4617AF302335059B87E769FB"
 msgid "Space and time are different there, but this you already know as a breeder. The Void is where @MONSTER_RACE@ come from."
-msgstr "El espacio y el tiempo se comportan de forma diferentes allí, pero esto ya lo debes saber como criador. El vacío es de donde vienen los @MONSTER_RACE@."
+msgstr "El espacio y el tiempo son diferentes allí, pero esto ya lo sabes como criador. El Vacío es de donde vienen los @MONSTER_RACE@."
 
 #. Key:	30642B1B484E9B1A506A4C8AA641CE01
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R06.Default__FaleneDefault01_R06_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R06.Default__FaleneDefault01_R06_C.SessionData.Lines(3).Lines
 msgctxt ",30642B1B484E9B1A506A4C8AA641CE01"
 msgid "Can't say I blame 'em!"
-msgstr "¡No puedo culparlos!"
+msgstr "¡No puedo decir que las culpe!"
 
 #. Key:	3075ABF441EF5686A57E81971B67D55E
 #. SourceLocation:	/Game/Breeding/Positions/LapDance.Default__LapDance_C.SessionData.Description
 #: /Game/Breeding/Positions/LapDance.Default__LapDance_C.SessionData.Description
 msgctxt ",3075ABF441EF5686A57E81971B67D55E"
 msgid "The receiver bounces on the giver's lap while getting nice and close with her breasts."
-msgstr "La receptora rebota en el regazo de el/la dador/a mientras se pone bien y cerca con sus senos."
+msgstr "La receptora rebota en el regazo del donante mientras se pone simpática y se cerca con sus pechos."
 
 #. Key:	307B12694EA9D8B0251B9D86E3760DB8
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMWantHuman.Default__DMWantHuman_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMWantHuman.Default__DMWantHuman_C.SessionData.Lines(1).Lines
 msgctxt ",307B12694EA9D8B0251B9D86E3760DB8"
 msgid "..."
-msgstr ""
+msgstr "..."
 
 #. Key:	308622B94E5A8BC25F1160888147CB16
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeHowLong.Default__MegaSlimeHowLong_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeHowLong.Default__MegaSlimeHowLong_C.SessionData.Lines(4).Lines
 msgctxt ",308622B94E5A8BC25F1160888147CB16"
 msgid "The stuff in the water is always cold... oh the slime I could make with a fresh hot load."
-msgstr ""
+msgstr "La materia en el agua siempre está fría... oh, el limo que podría hacer con una carga fresca y caliente."
 
 #. Key:	308B8DB245EC118210674A84BB3AFDC3
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleRideYou_RL_T.Default__KybeleRideYou_RL_T_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/Kybele/Default/KybeleRideYou_RL_T.Default__KybeleRideYou_RL_T_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",308B8DB245EC118210674A84BB3AFDC3"
 msgid "Aww what an adorable titty pony."
-msgstr ""
+msgstr "Amm, que adorable poni tetudita."
 
 #. Key:	3092F47E411D4A54A80D53BAF9BCBC3F
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToFuta(5).LinesToFuta
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToFuta(5).LinesToFuta
 msgctxt ",3092F47E411D4A54A80D53BAF9BCBC3F"
 msgid "It's a nutritious aphrodisiac, a very powerful one so be careful!"
-msgstr ""
+msgstr "Es un afrodisíaco nutritivo, uno muy poderoso, ¡así que ten cuidado!"
 
 #. Key:	30940E7C46EDA0BA71E783B92668ECFD
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernHadSex01.Default__FernHadSex01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Fern/Default/FernHadSex01.Default__FernHadSex01_C.SessionData.Lines(0).Lines
 msgctxt ",30940E7C46EDA0BA71E783B92668ECFD"
 msgid "Mmmm... mastah tasty!"
-msgstr ""
+msgstr "Mmmm... ¡Mastah sabroso!"
 
 #. Key:	309ABB3C4016F9879A6955B2D2BD5AE8
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleAnyMeans.Default__KybeleAnyMeans_C.SessionData.LinesToFuta(3).LinesToFuta
 #: /Game/Dialogue/Kybele/Default/KybeleAnyMeans.Default__KybeleAnyMeans_C.SessionData.LinesToFuta(3).LinesToFuta
 msgctxt ",309ABB3C4016F9879A6955B2D2BD5AE8"
 msgid "My strong body will easily overpower your human form."
-msgstr ""
+msgstr "Mi cuerpo fuerte dominará fácilmente tu forma humana."
 
 #. Key:	30B0262C40D2D8527E2C8EA23D4D4B6D
 #. SourceLocation:	/Game/Dialogue/Emissary/SexScenes/EmissaryAngelGroinLove.Default__EmissaryAngelGroinLove_C.SessionData.LinesToMale(1).LinesToMale
 #: /Game/Dialogue/Emissary/SexScenes/EmissaryAngelGroinLove.Default__EmissaryAngelGroinLove_C.SessionData.LinesToMale(1).LinesToMale
 msgctxt ",30B0262C40D2D8527E2C8EA23D4D4B6D"
 msgid "My labia are holy and magical. May your tongue be graced by their presence."
-msgstr "Mis labios son santos y mágicos. Que tu lengua sea agraciada por su presencia."
+msgstr "Mis labios son sagrados y mágicos. Que tu lengua sea agraciada con su presencia."
 
 #. Key:	30B4EDAF4D579766E7CE6082217D4CAC
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMLame.Default__DMLame_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMLame.Default__DMLame_C.SessionData.Lines(0).Lines
 msgctxt ",30B4EDAF4D579766E7CE6082217D4CAC"
 msgid "*Yawwwwwwn*"
-msgstr ""
+msgstr "*Uaaaaaah*"
 
 #. Key:	3101A3934639560426484AA6C6AAE3A1
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01_R02.Default__FernDefault01_R02_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Fern/Default/FernDefault01_R02.Default__FernDefault01_R02_C.SessionData.Lines(0).Lines
 msgctxt ",3101A3934639560426484AA6C6AAE3A1"
 msgid "Fern!"
-msgstr "¡Helecho!"
+msgstr "¡Fern!"
 
 #. Key:	3169578649A185428A32E78395F9C48E
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(3).LinesToFemale
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",3169578649A185428A32E78395F9C48E"
 msgid "This world is home to the @MONSTER_RACE@, an enigmatic race of human-monster hybrids."
-msgstr "Este mundo es el hogar de @MONSTER_RACE@, una raza enigmática de híbridos humano-monstruo."
+msgstr "Este mundo es el hogar de los @MONSTER_RACE@, una raza enigmática de híbridos humano-monstruo."
 
 #. Key:	31774B0844F7A12FF85DC5AE10CA3013
 #. SourceLocation:	/Game/Dialogue/Mirru/SexScenes/MirruKrakVag.Default__MirruKrakVag_C.SessionData.Lines(3).Lines
@@ -2636,7 +2648,7 @@ msgstr "Oh... ahh... se siente tan bien."
 #: /Game/UI/TaskDescriptions.TaskDescriptions.TextEntries(3).TextEntries
 msgctxt ",31D7D80147B2E3EC2048A689FD79BD27"
 msgid "Well I can certainly say the paper we use for writing these tasks is NOT tasty, meow! But you know what is tasty? Nephelym genitalia! Now bring me some! Meow, make it as big as possible... hmmm... I would say bigger than the whole town, but after what happened that one time... perhaps not. Just make it cute!  -Cassie"
-msgstr ""
+msgstr "Bueno, ciertamente puedo decir que el papel que usamos para escribir estas tareas NO es sabroso, ¡miau! ¿Pero sabes qué es sabroso? Genitales @MONSTER_RACE@! ¡Ahora tráeme un poco! Miau, hazlo lo más grande posible... hmmm... Yo diría más grande que todo el pueblo, pero después de lo que pasó esa vez... quizás no. ¡Solo hazlo lindo! -Cassie"
 
 #. Key:	31E2065041FFF628ED41DEB3E33F080F
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_Pregnancy.Default__FaleneDefault01_Pregnancy_C.SessionData.Lines(3).Lines
@@ -2650,49 +2662,49 @@ msgstr "Le permite a la madre saber cuándo la descendencia se convocará a este
 #: /Game/Dialogue/Neela/Default/NeelaDefault01.Default__NeelaDefault01_C.SessionData.Lines(0).Lines
 msgctxt ",3214B32B4A49DA94E7D6779180228EC0"
 msgid "No, I do not enjoy standing here all day wearing this ridiculous helmet."
-msgstr "No, no disfruto estando aquí todo el día con este ridículo casco."
+msgstr "No, no disfruto estando aquí todo el día usando este ridículo casco."
 
 #. Key:	322489D0449B3ABC5F1D12BCD6CAD220
 #. SourceLocation:	/Game/Dialogue/Cassie/SexScenes/CassieSplintersT.Default__CassieSplintersT_C.SessionData.Lines(6).Lines
 #: /Game/Dialogue/Cassie/SexScenes/CassieSplintersT.Default__CassieSplintersT_C.SessionData.Lines(6).Lines
 msgctxt ",322489D0449B3ABC5F1D12BCD6CAD220"
 msgid "Ouch, I'm getting splinters in my back! Ohhh... worth it."
-msgstr "¡Ay, me estoy llenando la espalda de astillas! Ohhh... vale la pena."
+msgstr "¡Ay, se me está astillando la espalda! Ohhh... vale la pena."
 
 #. Key:	323DCA0444372E8B59354A9FC665147D
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchGreeting01.Default__MonarchGreeting01_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Monarch/Default/MonarchGreeting01.Default__MonarchGreeting01_C.SessionData.Lines(4).Lines
 msgctxt ",323DCA0444372E8B59354A9FC665147D"
 msgid "Uh, m-m-my name is Monarch."
-msgstr ""
+msgstr "Uh, m-m-mi nombre es Monarch."
 
 #. Key:	324ED3C844A0E2724766EB9155484064
 #. SourceLocation:	/Game/Dialogue/Neela/SexScenes/NeelaSnakeCuddleT.Default__NeelaSnakeCuddleT_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Neela/SexScenes/NeelaSnakeCuddleT.Default__NeelaSnakeCuddleT_C.SessionData.Lines(1).Lines
 msgctxt ",324ED3C844A0E2724766EB9155484064"
 msgid "You feel so good human... ahhhh."
-msgstr "Te sientes tan bien humana... ahhhh."
+msgstr "Te sientes tan bien humano... ahhhh."
 
 #. Key:	325B057D42B7367B320C54941EEE0BA6
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_Forgot.Default__ParvatiDefault01_Forgot_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_Forgot.Default__ParvatiDefault01_Forgot_C.SessionData.Lines(4).Lines
 msgctxt ",325B057D42B7367B320C54941EEE0BA6"
 msgid "I will show again how to move your body beyond all measure."
-msgstr "Te mostraré nuevamente cómo mover tu cuerpo, sin límites conocer."
+msgstr "Volveré a mostrarte cómo mover tu cuerpo más allá de todo límite."
 
 #. Key:	32E74CA64F7C6339A9D526A19496DD86
 #. SourceLocation:	/Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",32E74CA64F7C6339A9D526A19496DD86"
 msgid "Oh! You're skin is so soft! I love the way it feels on my ass... ahhh."
-msgstr "¡Oh! ¡Tu piel es tan suave! Me encanta cómo se siente en mi trasero... ahhh."
+msgstr "¡Oh! ¡Tu piel es tan suave! Amo la forma en que se siente en mi culo... ahhh."
 
 #. Key:	330CF8FE454E1F3A60B2A894F9D4CA31
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.EM_Keystone_Monarch.FailMessage
 #: /Game/World/Overworld.Overworld:PersistentLevel.EM_Keystone_Monarch.FailMessage
 msgctxt ",330CF8FE454E1F3A60B2A894F9D4CA31"
 msgid "Monarch's magic prevents you."
-msgstr ""
+msgstr "La magia de Monarch te lo impide."
 
 #. Key:	330EAC0C483DA43FAFCBCBB789D5AB9E
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(9).Lines
@@ -2713,49 +2725,49 @@ msgstr "Me llamo Cassie, soy la arquitecta de la ciudad."
 #: /Game/Dialogue/OrcChief/Default/OrcGreeting01.Default__OrcGreeting01_C.SessionData.Lines(3).Lines
 msgctxt ",33869B7A401E77AD997246A9AFD3C136"
 msgid "*Snarl*"
-msgstr ""
+msgstr "*Gruñe*"
 
 #. Key:	3388B3134E9C8C83D182D5B5C5F89B85
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowSpiders.Default__WidowSpiders_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Widow/Default/WidowSpiders.Default__WidowSpiders_C.SessionData.Lines(0).Lines
 msgctxt ",3388B3134E9C8C83D182D5B5C5F89B85"
 msgid "Ahhh yes. I love spinning stories as much as webs."
-msgstr ""
+msgstr "Ahhh, si. Me encanta hilar historias tanto como las telarañas."
 
 #. Key:	33CE1E3D4DCA8528953414ACFA7C540B
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowScary.Default__WidowScary_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Widow/Default/WidowScary.Default__WidowScary_C.SessionData.Lines(0).Lines
 msgctxt ",33CE1E3D4DCA8528953414ACFA7C540B"
 msgid "Why is that so?"
-msgstr ""
+msgstr "¿Por qué es así?"
 
 #. Key:	33DB6107453143BAF4F8B0A81EFC2634
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault02.Default__CamillaDefault02_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaDefault02.Default__CamillaDefault02_C.SessionData.Lines(2).Lines
 msgctxt ",33DB6107453143BAF4F8B0A81EFC2634"
 msgid "A swarm of horny bats no doubt, or maybe a giant leech."
-msgstr ""
+msgstr "Un enjambre de murciélagos cachondos sin duda, o tal vez una sanguijuela gigante."
 
 #. Key:	33E5BA9741C0AE4944E1E5BBC54FDCFA
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcDefault01.Default__OrcDefault01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcDefault01.Default__OrcDefault01_C.SessionData.Lines(1).Lines
 msgctxt ",33E5BA9741C0AE4944E1E5BBC54FDCFA"
 msgid "*Snarl*"
-msgstr ""
+msgstr "*Gruñe*"
 
 #. Key:	33EFAFD748D8C769BA9A978D5F401884
 #. SourceLocation:	/Game/UI/TaskDescriptions.TaskDescriptions.TextEntries(4).TextEntries
 #: /Game/UI/TaskDescriptions.TaskDescriptions.TextEntries(4).TextEntries
 msgctxt ",33EFAFD748D8C769BA9A978D5F401884"
 msgid "The spirits have spoken! Through divine inspiration I am writing this request. Bring to me a lover, a reward from the heavens for my good service as high priestess. I am humbled that the spirits find my work worthy of such a gift. Oh and they have revealed more! This lover is to be... yes... the pinacle of beauty, large in all the right places.  -Leylanna"
-msgstr ""
+msgstr "¡Los espíritus han hablado! Por inspiración divina estoy escribiendo esta solicitud. Tráeme un amante, una recompensa de los cielos por mi buen servicio como suma sacerdotisa. Me siento honrada de que los espíritus consideren que mi trabajo es digno de tal regalo. ¡Ah, y han revelado más! Este amante será... sí... el pináculo de la belleza, grande en todos los lugares correctos. -Leylanna"
 
 #. Key:	341A1B1E4F52D36C69BFB9ACE71DBCD4
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimePlay.Default__MegaSlimePlay_C.SessionData.LinesToFuta(2).LinesToFuta
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePlay.Default__MegaSlimePlay_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",341A1B1E4F52D36C69BFB9ACE71DBCD4"
 msgid "I'm going to eat all of it and make lots of new slime..."
-msgstr ""
+msgstr "Me lo voy a comer todo y a hacer un montón de nuevos limos..."
 
 #. Key:	341E99EA4A6DE606AFFC6D8A11C1B7D5
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R07.Default__CamillaDefault01_R07_C.SessionData.LinesToFuta(1).LinesToFuta
@@ -2769,28 +2781,28 @@ msgstr "¡Las tetas de Amber son mas grandes que yo! Por qué este mundo es tan 
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(10).Lines
 msgctxt ",3432E91146A4FE41E5BCC2825E37B64C"
 msgid "Ages later, the universe was filled with Seraphim and Demon alike."
-msgstr "Eras más tarde, el universo se llenó de Serafines y Demonios por igual."
+msgstr "Eras más tarde, el universo se llenó de serafines y demonios por igual."
 
 #. Key:	34678F424650992E3728BD9DE99571DA
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchHaveKeystone2.Default__MonarchHaveKeystone2_C.SessionData.Message
 #: /Game/Dialogue/Monarch/Default/MonarchHaveKeystone2.Default__MonarchHaveKeystone2_C.SessionData.Message
 msgctxt ",34678F424650992E3728BD9DE99571DA"
 msgid "Monarch is satisfied."
-msgstr ""
+msgstr "Monarch está satisfecha."
 
 #. Key:	34C104D84D1D1734B9408FA6B2BDA125
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDefault01_Meow_ButterStick.Default__CassieDefault01_Meow_ButterStick_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Cassie/Default/CassieDefault01_Meow_ButterStick.Default__CassieDefault01_Meow_ButterStick_C.SessionData.Lines(0).Lines
 msgctxt ",34C104D84D1D1734B9408FA6B2BDA125"
 msgid "Awww... meow... Cassie is sad now."
-msgstr "Awww… miau... Cassie esta triste ahora."
+msgstr "Ammm… miau... Cassie esta triste ahora."
 
 #. Key:	350B5B304D18A9FD50E44AA8A979877B
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMSoBeIt.Default__DMSoBeIt_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMSoBeIt.Default__DMSoBeIt_C.SessionData.Lines(0).Lines
 msgctxt ",350B5B304D18A9FD50E44AA8A979877B"
 msgid "Ahhh... so be it!"
-msgstr ""
+msgstr "Ahhh... ¡que así sea!"
 
 #. Key:	3526724A47197988348500AADC4A0504
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_RL.Default__RomyDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
@@ -2804,7 +2816,7 @@ msgstr "Entonces, ¿te bañas todo el día?"
 #: /Game/Dialogue/Monarch/Default/MonarchHaveKeystone.Default__MonarchHaveKeystone_C.SessionData.Lines(4).Lines
 msgctxt ",354DB41C4CBE7109F318B1B3C5D66984"
 msgid "Usually, they have their way with me before I can finish."
-msgstr ""
+msgstr "Por lo general, se salen con la suya antes de que pueda terminar."
 
 #. Key:	354E29D445D2F28CFD2E2782082F8D11
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_StartSnatchT.Default__MirruDefault01_StartSnatchT_C.SessionData.Lines(0).Lines
@@ -2818,28 +2830,28 @@ msgstr "Ahhh… ¡ven aquí humano!"
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03_R01.Default__FernDefault03_R01_C.SessionData.Lines(2).Lines
 msgctxt ",3587D87D4538714F62271FBFA1D17FFF"
 msgid "If I have to spend the rest of eternity in one spot, I wouldn't want it to be with anyone else..."
-msgstr "Si tuviera que pasar el resto de la eternidad en un lugar, no quisiera que fuera con nadie más..."
+msgstr "Si tuviera que pasar el resto de la eternidad en un lugar, no querría que fuera con nadie más..."
 
 #. Key:	35908AA04644610D46AB42B909BDD768
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleTittyPony_T.Default__KybeleTittyPony_T_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/Kybele/Default/KybeleTittyPony_T.Default__KybeleTittyPony_T_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",35908AA04644610D46AB42B909BDD768"
 msgid "That's it human, you have annoyed me long enough. Bend over and prepare to be stuffed with my fat spear!"
-msgstr ""
+msgstr "Eso es humana, me has molestado lo suficiente. ¡Inclínate y prepárate para ser llenada con mi gorda lanza!"
 
 #. Key:	35B0312145CDC987463545B35DBCF219
 #. SourceLocation:	/Game/Dialogue/Mirru/SexScenes/MirruSnatchT.Default__MirruSnatchT_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Mirru/SexScenes/MirruSnatchT.Default__MirruSnatchT_C.SessionData.Lines(0).Lines
 msgctxt ",35B0312145CDC987463545B35DBCF219"
 msgid "Submit human... I cannot control my desires!"
-msgstr "Sométete humano... ¡No puedo controlar mis deseos!"
+msgstr "Entrégate humano... ¡No puedo controlar mis deseos!"
 
 #. Key:	35BF63974E330C75B3359E8E1E99F0CB
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(11).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(11).Lines
 msgctxt ",35BF63974E330C75B3359E8E1E99F0CB"
 msgid "However the demons grew weary of being governed by archangels, and decided to revolt."
-msgstr "Sin embargo, los demonios se cansaron de ser gobernados por los arcángeles y decidieron rebelarse."
+msgstr "Sin embargo, los demonios se cansaron de ser gobernados por las arcángeles y decidieron rebelarse."
 
 #. Key:	35CF617940B0723BA4795CA4E3D0FA22
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_StartLoveMakingT.Default__LeylannaDefault01_StartLoveMakingT_C.SessionData.Lines(0).Lines
@@ -2853,35 +2865,35 @@ msgstr "Ven a mi abrazo."
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(15).LinesToFemale
 msgctxt ",35E72C7041E32B269ECDA081BF9906C0"
 msgid "I'm getting wetter by the second..."
-msgstr "Me estoy poniendo más húmeda cada segundo..."
+msgstr "Me estoy mojando más a cada segundo..."
 
 #. Key:	360772034C5CFEB38121F884358A5F7C
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowHadSex01.Default__WidowHadSex01_C.SessionData.LinesGrungy(1).LinesGrungy
 #: /Game/Dialogue/Widow/Default/WidowHadSex01.Default__WidowHadSex01_C.SessionData.LinesGrungy(1).LinesGrungy
 msgctxt ",360772034C5CFEB38121F884358A5F7C"
 msgid "You need a bath. Come now, place your body between my breasts and let's get you clean."
-msgstr ""
+msgstr "Necesitas un baño. Ven ahora, coloca tu cuerpo entre mis pechos y vamos a limpiarte."
 
 #. Key:	364811A44C2FE9E58EA99A89A91D330A
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcGoneWorse.Default__OrcGoneWorse_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcGoneWorse.Default__OrcGoneWorse_C.SessionData.Lines(0).Lines
 msgctxt ",364811A44C2FE9E58EA99A89A91D330A"
 msgid "Grrrrrrr!!!!!!!!"
-msgstr ""
+msgstr "¡¡¡¡¡¡¡¡Grrrrrrr!!!!!!!!"
 
 #. Key:	3688842F4859D54E5DEE7C9284F1966A
 #. SourceLocation:	/Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToFuta(8).LinesToFuta
 #: /Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToFuta(8).LinesToFuta
 msgctxt ",3688842F4859D54E5DEE7C9284F1966A"
 msgid "Sweet delicious human seed, let it all go! Ahhh..."
-msgstr "Dulce y deliciosa semilla humana, ¡déjala toda salir! Ahhh..."
+msgstr "Dulce y deliciosa semilla humana, ¡déjala ir toda! Ahhh..."
 
 #. Key:	3688E2EC4574EAE7A8F242B913F48060
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeAboutBees.Default__BeeAboutBees_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/QueenBee/Default/BeeAboutBees.Default__BeeAboutBees_C.SessionData.Lines(0).Lines
 msgctxt ",3688E2EC4574EAE7A8F242B913F48060"
 msgid "There isn't much to say. We stake out a claim of land with plentiful flowers, and use the nectar."
-msgstr ""
+msgstr "No hay mucho que decir. Cercamos un reclamo de tierra con abundantes flores y usamos el néctar."
 
 #. Key:	36E3E99D4C836714C7292D93FA860BA5
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R03.Default__FaleneDefault01_R03_C.SessionData.Lines(9).Lines
@@ -2895,14 +2907,14 @@ msgstr "Uno o más seguramente se interesarán y te seguirán."
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeHadSex01.Default__MegaSlimeHadSex01_C.SessionData.LinesToFuta(0).LinesToFuta
 msgctxt ",36FB659142F59E57CE11B996BF838787"
 msgid "Wow that felt so good!"
-msgstr ""
+msgstr "¡Guau, eso se sintió tan bien!"
 
 #. Key:	3713C92543DDBF9AF3C3209EE018350C
 #. SourceLocation:	/Game/Dialogue/Emissary/SexScenes/EmissaryAngelGroinLove.Default__EmissaryAngelGroinLove_C.SessionData.LinesToFuta(2).LinesToFuta
 #: /Game/Dialogue/Emissary/SexScenes/EmissaryAngelGroinLove.Default__EmissaryAngelGroinLove_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",3713C92543DDBF9AF3C3209EE018350C"
 msgid "Does my soft golden skin please you @BREEDER_NAME@?"
-msgstr "¿Mi suave piel dorada te agrada @BREEDER_NAME@?"
+msgstr "¿Mi suave piel dorada te complace, @BREEDER_NAME@?"
 
 #. Key:	371A297549D5D30EA8E2A9A04A208FC8
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R03.Default__FaleneDefault01_R03_C.SessionData.Lines(4).Lines
@@ -2923,14 +2935,14 @@ msgstr "¡Oh! ¡El humano!"
 #: /Game/Dialogue/Widow/Default/WidowKeystone.Default__WidowKeystone_C.SessionData.Lines(3).Lines
 msgctxt ",3771E4E540E0BDDF6C468691EF623F85"
 msgid "Perhaps a trade is in order..."
-msgstr ""
+msgstr "Quizás un intercambio esté en regla..."
 
 #. Key:	37933117464CBF3120925D83C7A81935
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToFemale(4).LinesToFemale
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToFemale(4).LinesToFemale
 msgctxt ",37933117464CBF3120925D83C7A81935"
 msgid "Imagine how good my tentacles will feel between your labia... and I promise they will touch every corner."
-msgstr "Imagina lo bien que se sentirán mis tentáculos entre tus labios... y prometo que tocarán cada esquina."
+msgstr "Imagina lo bien que se sentirán mis tentáculos entre tus labios... y te prometo que tocarán todos los rincones."
 
 #. Key:	37BE82A749B75C694B68B3856342C2A7
 #. SourceLocation:	/Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToMale(4).LinesToMale
@@ -2951,49 +2963,49 @@ msgstr "¿Sabes lo que es ser pequeña en este mundo?"
 #: /Game/Dialogue/DragonMatriarch/Default/DMTaskFulfilled.Default__DMTaskFulfilled_C.SessionData.Lines(1).Lines
 msgctxt ",3815589C483262ECB1EA19B8C0F8DABA"
 msgid "You gave me so much milk, and I consumed all of it!"
-msgstr ""
+msgstr "Me diste tanta leche, ¡y la consumí toda!"
 
 #. Key:	382D95F84EE60493751368AE5D1FFE56
 #. SourceLocation:	/Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToFuta(6).LinesToFuta
 #: /Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToFuta(6).LinesToFuta
 msgctxt ",382D95F84EE60493751368AE5D1FFE56"
 msgid "Yes! I can feel you're about to cum... I want it all. Mmmm..."
-msgstr "¡Si! Puedo sentir que estás a punto de correrte... Lo quiero todo. Mmmm..."
+msgstr "¡Sí! Puedo sentir que estás a punto de correrte... Lo quiero todo. Mmmm..."
 
 #. Key:	3834BEFA49DCF9700CF52A8776CAE288
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowKeystone.Default__WidowKeystone_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Widow/Default/WidowKeystone.Default__WidowKeystone_C.SessionData.Lines(5).Lines
 msgctxt ",3834BEFA49DCF9700CF52A8776CAE288"
 msgid "Oh the thought of my own adorable elf is making me wet... and hungry."
-msgstr ""
+msgstr "Oh, la idea de mi propia elfa adorable me está poniendo húmeda... y hambrienta."
 
 #. Key:	38365E644649BD12B20E879BB823AAC7
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaHadSex02.Default__CamillaHadSex02_C.SessionData.LinesToMale(1).LinesToMale
 #: /Game/Dialogue/Camilla/Default/CamillaHadSex02.Default__CamillaHadSex02_C.SessionData.LinesToMale(1).LinesToMale
 msgctxt ",38365E644649BD12B20E879BB823AAC7"
 msgid "Your cock was so big, I didn't think I could take all of it."
-msgstr ""
+msgstr "Tu polla era tan grande, no pensé que pudiera tomarla toda."
 
 #. Key:	383F99384A9AA2EB709D22BFAE55B72F
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleGreeting01.Default__KybeleGreeting01_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Kybele/Default/KybeleGreeting01.Default__KybeleGreeting01_C.SessionData.Lines(3).Lines
 msgctxt ",383F99384A9AA2EB709D22BFAE55B72F"
 msgid "You will have to go through me!"
-msgstr ""
+msgstr "¡Tendrás que pasar por encima mío!"
 
 #. Key:	386696884552AA79E38A38B6CD4C33BA
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiTaskFulfilled.Default__FesssiTaskFulfilled_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiTaskFulfilled.Default__FesssiTaskFulfilled_C.SessionData.Lines(0).Lines
 msgctxt ",386696884552AA79E38A38B6CD4C33BA"
 msgid "Freedom! The fresh air feels sssso good. The titan you bred me was so strong, it had no trouble lifting my heavy body. It even smashed a few surrounding rocks too!"
-msgstr ""
+msgstr "¡Libertad! El aire fresco se siente muy bien. El titán que me criaste era tan fuerte que no tuvo problemas para levantar mi pesado cuerpo. ¡Incluso aplastó algunas rocas circundantes también!"
 
 #. Key:	3888188240872C25EF9A03B26842C93D
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraTaskFulfilled.Default__PetraTaskFulfilled_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Petra/Default/PetraTaskFulfilled.Default__PetraTaskFulfilled_C.SessionData.Lines(0).Lines
 msgctxt ",3888188240872C25EF9A03B26842C93D"
 msgid "Now I understand! Pawsmaati's wisdom knows no bounds."
-msgstr ""
+msgstr "¡Ahora entiendo! La sabiduría de Pawsmaati no conoce límites."
 
 #. Key:	38A804064868E5E8FF3BE5A81144D82A
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01.Default__FernDefault01_C.SessionData.Lines(1).Lines
@@ -3007,21 +3019,21 @@ msgstr "..."
 #: /Game/Dialogue/Autumn/Default/DryadBossomCherries.Default__DryadBossomCherries_C.SessionData.Lines(9).Lines
 msgctxt ",38BCD1174242BC7366EC2D967B472DE1"
 msgid "You can tell how hard I came by the size of the fruit. The larger ones were oh so fun to make."
-msgstr ""
+msgstr "Se puede decir lo mucho que me vine por el tamaño de la fruta. Las más grandes fueron muy divertidas de hacer."
 
 #. Key:	38CC526548FEE9E798647C9C32B75ECE
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadAboutDryads.Default__DryadAboutDryads_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Autumn/Default/DryadAboutDryads.Default__DryadAboutDryads_C.SessionData.Lines(4).Lines
 msgctxt ",38CC526548FEE9E798647C9C32B75ECE"
 msgid "I decided to use my dryad power to produce fruit for them, and they love it."
-msgstr ""
+msgstr "Decidí usar mi poder de dríada para producir fruta para ellos, y les encanta."
 
 #. Key:	38F493C44D198004851E1399B9B3A835
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleTittyPony.Default__KybeleTittyPony_C.SessionData.LinesToMale(1).LinesToMale
 #: /Game/Dialogue/Kybele/Default/KybeleTittyPony.Default__KybeleTittyPony_C.SessionData.LinesToMale(1).LinesToMale
 msgctxt ",38F493C44D198004851E1399B9B3A835"
 msgid "It's been sometime since I have been mounted, so I might get rough!"
-msgstr ""
+msgstr "Ha pasado algún tiempo desde que me montaron, ¡así que podría ponerme dura!"
 
 #. Key:	391607BA4B3A996D1551BC9B7E71F385
 #. SourceLocation:	/Game/Characters/Procedural/Variants/Harpy/Harvest/HarpyHarvest.Default__HarpyHarvest_C.Harvest.RaceName
@@ -3035,42 +3047,42 @@ msgstr "Arpía"
 #: /Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToFuta(9).LinesToFuta
 msgctxt ",396BA75142AC2655B980A8AEF0F46AA5"
 msgid "*Suck* *Suck*"
-msgstr "*Chupar *Chupa*"
+msgstr "*Chupa* *Chupa*"
 
 #. Key:	396D6F1D4A5CDF3A44406A84BB8CE6D9
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiGreeting01.Default__ParvatiGreeting01_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/Parvati/Default/ParvatiGreeting01.Default__ParvatiGreeting01_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",396D6F1D4A5CDF3A44406A84BB8CE6D9"
 msgid "A human filled with lust comes before me, this I know."
-msgstr "Una humana llena de lujuria viene ante mí, y no por puro azar."
+msgstr "Un humano lleno de lujuria viene ante mí, esto lo sé."
 
 #. Key:	397B4EDC415499258BF65B825D968230
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeDefault01_RL.Default__AmberMaeDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
 #: /Game/Dialogue/AmberMae/Default/AmberMaeDefault01_RL.Default__AmberMaeDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
 msgctxt ",397B4EDC415499258BF65B825D968230"
 msgid "What do you know about the old temple?"
-msgstr ""
+msgstr "¿Qué sabes del antiguo templo?"
 
 #. Key:	39BB76F04901D85036C696B74CA537B3
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeDefault01_Accent.Default__AmberMaeDefault01_Accent_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeDefault01_Accent.Default__AmberMaeDefault01_Accent_C.SessionData.Lines(2).Lines
 msgctxt ",39BB76F04901D85036C696B74CA537B3"
 msgid "She can get mighty cold though, ye best fatten up on 'mai milk if yer head'n that way!"
-msgstr "Ella puede volvehse mu fría acuerdade, ¡será mejoh engordarte en mi leshe si estáh de esa manera!"
+msgstr "Aunque puede enfriahse musho, ¡será mejoh que engordeh con mi leshe si te encabezonah de esa manera!"
 
 #. Key:	39E4B8C74F24A77B88CFA89F73E896C7
 #. SourceLocation:	/Game/UI/TaskDescriptions.TaskDescriptions.TextEntries(2).TextEntries
 #: /Game/UI/TaskDescriptions.TaskDescriptions.TextEntries(2).TextEntries
 msgctxt ",39E4B8C74F24A77B88CFA89F73E896C7"
 msgid "Meow! Yes, I write that as often as I blurt it out. Hmmmm... I want... um... meow! Gimme something cute I can put my butter stick in. The less noise it makes the better I guess, meow. Maybe make it extra warm and soft... you can control that right? Meow, this paper looks tasty. Just a few nibbles wouldn't hurt.  -Cassie"
-msgstr ""
+msgstr "¡Miau! Sí, escribo eso tan a menudo como lo suelto. Hmmmm... quiero... um... ¡miau! Dame algo lindo en el que pueda meter mi barra de mantequilla. Supongo que cuanto menos ruido haga mejor, miau. Tal vez hacerlo más cálido y suave... puedes controlar eso, ¿verdad? Miau, este papel se ve delicioso. Unos pocos bocados no harán daño. -Cassie"
 
 #. Key:	39E5F4F34604E8D146FCCBA395551EFA
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.MutHut.ManageActionMessage
 #: /Game/World/Overworld.Overworld:PersistentLevel.MutHut.ManageActionMessage
 msgctxt ",39E5F4F34604E8D146FCCBA395551EFA"
 msgid "Manage your Hybrids"
-msgstr "Gestiona tus Híbridas"
+msgstr "Gestiona tus Hybrids"
 
 #. Key:	39EB8468458A5DE6DD323B9399883245
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(8).LinesToMale
@@ -3084,91 +3096,91 @@ msgstr "¡Reproducirnos!"
 #: /Game/Dialogue/Cassie/Default/CassieHadSex01.Default__CassieHadSex01_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",3A445E064F00F058EEF964928975B1F0"
 msgid "Meow! That felt so good..."
-msgstr ""
+msgstr "¡Miau! Eso se sintió tan bien..."
 
 #. Key:	3A46F38444516EB07B8D84BC38A2B77C
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadHaveKeystone.Default__DryadHaveKeystone_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Autumn/Default/DryadHaveKeystone.Default__DryadHaveKeystone_C.SessionData.Lines(2).Lines
 msgctxt ",3A46F38444516EB07B8D84BC38A2B77C"
 msgid "Sure we made a giant fruit, but you lack the lust I require to feed these cows."
-msgstr ""
+msgstr "Seguro que hicimos una fruta gigante, pero te falta la lujuria que necesito para alimentar a estas vacas."
 
 #. Key:	3A5C7D5342118BA87B8C6595C9B5D200
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R01.Default__CamillaDefault01_R01_C.SessionData.Lines(7).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R01.Default__CamillaDefault01_R01_C.SessionData.Lines(7).Lines
 msgctxt ",3A5C7D5342118BA87B8C6595C9B5D200"
 msgid "The massive set of tits called Amber sells milk. You can find Amber across the way, but be warned: the only thing thicker than her accent is her body. Good luck with that."
-msgstr "El enorme conjunto de tetas llamado Amber vende leche. Puedes encontrar a Amber en el camino, pero ten cuidado: lo único más grueso que su acento es su cuerpo. Buena suerte con eso."
+msgstr "El enorme conjunto de tetas llamado Amber vende leche. Puedes encontrar a Amber al otro lado del camino, pero ten cuidado: lo único más grueso que su acento es su cuerpo. Buena suerte con eso."
 
 #. Key:	3A8C32C44AAB9702B680029FE2C6DAD8
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchStartShySex.Default__MonarchStartShySex_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/Monarch/Default/MonarchStartShySex.Default__MonarchStartShySex_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",3A8C32C44AAB9702B680029FE2C6DAD8"
 msgid "*Extreme blushing*"
-msgstr ""
+msgstr "*Sonrojo extremo*"
 
 #. Key:	3AB82ACD4DE402E534B94C83E44F5A2C
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaGreeting01.Default__NeelaGreeting01_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Neela/Default/NeelaGreeting01.Default__NeelaGreeting01_C.SessionData.Lines(2).Lines
 msgctxt ",3AB82ACD4DE402E534B94C83E44F5A2C"
 msgid "Neela, warden of the Void, keybearer of pussy portals, at your service."
-msgstr "Neela, guardiana del Vacío, portadora de llaves de los coño portales, a tu servicio."
+msgstr "Neela, guardiana del Vacío, portadora de llaves de los coño-portales, a tu servicio."
 
 #. Key:	3AD149F249D46CC8CCB146B464F0C53D
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_TastyHuman.Default__NeelaDefault01_TastyHuman_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_TastyHuman.Default__NeelaDefault01_TastyHuman_C.SessionData.Lines(0).Lines
 msgctxt ",3AD149F249D46CC8CCB146B464F0C53D"
 msgid "Ahhhhhh... finally!"
-msgstr "Ahhhhhh... finalmente!"
+msgstr "Ahhhhhh... ¡por fin!"
 
 #. Key:	3AD376874C56281EC3CDA2BCD39AC51E
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(21).LinesToFemale
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(21).LinesToFemale
 msgctxt ",3AD376874C56281EC3CDA2BCD39AC51E"
 msgid "@MONSTER_RACE@ you catch won't be blessed like me!"
-msgstr "¡@MONSTER_RACE@ que atrapes no serán bendecidos como yo!"
+msgstr "¡Los @MONSTER_RACE@ que atrapes no serán bendecidos como yo!"
 
 #. Key:	3AEC10F04A7A17CC79668DBE56DADBEA
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraTaskFulfilled.Default__PetraTaskFulfilled_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Petra/Default/PetraTaskFulfilled.Default__PetraTaskFulfilled_C.SessionData.Lines(1).Lines
 msgctxt ",3AEC10F04A7A17CC79668DBE56DADBEA"
 msgid "It was a dragon all along. How could I not have guessed that!"
-msgstr ""
+msgstr "Fue un dragón todo el tiempo. ¡Cómo no pude haberlo adivinado!"
 
 #. Key:	3B3FB5184F1E276BF9EE46AB7835441D
 #. SourceLocation:	/Game/Characters/Procedural/Variants/Starfallen/Harvest/StarfallenHarvest.Default__StarfallenHarvest_C.Harvest.Description
 #: /Game/Characters/Procedural/Variants/Starfallen/Harvest/StarfallenHarvest.Default__StarfallenHarvest_C.Harvest.Description
 msgctxt ",3B3FB5184F1E276BF9EE46AB7835441D"
 msgid "Starfallen body fluids."
-msgstr "Fluidos corporales de Caído/a de las Estrellas."
+msgstr "Fluidos corporales de Starfallen."
 
 #. Key:	3B447AD04300826ECFC550A03A3AA0BC
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03_R02.Default__FernDefault03_R02_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03_R02.Default__FernDefault03_R02_C.SessionData.Lines(4).Lines
 msgctxt ",3B447AD04300826ECFC550A03A3AA0BC"
 msgid "My lower body is filled with nectar just waiting to surround your body as you cum again... and again."
-msgstr "Mi parte inferior del cuerpo está llena de néctar solo esperando rodear tu cuerpo mientras te corres una y otra vez."
+msgstr "La parte inferior de mi cuerpo está llena de néctar solo esperando rodear tu cuerpo mientras te corres otra una... y otra vez."
 
 #. Key:	3B686C7E477142920CF64F8119EC7E6F
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_FloatRhyme.Default__ParvatiDefault01_FloatRhyme_C.SessionData.Lines(6).Lines
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_FloatRhyme.Default__ParvatiDefault01_FloatRhyme_C.SessionData.Lines(6).Lines
 msgctxt ",3B686C7E477142920CF64F8119EC7E6F"
 msgid "Give into your desires, it will not render you weak."
-msgstr "Cede a tus deseos, no te hará debilitarte."
+msgstr "Cede a tus deseos, no te debilitará."
 
 #. Key:	3B6C0A634B200C954436A296F4A9EFEE
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_HowToSpiritForm.Default__LeylannaDefault01_HowToSpiritForm_C.SessionData.LinesToMale(2).LinesToMale
 #: /Game/Dialogue/Leylanna/Default/LeylannaDefault01_HowToSpiritForm.Default__LeylannaDefault01_HowToSpiritForm_C.SessionData.LinesToMale(2).LinesToMale
 msgctxt ",3B6C0A634B200C954436A296F4A9EFEE"
 msgid "Catch a male Vulwarg if you have not done so, and then return to me. We will then make love and form a covenant."
-msgstr "Atrapa a un Vulwarg macho, si aún no lo has hecho, y luego regresa a mí. Entonces haremos el amor y formaremos un pacto."
+msgstr "Atrapa a un macho vulwarg si aún no lo has hecho, y luego vuelve a mí. Luego haremos el amor y formaremos un pacto."
 
 #. Key:	3B7564A547A46D41C60CB999DCC9B845
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiHowLong.Default__FesssiHowLong_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiHowLong.Default__FesssiHowLong_C.SessionData.Lines(4).Lines
 msgctxt ",3B7564A547A46D41C60CB999DCC9B845"
 msgid "But by far the best surprises came from behind... or they did before that confounded Cockblock Gate sealed itself a few days ago."
-msgstr ""
+msgstr "Pero, con mucho, las mejores sorpresas vinieron desde atrás... o lo hicieron antes de que el confuso Portón Bloque-polla se sellara hace unos días."
 
 #. Key:	3B79840D47C6CCB278E40AB26C3546E7
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_StartMIssionary.Default__ParvatiDefault01_StartMIssionary_C.SessionData.Lines(0).Lines
@@ -3182,21 +3194,21 @@ msgstr "..."
 #: /Game/Dialogue/Widow/Default/WidowGreeting01.Default__WidowGreeting01_C.SessionData.Lines(0).Lines
 msgctxt ",3B83735E49E0C65B9C47E19DEE0B3417"
 msgid "*Strange moans and squishy noises can be heard within.*"
-msgstr ""
+msgstr "*Se pueden escuchar extraños gemidos y ruidos blandos en el interior.*"
 
 #. Key:	3B85C4B1437679C67EE00DB4AEA10E96
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcBrashDumb.Default__OrcBrashDumb_C.SessionData.Lines(7).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcBrashDumb.Default__OrcBrashDumb_C.SessionData.Lines(7).Lines
 msgctxt ",3B85C4B1437679C67EE00DB4AEA10E96"
 msgid "Me chieftain because I use my dick the most, so watch out!"
-msgstr ""
+msgstr "Yo cacique porque uso más mi pene, ¡así que ten cuidado!"
 
 #. Key:	3C151FC94376B799967B11AAA342949E
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDungeon_RL.Default__LeylannaDungeon_RL_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/Leylanna/Default/LeylannaDungeon_RL.Default__LeylannaDungeon_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",3C151FC94376B799967B11AAA342949E"
 msgid "You're the high priestess!!!!"
-msgstr ""
+msgstr "¡¡¡¡Eres la suma sacerdotisa!!!!"
 
 #. Key:	3C197E81483FDB92C0B7DE83C29374D3
 #. SourceLocation:	/Game/Ranch/Upgrades/ThriaeHive.Default__ThriaeHive_C.Upgrade.DisplayName
@@ -3210,14 +3222,14 @@ msgstr "Colmena de Thriaes"
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePearl.Default__MegaSlimePearl_C.SessionData.Message
 msgctxt ",3C6678BF441FA4DC09CD16B12864C86C"
 msgid "Beautiful Pearl was given away."
-msgstr ""
+msgstr "Perla Preciosa fue regalada."
 
 #. Key:	3C6949B84E9BE02327C5408DC7F1D673
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadDefault01_RL.Default__DryadDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
 #: /Game/Dialogue/Autumn/Default/DryadDefault01_RL.Default__DryadDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
 msgctxt ",3C6949B84E9BE02327C5408DC7F1D673"
 msgid "I can help you make a cherry!"
-msgstr ""
+msgstr "¡Puedo ayudarte a hacer una cereza!"
 
 #. Key:	3C944B624D25292479528987C3078CBF
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryGreeting01.Default__EmissaryGreeting01_C.SessionData.Lines(7).Lines
@@ -3231,35 +3243,37 @@ msgstr "Porque de Ella y a través de Ella y para Ella son todas las cosas. Para
 #: /Game/Dialogue/Widow/Default/WidowDefault01_RL.Default__WidowDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",3C9BA6E04AC95F2B27A50B89FF127DCA"
 msgid "Tell me about spiders."
-msgstr ""
+msgstr "Háblame de las arañas."
 
 #. Key:	3CA687014A0A2E686C1525BCF1F25CAE
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(30 - Value).TraitIcons.HelpText
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(30 - Value).TraitIcons.HelpText
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(30 -
+#: Value).TraitIcons.HelpText
 msgctxt ",3CA687014A0A2E686C1525BCF1F25CAE"
 msgid "Gaudy: Inherited an unusual vivid color scheme."
-msgstr "Llamativa/o: Heredó un inusual esquema de colores vivos."
+msgstr "Llamativo: heredó un inusual esquema de colores vivos."
 
 #. Key:	3CAE764B43C77D2CB4504791345E729C
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadFatAssLamia.Default__DryadFatAssLamia_C.SessionData.Lines(7).Lines
 #: /Game/Dialogue/Autumn/Default/DryadFatAssLamia.Default__DryadFatAssLamia_C.SessionData.Lines(7).Lines
 msgctxt ",3CAE764B43C77D2CB4504791345E729C"
 msgid "It's been awhile, maybe I should go check on her."
-msgstr ""
+msgstr "Ha pasado un tiempo, tal vez debería ir a ver cómo está."
 
 #. Key:	3CD8374646422958F67B3F8F2C11622C
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleTittyPony.Default__KybeleTittyPony_C.SessionData.LinesToFemale(2).LinesToFemale
 #: /Game/Dialogue/Kybele/Default/KybeleTittyPony.Default__KybeleTittyPony_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",3CD8374646422958F67B3F8F2C11622C"
 msgid "That should teach you to cross this titty po--I mean mighty centaur warmaiden, again!"
-msgstr ""
+msgstr "Eso debería enseñarte a cruzar esta poni tet-: ¡otra vez, me refiero a la poderosa doncella-guerrera centauro!"
 
 #. Key:	3D4441784AF4D03AE277679928164F4E
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(21 - Value).TraitIcons.DisplayName
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(21 - Value).TraitIcons.DisplayName
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(21 -
+#: Value).TraitIcons.DisplayName
 msgctxt ",3D4441784AF4D03AE277679928164F4E"
 msgid "Stoic"
-msgstr "Estoica/o"
+msgstr "Estoico"
 
 #. Key:	3D80ACD9492E522E22EE0EAAD298E834
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03_RL_F.Default__FernDefault03_RL_F_C.ResponseData(4).ResponseData.BreederPrompt
@@ -3273,109 +3287,110 @@ msgstr "Estoy trepando en tu flor."
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeDefault01_RL.Default__MegaSlimeDefault01_RL_C.ResponseData(4).ResponseData.BreederPrompt
 msgctxt ",3D8EEBEC4ED68B55EF4D03AE26C8037C"
 msgid "I want to play in your slime!"
-msgstr ""
+msgstr "¡Quiero jugar en tu limo!"
 
 #. Key:	3DB538F149AC7F6C7364009E1811D1CF
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault02.Default__EmissaryDefault02_C.SessionData.Lines(6).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault02.Default__EmissaryDefault02_C.SessionData.Lines(6).Lines
 msgctxt ",3DB538F149AC7F6C7364009E1811D1CF"
 msgid "Or, hath desire brought you abreast my holy golden bosom?"
-msgstr ""
+msgstr "¿O acaso el deseo te trajo junto a mi santo seno dorado?"
 
 #. Key:	3DDC87214109BEB2D2A970A966C08449
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchStartShySex.Default__MonarchStartShySex_C.SessionData.LinesToFemale(2).LinesToFemale
 #: /Game/Dialogue/Monarch/Default/MonarchStartShySex.Default__MonarchStartShySex_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",3DDC87214109BEB2D2A970A966C08449"
 msgid "May I... use my toy on you?"
-msgstr ""
+msgstr "¿Puedo... usar mi juguete contigo?"
 
 #. Key:	3DE7C5E5483FE8321224F9A0BE1EE1E2
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeLikesPresent.Default__MegaSlimeLikesPresent_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeLikesPresent.Default__MegaSlimeLikesPresent_C.SessionData.Lines(1).Lines
 msgctxt ",3DE7C5E5483FE8321224F9A0BE1EE1E2"
 msgid "I will keep it forever as a token of our friendship!"
-msgstr ""
+msgstr "¡Lo guardaré para siempre como muestra de nuestra amistad!"
 
 #. Key:	3E483C5F491D4BAE82E56082A61D1FA0
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleTaskFulfilled.Default__KybeleTaskFulfilled_C.SessionData.LinesToFemale(5).LinesToFemale
 #: /Game/Dialogue/Kybele/Default/KybeleTaskFulfilled.Default__KybeleTaskFulfilled_C.SessionData.LinesToFemale(5).LinesToFemale
 msgctxt ",3E483C5F491D4BAE82E56082A61D1FA0"
 msgid "Ahhh! She's the perfect toy for such a boring task. You have my thanks."
-msgstr ""
+msgstr "¡Ahhh! Ella es el juguete perfecto para una tarea tan aburrida. Tienes mi agradecimiento."
 
 #. Key:	3E509CE6430904677DC8DBB0A19336D8
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMDefault_RL.Default__DMDefault_RL_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/DragonMatriarch/Default/DMDefault_RL.Default__DMDefault_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",3E509CE6430904677DC8DBB0A19336D8"
 msgid "Can't you nap somewhere else?"
-msgstr ""
+msgstr "¿No puedes tomar una siesta en otro lugar?"
 
 #. Key:	3E5797444DCB450E19730E9C8CB6A4FB
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleTittyPony.Default__KybeleTittyPony_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/Kybele/Default/KybeleTittyPony.Default__KybeleTittyPony_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",3E5797444DCB450E19730E9C8CB6A4FB"
 msgid "That's it human, you have annoyed me long enough. Bend over and prepare to be stuffed with my fat spear!"
-msgstr ""
+msgstr "Eso es humana, me has molestado lo suficiente. ¡Inclínate y prepárate para ser llenada con mi gorda lanza!"
 
 #. Key:	3E5B1CA94E6EB9CC180AE3A6F9EC5439
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryCockblockGates.Default__EmissaryCockblockGates_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryCockblockGates.Default__EmissaryCockblockGates_C.SessionData.Lines(2).Lines
 msgctxt ",3E5B1CA94E6EB9CC180AE3A6F9EC5439"
 msgid "Seek the keystones hidden throughout the world, for one is required per gate."
-msgstr ""
+msgstr "Busca las piedras-llave escondidas en todo el mundo, ya que se requiere una por portón."
 
 #. Key:	3EAFC53348C0B793D4BF32A6B78F4E3F
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_Forgot_RL.Default__ParvatiDefault01_Forgot_RL_C.ResponseData(4).ResponseData.BreederPrompt
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_Forgot_RL.Default__ParvatiDefault01_Forgot_RL_C.ResponseData(4).ResponseData.BreederPrompt
 msgctxt ",3EAFC53348C0B793D4BF32A6B78F4E3F"
 msgid "Lifted!"
-msgstr "¡Levantado/a!"
+msgstr "¡Levantado!"
 
 #. Key:	3EB71DED4BE3050E6199E7B8D96DD53B
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiStuck.Default__FesssiStuck_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiStuck.Default__FesssiStuck_C.SessionData.Lines(5).Lines
 msgctxt ",3EB71DED4BE3050E6199E7B8D96DD53B"
 msgid "Hiss! Perhaps it's finally time I did something about thisss, so that I might share my ass with the world."
-msgstr ""
+msgstr "¡Sss! Quizás finalmente es hora de que haga algo al respecto, para poder compartir mi culo con el mundo."
 
 #. Key:	3ECED49B42C93D52237EFFBEAB033F9A
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeDefault01.Default__BeeDefault01_C.SessionData.LinesToMale(1).LinesToMale
 #: /Game/Dialogue/QueenBee/Default/BeeDefault01.Default__BeeDefault01_C.SessionData.LinesToMale(1).LinesToMale
 msgctxt ",3ECED49B42C93D52237EFFBEAB033F9A"
 msgid "Soon my nectar collection will be complete, and I can return to the Hivelands."
-msgstr ""
+msgstr "Pronto mi colección de néctar estará completa y podré regresar a las Tierras-Colmena."
 
 #. Key:	3EDC6D7644348135F915AD8CFA2438CE
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_RL_F.Default__FernDefault02_RL_F_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02_RL_F.Default__FernDefault02_RL_F_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",3EDC6D7644348135F915AD8CFA2438CE"
 msgid "Why did you call me master?"
-msgstr "¿Por qué me llamaste maestra?"
+msgstr "¿Por qué me llamaste, Master?"
 
 #. Key:	3EDC810646DEEE7CC8706393F4141D13
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimePlay.Default__MegaSlimePlay_C.SessionData.LinesToMale(0).LinesToMale
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePlay.Default__MegaSlimePlay_C.SessionData.LinesToMale(0).LinesToMale
 msgctxt ",3EDC810646DEEE7CC8706393F4141D13"
 msgid "Really?! These truly are the best days of my life!"
-msgstr ""
+msgstr "¡¿En serio?! ¡Estos son verdaderamente los mejores días de mi vida!"
 
 #. Key:	3EEDCB0B41A901791EE10990EB7EBF6A
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_AboutMusic.Default__RomyDefault01_AboutMusic_C.SessionData.Lines(6).Lines
 #: /Game/Dialogue/Romy/Default/RomyDefault01_AboutMusic.Default__RomyDefault01_AboutMusic_C.SessionData.Lines(6).Lines
 msgctxt ",3EEDCB0B41A901791EE10990EB7EBF6A"
 msgid "But every now and then a few like to roll around in the dirt."
-msgstr "Pero de vez en cuando a algunos les gusta rodar por la tierra."
+msgstr "Pero de vez en cuando a algunos les gusta revolcarse en la tierra."
 
 #. Key:	3EF462824AF0C626F44930B3EB3D1614
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R02.Default__CamillaDefault01_R02_C.SessionData.Lines(6).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R02.Default__CamillaDefault01_R02_C.SessionData.Lines(6).Lines
 msgctxt ",3EF462824AF0C626F44930B3EB3D1614"
 msgid "Demons prefer the lava flows of Moaning Crag."
-msgstr "Los Demonios prefieren los flujos de lava del Peñasco Gimiente."
+msgstr "Los demonios prefieren los flujos de lava del Risco Gimiente."
 
 #. Key:	3EF6E0F646189B89DDE495A5A01F7FC3
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(32 - Value).TraitIcons.DisplayName
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(32 - Value).TraitIcons.DisplayName
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(32 -
+#: Value).TraitIcons.DisplayName
 msgctxt ",3EF6E0F646189B89DDE495A5A01F7FC3"
 msgid "Abomination"
 msgstr "Abominación"
@@ -3385,7 +3400,7 @@ msgstr "Abominación"
 #: /Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFuta(0).LinesToFuta
 msgctxt ",3EFC55C841DE04F93E1162B03860B502"
 msgid "Ohhh @BREEDER_NAME@... you were amazing."
-msgstr ""
+msgstr "Ohhh, @BREEDER_NAME@... estuviste increíble."
 
 #. Key:	3F053255484259108C0E28AFBD627175
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToMale(1).LinesToMale
@@ -3399,21 +3414,21 @@ msgstr "No tienes idea de cuánto me estoy conteniendo en este momento..."
 #: /Game/Dialogue/Leylanna/Default/LeylannaOldTempleDungeon.Default__LeylannaOldTempleDungeon_C.SessionData.Lines(2).Lines
 msgctxt ",3F42819C4BE489F79C959596626E0A60"
 msgid "Oh..."
-msgstr ""
+msgstr "Oh..."
 
 #. Key:	3FA017C943E38117C9C5C1B911067136
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadCherryHelp_RL.Default__DryadCherryHelp_RL_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/Autumn/Default/DryadCherryHelp_RL.Default__DryadCherryHelp_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",3FA017C943E38117C9C5C1B911067136"
 msgid "Let's make a fruit!"
-msgstr ""
+msgstr "¡Hagamos una fruta!"
 
 #. Key:	3FF7BD1544456D7735C2D2AA0DCBAA1A
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaHadSex01.Default__CamillaHadSex01_C.SessionData.LinesToFuta(1).LinesToFuta
 #: /Game/Dialogue/Camilla/Default/CamillaHadSex01.Default__CamillaHadSex01_C.SessionData.LinesToFuta(1).LinesToFuta
 msgctxt ",3FF7BD1544456D7735C2D2AA0DCBAA1A"
 msgid "Your cock was so big, I didn't think I could take all of it."
-msgstr ""
+msgstr "Tu polla era tan grande, no pensé que pudiera tomarla toda."
 
 #. Key:	40100E704D14DC5D1B113F84C1BCE936
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(10).LinesToMale
@@ -3434,56 +3449,56 @@ msgstr "A pesar de mis constantes intentos de complacerla y amarla, ella no dijo
 #: /Game/Dialogue/Emissary/Default/EmissaryGreeting01.Default__EmissaryGreeting01_C.SessionData.Lines(1).Lines
 msgctxt ",4019AADD47513B243D987E8810645FAD"
 msgid "Before you is an emissary of the Goddess, and your archangel servant. Let these words pierce your heart, for I speak on Her behalf."
-msgstr "Ante ti hay una emisaria de la Diosa y tu arcángel sirviente. Deja que estas palabras atraviesen tu corazón, porque hablo en Su nombre."
+msgstr "Ante ti está una emisaria de la Diosa y tu arcángel sirviente. Deja que estas palabras traspasen tu corazón, porque hablo en Su nombre."
 
 #. Key:	4021F6674834D5C495A7E59231DB4FA4
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R03.Default__FaleneDefault01_R03_C.SessionData.Lines(12).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R03.Default__FaleneDefault01_R03_C.SessionData.Lines(12).Lines
 msgctxt ",4021F6674834D5C495A7E59231DB4FA4"
 msgid "If you aren't in the mood, you can also catch them by rubbing @MONSTER_RACE@ semen on their skin, or feeding them @MONSTER_RACE@ milk."
-msgstr "Si no estás de humor, también puede atraparlos frotando semen @MONSTER_RACE@ en su piel, o dándoles de comer leche de @MONSTER_RACE@."
+msgstr "Si no está de humor, también puede atraparlos frotando semen de @MONSTER_RACE@ en su piel o alimentándolos con leche de @MONSTER_RACE@."
 
 #. Key:	402496A44933EE13233F8E8A45D06E47
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchDefault01_RL.Default__MonarchDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/Monarch/Default/MonarchDefault01_RL.Default__MonarchDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",402496A44933EE13233F8E8A45D06E47"
 msgid "The queen?"
-msgstr ""
+msgstr "¿La reina?"
 
 #. Key:	4052D6DF434789A177EAA1A32665DC40
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_RL_T.Default__FernDefault02_RL_T_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02_RL_T.Default__FernDefault02_RL_T_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",4052D6DF434789A177EAA1A32665DC40"
 msgid "Why did you call me master?"
-msgstr "¿Por qué me llamaste maestra?"
+msgstr "¿Por qué me llamaste, Master?"
 
 #. Key:	408D0D424145C7FC8A4A419C5F15FC5E
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleAnyMeans.Default__KybeleAnyMeans_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/Kybele/Default/KybeleAnyMeans.Default__KybeleAnyMeans_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",408D0D424145C7FC8A4A419C5F15FC5E"
 msgid "Yes. By any means necessary!"
-msgstr ""
+msgstr "Si. ¡Por cualquier medio necesario!"
 
 #. Key:	409211234F50BB3CC5987D94FC8463AA
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraDefault01_RL.Default__PetraDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/Petra/Default/PetraDefault01_RL.Default__PetraDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",409211234F50BB3CC5987D94FC8463AA"
 msgid "Can you help me get that keystone?"
-msgstr ""
+msgstr "¿Puedes ayudarme a conseguir esa piedra-llave?"
 
 #. Key:	40FFE44B48699F620EAC16A81249A058
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeHadSex01.Default__MegaSlimeHadSex01_C.SessionData.LinesToFuta(3).LinesToFuta
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeHadSex01.Default__MegaSlimeHadSex01_C.SessionData.LinesToFuta(3).LinesToFuta
 msgctxt ",40FFE44B48699F620EAC16A81249A058"
 msgid "You should stay down here and give me more! We can be friends forever."
-msgstr ""
+msgstr "¡Deberías quedarte aquí y darme más! Podemos ser amigos para siempre."
 
 #. Key:	410012DF43FE2AB2B4B74FA7EE1CB85E
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeDefault01.Default__AmberMaeDefault01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeDefault01.Default__AmberMaeDefault01_C.SessionData.Lines(1).Lines
 msgctxt ",410012DF43FE2AB2B4B74FA7EE1CB85E"
 msgid "Come 'an put yerself betwixt them--I don't mind none!"
-msgstr "Ven y ponte entre ellah -- ¡No me importa na!"
+msgstr "Ven y ponte entre ellah: ¡no me importa na'!"
 
 #. Key:	41480BAC414E8393545F14A5AF5C1CBD
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernGreeting01.Default__FernGreeting01_C.SessionData.Lines(3).Lines
@@ -3497,56 +3512,56 @@ msgstr "..."
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_AboutKrakens.Default__MirruDefault01_AboutKrakens_C.SessionData.Lines(7).Lines
 msgctxt ",41542C1D49AAE2C08A8E1785C30CC95C"
 msgid "Most Krakens are futas, to maximize our pleasure and breeding potential."
-msgstr "La mayoría de los Krakens son futas, para maximizar nuestro placer y potencial de reproducción."
+msgstr "La mayoría de los krakens son futas, para maximizar nuestro placer y potencial de reproducción."
 
 #. Key:	415BAAD3485DF4862A1042A34A209E90
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMMuchEnergy.Default__DMMuchEnergy_C.SessionData.LinesToFemale(2).LinesToFemale
 #: /Game/Dialogue/DragonMatriarch/Default/DMMuchEnergy.Default__DMMuchEnergy_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",415BAAD3485DF4862A1042A34A209E90"
 msgid "Perhaps a quick flight up to Climax Peak is in order, there's bound to be a dumb Titan lumbering about."
-msgstr ""
+msgstr "Quizás un vuelo rápido hasta la Cumbre del Clímax esté en regla, seguramente habrá un titán tonto caminando pesadamente."
 
 #. Key:	4163AB5147C585FA2B2677AB39C31FC2
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcAkabekoCheck.Default__OrcAkabekoCheck_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcAkabekoCheck.Default__OrcAkabekoCheck_C.SessionData.Lines(1).Lines
 msgctxt ",4163AB5147C585FA2B2677AB39C31FC2"
 msgid "Human did good, chieftain already dumped loads in her."
-msgstr ""
+msgstr "El humano lo hizo bien, la cacique ya arrojó cargas sobre ella."
 
 #. Key:	417606634FB97A6E74DED7A87503CED0
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcDefault01.Default__OrcDefault01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcDefault01.Default__OrcDefault01_C.SessionData.Lines(0).Lines
 msgctxt ",417606634FB97A6E74DED7A87503CED0"
 msgid "Human! My tribe sisters want to breed."
-msgstr ""
+msgstr "¡Humano! Las hermanas de mi tribu quieren reproducirse."
 
 #. Key:	4190CA08434458A4DA0C58AFFD9BDDC9
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R04.Default__FaleneDefault01_R04_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R04.Default__FaleneDefault01_R04_C.SessionData.Lines(2).Lines
 msgctxt ",4190CA08434458A4DA0C58AFFD9BDDC9"
 msgid "According to my theories, I estimate @MONSTER_RACE@ are about 18 times as lustful as what we think humans to be."
-msgstr "Según mis teorías, calculo que @MONSTER_RACE@ son unas 18 veces más lujuriosos de lo que creemos que son los humanos."
+msgstr "Según mis teorías, calculo que los @MONSTER_RACE@ son unas 18 veces más lujuriosos de lo que creemos que son los humanos."
 
 #. Key:	41B56BDE47DBF26EB76387BAB182E0D2
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeDefault01.Default__BeeDefault01_C.SessionData.LinesToMale(2).LinesToMale
 #: /Game/Dialogue/QueenBee/Default/BeeDefault01.Default__BeeDefault01_C.SessionData.LinesToMale(2).LinesToMale
 msgctxt ",41B56BDE47DBF26EB76387BAB182E0D2"
 msgid "Is t-t-there something... you want human?"
-msgstr ""
+msgstr "¿Hay a-a-algo... que quieras humano?"
 
 #. Key:	41CE38AC413D8EA31A17AAA16825D852
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimePlay.Default__MegaSlimePlay_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePlay.Default__MegaSlimePlay_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",41CE38AC413D8EA31A17AAA16825D852"
 msgid "You will feel so good as I flood your womb with my slime..."
-msgstr ""
+msgstr "Te sentirás tan bien mientras inundo tu útero con mi limo..."
 
 #. Key:	41D4E33A4F278EEAC8E03DBD1A9618E5
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeSuckJugs_Start.Default__AmberMaeSuckJugs_Start_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeSuckJugs_Start.Default__AmberMaeSuckJugs_Start_C.SessionData.Lines(1).Lines
 msgctxt ",41D4E33A4F278EEAC8E03DBD1A9618E5"
 msgid "I'm get'n wet, milk me 'lil human! Drink it all!"
-msgstr "¡Me ehtoy mojando, ordeñame peke humana! ¡Bébela toa!"
+msgstr "¡Me ehtoy mojando, ordéñame peke humano! ¡Bébela toa!"
 
 #. Key:	42094BD145964827266556B272FD2005
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernGreeting03.Default__FernGreeting03_C.SessionData.LinesToMale(4).LinesToMale
@@ -3567,14 +3582,14 @@ msgstr "¿Qué puedes hacer?"
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFuta(21).LinesToFuta
 msgctxt ",421A6EEB4894FA5513454B9A113B5D73"
 msgid "@MONSTER_RACE@ you catch won't be blessed like me!"
-msgstr "¡@MONSTER_RACE@ que atrapes no serán bendecidos como yo!"
+msgstr "¡Los @MONSTER_RACE@ que atrapes no serán bendecidos como yo!"
 
 #. Key:	4225207741108002DA6A24AE7B076E55
 #. SourceLocation:	/Game/Dialogue/Yasmine/Default/YasminePearls.Default__YasminePearls_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Yasmine/Default/YasminePearls.Default__YasminePearls_C.SessionData.Lines(1).Lines
 msgctxt ",4225207741108002DA6A24AE7B076E55"
 msgid "They are fun to make, and can sell for a decent chunk of orgasium."
-msgstr ""
+msgstr "Son divertidas de hacer, y pueden venderse por una cantidad decente de orgasium."
 
 #. Key:	424BF25644C67138FF6800BD56A2F0CF
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(9).LinesToMale
@@ -3588,14 +3603,14 @@ msgstr "Nos encanta reproducirnos con todos los demás @MONSTER_RACE@."
 #: /Game/Dialogue/AmberMae/SexScenes/AmberMilkyF.Default__AmberMilkyF_C.SessionData.Lines(3).Lines
 msgctxt ",42666B4E478FE544AD7A4B91FD65DE82"
 msgid "Aye don't stop 'lil human! It's thick and creamy... ahhh!"
-msgstr "¡Sí, no pareh peke humana! Eh ehpesa y cremosa... ¡ahhh!"
+msgstr "¡Seh, no pareh peke humana! Eh ehpesa y cremosa... ¡ahhh!"
 
 #. Key:	42E4526948669BCD5AFBD29DC9583D3C
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R06.Default__FaleneDefault01_R06_C.SessionData.Lines(7).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R06.Default__FaleneDefault01_R06_C.SessionData.Lines(7).Lines
 msgctxt ",42E4526948669BCD5AFBD29DC9583D3C"
 msgid "Meh, I am an alchemist... I don't believe in this stuff! Go talk to high priestess Leylanna or that creepy Seraphim if you want to learn more about this myth!"
-msgstr "Meh, soy una alquimista... ¡No creo en estas cosas! ¡Ve a hablar con la suma sacerdotisa Leylanna o con esa espeluznante Serafin si quieres aprender más sobre este mito!"
+msgstr "Meh, soy una alquimista... ¡no creo en estas cosas! ¡Ve a hablar con la suma sacerdotisa Leylanna o con esa espeluznante serafín si quieres aprender más sobre este mito!"
 
 #. Key:	431393014FD2AE0F14B10994F1A6E951
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(5).Lines
@@ -3609,42 +3624,42 @@ msgstr "Se necesitó una fuerza para contrastar la luz, por lo que la Diosa cedi
 #: /Game/Dialogue/OrcChief/Default/OrcFixOwnGate.Default__OrcFixOwnGate_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",432AB6154EB0FCBABFD45A9F48D948F8"
 msgid "Human fix gate now, or get cock stuffed down gullet!"
-msgstr ""
+msgstr "¡Ahora arregla el portón humana, o haré que la polla rellene bajando por la garganta!"
 
 #. Key:	433691C34A0864415618B78808993A0E
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMNapSomewhereElse.Default__DMNapSomewhereElse_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMNapSomewhereElse.Default__DMNapSomewhereElse_C.SessionData.Lines(1).Lines
 msgctxt ",433691C34A0864415618B78808993A0E"
 msgid "For hundreds of years I have come to this rock to rest, it's quite comfortable."
-msgstr ""
+msgstr "Durante cientos de años he venido a descansar a esta roca, es bastante cómodo."
 
 #. Key:	434F3EDD4D71E19F342B9FB4B2780A63
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaHadSex01.Default__NeelaHadSex01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Neela/Default/NeelaHadSex01.Default__NeelaHadSex01_C.SessionData.Lines(0).Lines
 msgctxt ",434F3EDD4D71E19F342B9FB4B2780A63"
 msgid "Oh yes, that was incredible."
-msgstr ""
+msgstr "Oh, sí, eso fue increíble."
 
 #. Key:	434FF9C34E180AC6724D628D8E2EB07A
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDungeon2.Default__CassieDungeon2_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Cassie/Default/CassieDungeon2.Default__CassieDungeon2_C.SessionData.Lines(4).Lines
 msgctxt ",434FF9C34E180AC6724D628D8E2EB07A"
 msgid "*Purr* You made me feel so good... so Cassie fixed it for you!"
-msgstr ""
+msgstr "*Ronronea* Me hiciste sentir tan bien... ¡así que Cassie te lo arregló!"
 
 #. Key:	4360D9A3483F76A70B34C59BF0B5B019
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiAreYouOk.Default__FesssiAreYouOk_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiAreYouOk.Default__FesssiAreYouOk_C.SessionData.Lines(0).Lines
 msgctxt ",4360D9A3483F76A70B34C59BF0B5B019"
 msgid "Your concern is making me wet... hissss... come closer."
-msgstr ""
+msgstr "Tu preocupación me está mojando... sss... acércate."
 
 #. Key:	436AE5954AEC637113E3E1A30DFDE1C5
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMNapSomewhereElse.Default__DMNapSomewhereElse_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMNapSomewhereElse.Default__DMNapSomewhereElse_C.SessionData.Lines(0).Lines
 msgctxt ",436AE5954AEC637113E3E1A30DFDE1C5"
 msgid "Nah."
-msgstr ""
+msgstr "Nah."
 
 #. Key:	437DBE7940749A6838FDA39FD90FF637
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryRaiseTraitLvl_RL.Default__EmissaryRaiseTraitLvl_RL_C.ResponseData(0).ResponseData.BreederPrompt
@@ -3658,21 +3673,21 @@ msgstr "Aceptar"
 #: /Game/Dialogue/Camilla/Default/CamillaHadSex01.Default__CamillaHadSex01_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",43B91A4A43D78CA88ED80E9B8E857EB2"
 msgid "If you... uh... ever get desperate again, you know where to find me!"
-msgstr ""
+msgstr "Si... eh... alguna vez te desesperas de nuevo, ¡ya sabes dónde encontrarme!"
 
 #. Key:	43D16A4C487E8E717D3AF2A72A1F2C56
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_MultipleHearts.Default__MirruDefault01_MultipleHearts_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_MultipleHearts.Default__MirruDefault01_MultipleHearts_C.SessionData.Lines(1).Lines
 msgctxt ",43D16A4C487E8E717D3AF2A72A1F2C56"
 msgid "Way to kill the mood human."
-msgstr "Qué manera de matar el humor humana."
+msgstr "Qué manera de matar el humor, humano."
 
 #. Key:	43D6E7FC4718254A804FD5AF3D1C8186
 #. SourceLocation:	/Game/Dialogue/Neela/SexScenes/NeelaSnakeCuddleT.Default__NeelaSnakeCuddleT_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Neela/SexScenes/NeelaSnakeCuddleT.Default__NeelaSnakeCuddleT_C.SessionData.Lines(3).Lines
 msgctxt ",43D6E7FC4718254A804FD5AF3D1C8186"
 msgid "Does my Lamia body please you?"
-msgstr "¿Mi cuerpo de Lamia te agrada?"
+msgstr "¿Mi cuerpo de lamia te complace?"
 
 #. Key:	43D79A3F4EFECC071827CCAC96ED865A
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R06.Default__FaleneDefault01_R06_C.SessionData.Lines(5).Lines
@@ -3686,14 +3701,14 @@ msgstr "Ella dio a luz descendencia a su imagen y los hizo inmortales. Los que c
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R07.Default__CamillaDefault01_R07_C.SessionData.LinesToFuta(0).LinesToFuta
 msgctxt ",43F7A9D34F081E2EA25537A60B42DBA3"
 msgid "Don't waste your delicious body fluid on me. Just wait for Falene to come back, or go suck on Amber's tits."
-msgstr "No desperdicies tu delicioso líquido corporal en mí. Solo espera a que Falene vuelva, o ve a chupar las tetas de Amber."
+msgstr "No desperdicies tu delicioso fluido corporal en mí. Solo espera a que vuelva Falene o ve a chupar las tetas de Amber."
 
 #. Key:	44000BD74D084D5F4F4AD99708071613
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieHadSex01.Default__CassieHadSex01_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/Cassie/Default/CassieHadSex01.Default__CassieHadSex01_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",44000BD74D084D5F4F4AD99708071613"
 msgid "*Purr*"
-msgstr ""
+msgstr "*Ronronea*"
 
 #. Key:	442AA41044275C5F5330F99CF2ECE542
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_StartLifted.Default__ParvatiDefault01_StartLifted_C.SessionData.Lines(0).Lines
@@ -3707,21 +3722,22 @@ msgstr "..."
 #: /Game/Dialogue/Fesssi/Default/FesssiStuck.Default__FesssiStuck_C.SessionData.Lines(1).Lines
 msgctxt ",44A109FA42CB5758C411968173BA0B7F"
 msgid "My giant, but delicious ass, has been stuck in this cave for a long time. Hiss!"
-msgstr ""
+msgstr "Mi gigante pero delicioso culo lleva mucho tiempo atrapado en esta cueva. ¡Sss!"
 
 #. Key:	44ABED7740DE9FD12170D8B548E87A78
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(8).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(8).Lines
 msgctxt ",44ABED7740DE9FD12170D8B548E87A78"
 msgid "She assigned each world a special Seraphim, an archangel, to guide the evolution of life."
-msgstr "Ella asignó a cada mundo una Serafín especial, una arcángel, para guiar la evolución de la vida."
+msgstr "Ella asignó a cada mundo una serafín especial, una arcángel, para guiar la evolución de la vida."
 
 #. Key:	44BC09AE4BDFA439FBFD8BAABD7A96D0
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(25 - Value).TraitIcons.DisplayName
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(25 - Value).TraitIcons.DisplayName
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(25 -
+#: Value).TraitIcons.DisplayName
 msgctxt ",44BC09AE4BDFA439FBFD8BAABD7A96D0"
 msgid "Chubby"
-msgstr "Gordita/o"
+msgstr "Gordito"
 
 #. Key:	44F952984F6E2F20583500AA72B0067A
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_WhatGoddessDoes.Default__EmissaryDefault01_WhatGoddessDoes_C.SessionData.Lines(0).Lines
@@ -3742,21 +3758,21 @@ msgstr "¡Eso hace que tu trabajo sea mucho más fácil!"
 #: /Game/Characters/Procedural/Variants/Sylvan/Harvest/SylvanHarvest.Default__SylvanHarvest_C.Harvest.RaceName
 msgctxt ",451D045F4EC3DCF8BA7211AC97FF4D8A"
 msgid "Sylvan"
-msgstr "Silvestre"
+msgstr "Silvano"
 
 #. Key:	451F078442E7E1029E8F99BF760B9E69
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFuta(12).LinesToFuta
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFuta(12).LinesToFuta
 msgctxt ",451F078442E7E1029E8F99BF760B9E69"
 msgid "You have a beautiful set of fertile hips and breasts... and... ohhhh, a nice thick dick! You, my lovely futa, will make a great mate!"
-msgstr "Tienes un hermoso conjunto de fértiles senos y caderas ... y ... ¡ohhhh, una bonita polla gruesa! ¡Tú, mi encantadora futa, serás una gran compañera!"
+msgstr "Tienes un hermoso conjunto de caderas y pechos fértiles... y... ¡ohhhh, un buen y grueso pene! ¡Tú, mi adorable futa, serás una gran pareja!"
 
 #. Key:	45593BFD42216BAC5309AAAB9A612E59
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiHadSex01.Default__FesssiHadSex01_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/Fesssi/Default/FesssiHadSex01.Default__FesssiHadSex01_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",45593BFD42216BAC5309AAAB9A612E59"
 msgid "Bring that human pussy back to me soon."
-msgstr ""
+msgstr "Tráeme ese coño humano pronto."
 
 #. Key:	45B1E6E34C7DA1B37BDE04B204DC4C4B
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_RL.Default__MirruDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
@@ -3777,7 +3793,7 @@ msgstr "Gestiona tus Nekos"
 #: /Game/Dialogue/Kybele/Default/KybeleCentaur.Default__KybeleCentaur_C.SessionData.Lines(6).Lines
 msgctxt ",46018B7B49E8F91F3AB3B5A9002485B1"
 msgid "External \"help\" is required, and you are looking tasty at the moment."
-msgstr ""
+msgstr "Se requiere \"ayuda\" externa y te ves delicioso en este momento."
 
 #. Key:	464B0F3B450345A0F3EA8E98C67A5248
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(6).LinesToMale
@@ -3791,49 +3807,49 @@ msgstr "Mi nombre es Falene, la especialista de @MONSTER_RACE@ líder en todo @W
 #: /Game/Ranch/Upgrades/RisuHutch.Default__RisuHutch_C.Upgrade.Description
 msgctxt ",465ADEB24CD3DDFD522F83BA4982D09B"
 msgid "This allows you to catch and store all variants of Risu."
-msgstr ""
+msgstr "Esto te permite capturar y almacenar todas las variantes de Risus."
 
 #. Key:	4673804842CCE448A5F016907F5651DD
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_Princess.Default__MirruDefault01_Princess_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_Princess.Default__MirruDefault01_Princess_C.SessionData.Lines(1).Lines
 msgctxt ",4673804842CCE448A5F016907F5651DD"
 msgid "My mother is a magnificent Kraken, a beautiful voluptous maiden of the sea. To be half as good a queen as her would be a life well lived..."
-msgstr "Mi madre es una magnífica Kraken, una hermosa voluptuosa doncella del mar. Ser la mitad de buena reina que ella, sería una vida bien vivida..."
+msgstr "Mi madre es una kraken magnífica, una hermosa y voluptuosa doncella del mar. Ser la mitad de buena reina que ella sería una vida bien vivida..."
 
 #. Key:	46745F5D451EF7EB89BFE58F57B364E3
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadHadSex01.Default__DryadHadSex01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Autumn/Default/DryadHadSex01.Default__DryadHadSex01_C.SessionData.Lines(0).Lines
 msgctxt ",46745F5D451EF7EB89BFE58F57B364E3"
 msgid "Look at the size of it!"
-msgstr ""
+msgstr "¡Mira el tamaño!"
 
 #. Key:	46C09FA14157EC1F3D6608BB30F25A60
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon2.Default__AmberMaeLockedDungeon2_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon2.Default__AmberMaeLockedDungeon2_C.SessionData.Lines(3).Lines
 msgctxt ",46C09FA14157EC1F3D6608BB30F25A60"
 msgid "Them townsfolk loved playing with 'mai soft body... *sigh*"
-msgstr ""
+msgstr "A la gente der pueblo le encantaba jugah con mi zuave cuerpo... *suspira*"
 
 #. Key:	46D776EB4F6C6F71D802088F7C493A82
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToFuta(6).LinesToFuta
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToFuta(6).LinesToFuta
 msgctxt ",46D776EB4F6C6F71D802088F7C493A82"
 msgid "If that doesn't suit you, how about you feed me some of your delicious cum?"
-msgstr ""
+msgstr "Si eso no te conviene, ¿qué tal si me das un poco de tu delicioso semen?"
 
 #. Key:	46DF2A6B40E2BC05DF3CD5879A17D834
 #. SourceLocation:	/Game/Characters/Procedural/Variants/Sylvan/Harvest/SylvanHarvest.Default__SylvanHarvest_C.Harvest.Description
 #: /Game/Characters/Procedural/Variants/Sylvan/Harvest/SylvanHarvest.Default__SylvanHarvest_C.Harvest.Description
 msgctxt ",46DF2A6B40E2BC05DF3CD5879A17D834"
 msgid "Sylvan body fluids."
-msgstr "Fluidos corporales de Silvestre."
+msgstr "Fluidos corporales de Silvano."
 
 #. Key:	46E1708442BF3BDBC5C555BB87A184A4
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiIdiots.Default__FesssiIdiots_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiIdiots.Default__FesssiIdiots_C.SessionData.Lines(4).Lines
 msgctxt ",46E1708442BF3BDBC5C555BB87A184A4"
 msgid "Maybe a team of vulwarg males... no they would just want blow jobs and then run away."
-msgstr ""
+msgstr "Tal vez un equipo de machos vulwarg... no, solo querrían mamadas y luego escapar."
 
 #. Key:	4713FDFD44B74E42186DE9AD0CAAEBC6
 #. SourceLocation:	/Game/Dialogue/Neela/SexScenes/NeelaSnakeCuddleF.Default__NeelaSnakeCuddleF_C.SessionData.Lines(3).Lines
@@ -3847,14 +3863,14 @@ msgstr "*Lame*"
 #: /Game/Dialogue/Kybele/Default/KybeleDefault01_RL.Default__KybeleDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",473797F44055F2EA1A6BA1B748146FFF"
 msgid "Wow a centaur!"
-msgstr ""
+msgstr "¡Guau, un centauro!"
 
 #. Key:	47464D7B43F2BD56B082E8AB7F91F25E
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiHowLong.Default__FesssiHowLong_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiHowLong.Default__FesssiHowLong_C.SessionData.Lines(5).Lines
 msgctxt ",47464D7B43F2BD56B082E8AB7F91F25E"
 msgid "Damn those Cockblock Gates... we never asked for those. Imagine if the ancient builders of the world made something useful, like a spell to give futas a scrotum."
-msgstr ""
+msgstr "Malditos sean esos Portones Bloque-polla... nunca los pedimos. Imagínese si los antiguos constructores del mundo hicieran algo útil, como un hechizo para dar a los futas un escroto."
 
 #. Key:	47621D134EBA27E9FF0A6888F1D9CF3D
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernGreeting03.Default__FernGreeting03_C.SessionData.LinesToFemale(2).LinesToFemale
@@ -3879,7 +3895,8 @@ msgstr "¡Puedes tener mi leche materna!"
 
 #. Key:	47D73C824ADC81BC6CCF3D92213FA9A5
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(29 - Value).TraitIcons.DisplayName
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(29 - Value).TraitIcons.DisplayName
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(29 -
+#: Value).TraitIcons.DisplayName
 msgctxt ",47D73C824ADC81BC6CCF3D92213FA9A5"
 msgid "Sterile"
 msgstr "Estéril"
@@ -3889,32 +3906,33 @@ msgstr "Estéril"
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_Forgot_RL.Default__ParvatiDefault01_Forgot_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",47E16E8D474D1F2D115C12A6DEB45E2B"
 msgid "Oh wait I haven't learned anything yet!!!!!"
-msgstr "¡Oh, espera, aún no he aprendido nada!"
+msgstr "¡¡¡¡¡Oh, espera, no he aprendido nada todavía!!!!!"
 
 #. Key:	47F7DAF04C7F69F373B132BD8B955A76
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcFixOwnGate.Default__OrcFixOwnGate_C.SessionData.LinesToFemale(2).LinesToFemale
 #: /Game/Dialogue/OrcChief/Default/OrcFixOwnGate.Default__OrcFixOwnGate_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",47F7DAF04C7F69F373B132BD8B955A76"
 msgid "*Snarl*"
-msgstr ""
+msgstr "*Gruñe*"
 
 #. Key:	47FF727144E602154C40FFB1396CB921
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_RL.Default__FaleneDefault01_RL_C.ResponseData(5).ResponseData.BreederPrompt
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_RL.Default__FaleneDefault01_RL_C.ResponseData(5).ResponseData.BreederPrompt
 msgctxt ",47FF727144E602154C40FFB1396CB921"
 msgid "Tell me about painted elves."
-msgstr "Háblame sobre los elfos pintados."
+msgstr "Háblame de los elfos pintados."
 
 #. Key:	480CD24248AA305AA580D7AE82BC3035
 #. SourceLocation:	/Game/UI/TaskDescriptions.TaskDescriptions.TextEntries(6).TextEntries
 #: /Game/UI/TaskDescriptions.TaskDescriptions.TextEntries(6).TextEntries
 msgctxt ",480CD24248AA305AA580D7AE82BC3035"
 msgid "For once I would like someone to bathe me. If it is not too much trouble, breed me an elegant wild Nephelym with the sweetest music so that we may bathe together. I want to feel their hands rub my fins while we sulk in warm water and dive deeper into the pleasures of love.  -Romy"
-msgstr ""
+msgstr "Por una vez me gustaría que alguien me bañara. Si no es mucho problema, críame un elegante Nephelym silvestre con la música más dulce para que podamos bañarnos juntos. Quiero sentir sus manos frotando mis aletas mientras nos enfurruñamos en agua tibia y nos sumergimos más profundamente en los placeres del amor. -Romy"
 
 #. Key:	48107A45419D9511DA312F919A7866E8
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TravelShrines(6 - Value).TravelShrines.ShrineName
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TravelShrines(6 - Value).TravelShrines.ShrineName
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TravelShrines(6 -
+#: Value).TravelShrines.ShrineName
 msgctxt ",48107A45419D9511DA312F919A7866E8"
 msgid "Hedon Township"
 msgstr "Municipio de Hedon"
@@ -3931,7 +3949,7 @@ msgstr "Los placeres que experimentamos durante la reproducción son... intensos
 #: /Game/World/Overworld.Overworld:PersistentLevel.EM_HedonDungeonSwitch.BlockMessage
 msgctxt ",486FA5BE4745240DE60186BE36444829"
 msgid "The switch does not move."
-msgstr ""
+msgstr "El interruptor no se mueve."
 
 #. Key:	48A773D34A077935AE7A2FAD14F4A978
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryGreeting01.Default__EmissaryGreeting01_C.SessionData.Lines(6).Lines
@@ -3945,49 +3963,50 @@ msgstr "Cuanto más poderosa el alma que me confíes, mayor será tu recompensa.
 #: /Game/Characters/Procedural/Variants/Foxen/Harvest/FoxenHarvest.Default__FoxenHarvest_C.Harvest.RaceName
 msgctxt ",48CC4FFE4554B0228CDDB7A68DA380FB"
 msgid "Foxen"
-msgstr "Zorro"
+msgstr "Foxen"
 
 #. Key:	48ECD1FC4E34FAB69B41249F46A1CAB8
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryGreeting01.Default__EmissaryGreeting01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryGreeting01.Default__EmissaryGreeting01_C.SessionData.Lines(0).Lines
 msgctxt ",48ECD1FC4E34FAB69B41249F46A1CAB8"
 msgid "@BREEDER_NAME@. Long have I waited for your arrival."
-msgstr "@BREEDER_NAME@. Hace tiempo que espero tu llegada."
+msgstr "@BREEDER_NAME@. Hace mucho que esperaba tu llegada."
 
 #. Key:	48EDBF874DED77CEE66F469303F265EB
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFemale(9).LinesToFemale
 #: /Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFemale(9).LinesToFemale
 msgctxt ",48EDBF874DED77CEE66F469303F265EB"
 msgid "I won't go near that temple, they will probably try and convert me, or make me inhale blue smoke."
-msgstr ""
+msgstr "No me acercaré a ese templo, probablemente intentarán convertirme o me harán inhalar humo azul."
 
 #. Key:	48F333E347A7091F18F946AADDC3C69D
 #. SourceLocation:	/Game/Dialogue/Mirru/SexScenes/MirruKrakVag.Default__MirruKrakVag_C.SessionData.Lines(6).Lines
 #: /Game/Dialogue/Mirru/SexScenes/MirruKrakVag.Default__MirruKrakVag_C.SessionData.Lines(6).Lines
 msgctxt ",48F333E347A7091F18F946AADDC3C69D"
 msgid "Oh... you please this Kraken princess greatly human..."
-msgstr "Oh ... tu complaces esta princesa Kraken intensamente humana..."
+msgstr "Oh... complaces a esta princesa kraken enormemente humano..."
 
 #. Key:	4941188D4EE43A48ECE99F9361838C0C
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(4).LinesToMale
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(4).LinesToMale
 msgctxt ",4941188D4EE43A48ECE99F9361838C0C"
 msgid "And I'm one of them! A blessed female Painted Elf to be exact!"
-msgstr "¡Y yo soy una de ellos! ¡Una bendecida elfa pintada, para ser exactos!"
+msgstr "¡Y yo soy una de ellos! ¡Una elfa pintada bendecida para ser exactas!"
 
 #. Key:	4954D9E748572866289FA785934950B8
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_Teach.Default__ParvatiDefault01_Teach_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_Teach.Default__ParvatiDefault01_Teach_C.SessionData.Lines(0).Lines
 msgctxt ",4954D9E748572866289FA785934950B8"
 msgid "Remove your garments, for you must be nude."
-msgstr "Quítate la ropa, debes estar desnuda."
+msgstr "Quítate tus prendas, debes estar desnudo."
 
 #. Key:	49C9E46943998C63648E12A033938266
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(9 - Value).TraitIcons.DisplayName
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(9 - Value).TraitIcons.DisplayName
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(9 -
+#: Value).TraitIcons.DisplayName
 msgctxt ",49C9E46943998C63648E12A033938266"
 msgid "Debauched"
-msgstr "Perversa/o"
+msgstr "Perverso"
 
 #. Key:	49DC40D24B51D1AB62F3B6A881228980
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernGreeting01.Default__FernGreeting01_C.SessionData.Lines(1).Lines
@@ -4001,14 +4020,14 @@ msgstr "..."
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeHadSex01.Default__MegaSlimeHadSex01_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",4A37F933461F6E0CC65A6D82757FB764"
 msgid "Wow that felt so good!"
-msgstr ""
+msgstr "¡Guau, eso se sintió tan bien!"
 
 #. Key:	4A730CFD4FE7937D823362B706A236A2
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_EnlightenedOne.Default__NeelaDefault01_EnlightenedOne_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_EnlightenedOne.Default__NeelaDefault01_EnlightenedOne_C.SessionData.Lines(1).Lines
 msgctxt ",4A730CFD4FE7937D823362B706A236A2"
 msgid "Her name is Pawsmaati, a blessed Neko in Sultry Plateau."
-msgstr "Su nombre es Pawsmaati, una bendecida Neko en la Meseta Bochornosa."
+msgstr "Su nombre es Pawsmaati, una neko bendecida en la Meseta Bochornosa."
 
 #. Key:	4A786E0642F65E2541EAB4BB64AD2628
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_RL_M.Default__FernDefault02_RL_M_C.ResponseData(1).ResponseData.BreederPrompt
@@ -4022,7 +4041,7 @@ msgstr "Has cambiado."
 #: /Game/World/Overworld.Overworld:PersistentLevel.CBGate_Crag.BlockMessage
 msgctxt ",4A8B6F014E313E51F87D8C8706BE28E3"
 msgid "Webs block this gate."
-msgstr ""
+msgstr "Las telarañas bloquean este potón."
 
 #. Key:	4A8BADCE4B9CDED5FAF83F9E2C212E8C
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToMale(0).LinesToMale
@@ -4050,14 +4069,14 @@ msgstr "¿Qué puedes hacer?"
 #: /Game/Dialogue/Parvati/Default/ParvatiGreeting01.Default__ParvatiGreeting01_C.SessionData.LinesToFemale(7).LinesToFemale
 msgctxt ",4ADC18CD4A8D1152D3ABF788E0A8ECCF"
 msgid "Just as water can take on any form."
-msgstr "Así como el agua puede tomar cualquier forma aún sin pulir."
+msgstr "Así como el agua puede adoptar cualquier forma."
 
 #. Key:	4AF4F6C44BC706495A6BC1910F5EB035
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaFaleneWeek.Default__CamillaFaleneWeek_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaFaleneWeek.Default__CamillaFaleneWeek_C.SessionData.Lines(1).Lines
 msgctxt ",4AF4F6C44BC706495A6BC1910F5EB035"
 msgid "Which is nothing more than an excuse to have sex with everything in sight while I do all the work!!"
-msgstr ""
+msgstr "¡¡Que no es más que una excusa para tener sexo con todo lo que se mueve mientras yo hago todo el trabajo!!"
 
 #. Key:	4AF6D7774E005B4FEFEFBD91CE5F5322
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01_RL_T.Default__FernDefault01_RL_T_C.ResponseData(4).ResponseData.BreederPrompt
@@ -4071,14 +4090,14 @@ msgstr "¡Puedes tener mi leche materna!"
 #: /Game/Dialogue/Petra/Default/PetraGetKeystone.Default__PetraGetKeystone_C.SessionData.Lines(7).Lines
 msgctxt ",4B400F8545DB288AE092E39BA2CD24BF"
 msgid "If you can find me something that fits Pawsmaati's request, I will get that keystone for you."
-msgstr ""
+msgstr "Si puedes encontrarme algo que se ajuste a la petición de Pawsmaati, te conseguiré esa piedra-llave."
 
 #. Key:	4B96D56447562EBC8748929A5D3B51FD
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernGreeting02.Default__FernGreeting02_C.SessionData.LinesToFuta(3).LinesToFuta
 #: /Game/Dialogue/Fern/DefaultP2/FernGreeting02.Default__FernGreeting02_C.SessionData.LinesToFuta(3).LinesToFuta
 msgctxt ",4B96D56447562EBC8748929A5D3B51FD"
 msgid "Let me wrap my lips around that fat cock of yours, my body longs for your warm cum."
-msgstr "Déjame envolver mis labios alrededor de esa polla gorda tuya, mi cuerpo anhela tu semen caliente."
+msgstr "Déjame envolver mis labios alrededor de esa gorda polla tuya, mi cuerpo anhela tu cálido semen."
 
 #. Key:	4B9F497F40EDDFFEA5F6DCB0FB8B4675
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_YourMusic_RL.Default__RomyDefault01_YourMusic_RL_C.ResponseData(0).ResponseData.BreederPrompt
@@ -4099,49 +4118,49 @@ msgstr "Eres una hermosa cosa púrpura."
 #: /Game/Dialogue/QueenBee/Default/BeeUhNo.Default__BeeUhNo_C.SessionData.Lines(1).Lines
 msgctxt ",4BCD2C0947A04AB07ED274984B39E519"
 msgid "I ought to punish you, but... ohhh! As you can see, I'm busy."
-msgstr ""
+msgstr "Debería castigarte, pero... ¡ohhh! Como puedes ver, estoy ocupada."
 
 #. Key:	4BEA745E46427D48E9DB48A470FF3A40
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadFatAssLamia.Default__DryadFatAssLamia_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Autumn/Default/DryadFatAssLamia.Default__DryadFatAssLamia_C.SessionData.Lines(4).Lines
 msgctxt ",4BEA745E46427D48E9DB48A470FF3A40"
 msgid "From that moment on I was fixed on her... I wanted to please her in ways I never before considered."
-msgstr ""
+msgstr "A partir de ese momento me fijé en ella... Quería complacerla de formas que nunca antes había considerado."
 
 #. Key:	4C00C7F544226DAA1CBB4781B0CEB82F
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(3).Lines
 msgctxt ",4C00C7F544226DAA1CBB4781B0CEB82F"
 msgid "Aye, 'mai specialty is all things milk, and a quare good pair on me front. Bless me, hav'n jugs like these can really hurt 'mai back!"
-msgstr "Seh, mih espesialidadeh son toa lah cosah relasionadah con la leshe, y un buen pah en frente a mi. ¡Bendíseme, teneh jarrah como ehtah reahmente pueden lahtimarme la ehparda!"
+msgstr "Seh, mih espesialidadeh son toa lah cosah relasionadah con la leshe, y un buen pah cuadrado en la parte delantera. ¡Bendita sea, teneh cántaroh de leshe como ehtoh reahmente pueden lahtimarme la ehparda!"
 
 #. Key:	4C1E56854BDDE954FC7ACA99874AB4C3
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaHadSex02.Default__CamillaHadSex02_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/Camilla/Default/CamillaHadSex02.Default__CamillaHadSex02_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",4C1E56854BDDE954FC7ACA99874AB4C3"
 msgid "This little body experienced a lot of pleasure..."
-msgstr ""
+msgstr "Este cuerpecito experimentó mucho placer..."
 
 #. Key:	4C58896E4C9EC24AD95FD9B3C5846453
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiDefault02_RL.Default__FesssiDefault02_RL_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/Fesssi/Default/FesssiDefault02_RL.Default__FesssiDefault02_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",4C58896E4C9EC24AD95FD9B3C5846453"
 msgid "But... you're stuck."
-msgstr ""
+msgstr "Pero... estás atascada."
 
 #. Key:	4CC5D673471A3B46D285D681BCAEC1A8
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraPracticeMe.Default__PetraPracticeMe_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Petra/Default/PetraPracticeMe.Default__PetraPracticeMe_C.SessionData.Lines(2).Lines
 msgctxt ",4CC5D673471A3B46D285D681BCAEC1A8"
 msgid "Ahhh... yes! Well what are you waiting for?"
-msgstr ""
+msgstr "Ahhh... ¡sí! ¿Bueno, qué estás esperando?"
 
 #. Key:	4CEEC1684CDAEA938B302F89B5DCC6FD
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiCave.Default__FesssiCave_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiCave.Default__FesssiCave_C.SessionData.Lines(2).Lines
 msgctxt ",4CEEC1684CDAEA938B302F89B5DCC6FD"
 msgid "You won't find seraphim and elves down there... no. Goblins, bats, and spiders are more likely."
-msgstr ""
+msgstr "No encontrarás serafines ni elfos ahí abajo... no. Es más probable que haya goblins, murciélagos y arañas."
 
 #. Key:	4D0B9DAB42EF8CA84E014A8298104E74
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_UpHere.Default__RomyDefault01_UpHere_C.SessionData.Lines(4).Lines
@@ -4155,7 +4174,7 @@ msgstr "Solo la Diosa te dará respuestas. Lamentablemente, no puedo escuchar Su
 #: /Game/Dialogue/Kybele/Default/KybeleCentaur.Default__KybeleCentaur_C.SessionData.Lines(1).Lines
 msgctxt ",4D14F6284D4722E3384EB5A50BDD7ACC"
 msgid "You would do well to turn around and leave the dragons alone."
-msgstr ""
+msgstr "Harías bien en darte la vuelta y dejar en paz a los dragones."
 
 #. Key:	4DA62EBE4FE5CCF8694322AA22E38C1D
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R04.Default__FaleneDefault01_R04_C.SessionData.Lines(12).Lines
@@ -4169,70 +4188,70 @@ msgstr "Nos encanta crear nuevos @MONSTER_RACE@, para que ellos también puedan 
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R07_RL.Default__CamillaDefault01_R07_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",4DE4EDAD457F0C2715629B82E07D5D91"
 msgid "Oh come here you lovable shortstack!"
-msgstr "Oh, ¡ven aquí adorable pequeño montón!"
+msgstr "¡Oh, ven aquí, adorable montoncito!"
 
 #. Key:	4E12D93143928EAE2221E7A3621657C0
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R01.Default__FaleneDefault01_R01_C.SessionData.Lines(8).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R01.Default__FaleneDefault01_R01_C.SessionData.Lines(8).Lines
 msgctxt ",4E12D93143928EAE2221E7A3621657C0"
 msgid "My theory is when @MONSTER_RACE@ semen and ovum unite, they fracture time and space itself."
-msgstr "Mi teoría es que cuando semen y óvulo @MONSTER_RACE@ se unen, fracturan el tiempo y el espacio."
+msgstr "Mi teoría es que cuando semen y óvulo @MONSTER_RACE@ se unen, fracturan el tiempo y el espacio mismos."
 
 #. Key:	4E27E33747B868644B436C9F77707525
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeDefault01_RL.Default__AmberMaeDefault01_RL_C.ResponseData(3).ResponseData.BreederPrompt
 #: /Game/Dialogue/AmberMae/Default/AmberMaeDefault01_RL.Default__AmberMaeDefault01_RL_C.ResponseData(3).ResponseData.BreederPrompt
 msgctxt ",4E27E33747B868644B436C9F77707525"
 msgid "May I suck on your jugs?"
-msgstr "¿Puedo chuparte las jarras?"
+msgstr "¿Puedo chuparte los cántaros de leche?"
 
 #. Key:	4E36B8A545FB7E25EE044C834B5EFC4D
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernHadSex02.Default__FernHadSex02_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Fern/DefaultP2/FernHadSex02.Default__FernHadSex02_C.SessionData.Lines(0).Lines
 msgctxt ",4E36B8A545FB7E25EE044C834B5EFC4D"
 msgid "Mmmm... mastah tasty!"
-msgstr ""
+msgstr "Mmmm... ¡Mastah sabroso!"
 
 #. Key:	4E498E254A8B38B0C2BC51A386589A62
 #. SourceLocation:	/Game/Dialogue/Leylanna/SexScenes/LeylannaLeyCov.Default__LeylannaLeyCov_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/Leylanna/SexScenes/LeylannaLeyCov.Default__LeylannaLeyCov_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",4E498E254A8B38B0C2BC51A386589A62"
 msgid "Lay back and relax @BREEDER_NAME@..."
-msgstr "Túmbate y relájate @BREEDER_NAME@..."
+msgstr "Recuéstate y relájate @BREEDER_NAME@..."
 
 #. Key:	4E52974540DE6960CB56CDB713C76A05
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToMale(8).LinesToMale
 #: /Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToMale(8).LinesToMale
 msgctxt ",4E52974540DE6960CB56CDB713C76A05"
 msgid "That must have been you, perhaps you should go and talk to her."
-msgstr ""
+msgstr "Debes haber sido tú, quizás deberías ir a hablar con ella."
 
 #. Key:	4E5BBE2D466F692CEB63ACA293C411A8
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruHadSex01.Default__MirruHadSex01_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/Mirru/Default/MirruHadSex01.Default__MirruHadSex01_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",4E5BBE2D466F692CEB63ACA293C411A8"
 msgid "You have satisfied a kraken princess, and allowed me to release my lust."
-msgstr ""
+msgstr "Has satisfecho a una princesa kraken, y me has permitido liberar mi lujuria."
 
 #. Key:	4E7910C949370E1A22F20886B7F19689
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryBlessedInquiry01_RL.Default__EmissaryBlessedInquiry01_RL_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/Emissary/Default/EmissaryBlessedInquiry01_RL.Default__EmissaryBlessedInquiry01_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",4E7910C949370E1A22F20886B7F19689"
 msgid "Huh... that means you're just as horny then."
-msgstr "Huh... eso significa que eres igual de caliente entonces."
+msgstr "Huh... eso significa que eres igual de cachonda entonces."
 
 #. Key:	4E7998DA4738ECC33C9E7DA9B98FC68B
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_BatheAllDay.Default__RomyDefault01_BatheAllDay_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Romy/Default/RomyDefault01_BatheAllDay.Default__RomyDefault01_BatheAllDay_C.SessionData.Lines(2).Lines
 msgctxt ",4E7998DA4738ECC33C9E7DA9B98FC68B"
 msgid "They let me wash every inch of their bodies, and I enjoy it... immensely."
-msgstr "Me dejaron lavar cada centímetro de sus cuerpos, y lo disfruto... inmensamente."
+msgstr "Me dejan lavar cada centímetro de sus cuerpos y lo disfruto... inmensamente."
 
 #. Key:	4E7C9B4743337D054AE863AB4EAF155F
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiDefault03_RL_F.Default__FesssiDefault03_RL_F_C.ResponseData(3).ResponseData.BreederPrompt
 #: /Game/Dialogue/Fesssi/Default/FesssiDefault03_RL_F.Default__FesssiDefault03_RL_F_C.ResponseData(3).ResponseData.BreederPrompt
 msgctxt ",4E7C9B4743337D054AE863AB4EAF155F"
 msgid "You can stick that tongue in me..."
-msgstr ""
+msgstr "Puedes meterme esa lengua..."
 
 #. Key:	4E899A5D4E84988C4EA22C94596B1177
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_YourMusic.Default__RomyDefault01_YourMusic_C.SessionData.LinesToFemale(2).LinesToFemale
@@ -4253,7 +4272,7 @@ msgstr "¿Qué puedes hacer?"
 #: /Game/Dialogue/Autumn/Default/DryadBossomCherries.Default__DryadBossomCherries_C.SessionData.Lines(2).Lines
 msgctxt ",4EBD4351412C922E0D1B4DAE8A11ABC7"
 msgid "It's not uncommon for a single Ayrshire to eat ten bosom cherries in a single day."
-msgstr ""
+msgstr "No es raro que una sola ayrshire coma diez cerezas de seno en un solo día."
 
 #. Key:	4F17407F4C735CA48643138A59606A3C
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01.Default__FernDefault01_C.SessionData.Lines(2).Lines
@@ -4274,28 +4293,28 @@ msgstr "*Chupa* *Lame*"
 #: /Game/Dialogue/Autumn/Default/DryadGreeting01.Default__DryadGreeting01_C.SessionData.Lines(1).Lines
 msgctxt ",4F3471C54B27DDD9BC7D5F8A12D1E871"
 msgid "Soft and plump, with many a bump."
-msgstr ""
+msgstr "Suave y regordeta, con muchas protuberancias."
 
 #. Key:	4F37D08C43E11EDF706D07998D86692F
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyHadSex01.Default__RomyHadSex01_C.SessionData.LinesGrungy(0).LinesGrungy
 #: /Game/Dialogue/Romy/Default/RomyHadSex01.Default__RomyHadSex01_C.SessionData.LinesGrungy(0).LinesGrungy
 msgctxt ",4F37D08C43E11EDF706D07998D86692F"
 msgid "Oh you dirty dirty human... what have you done to yourself?"
-msgstr ""
+msgstr "Oh, sucio, sucio humano... ¿Qué te has hecho a ti mismo?"
 
 #. Key:	4F601DAA48F980A712CFA1A4888DDCBC
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToFuta(2).LinesToFuta
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",4F601DAA48F980A712CFA1A4888DDCBC"
 msgid "I have experienced @MONSTER_RACE@ dick and vagina beyond comprehension."
-msgstr "He experimentado @MONSTER_RACE@ polla y vagina más allá de la comprensión."
+msgstr "He experimentado el pene y la vagina @MONSTER_RACE@ más allá de la comprensión."
 
 #. Key:	4F85128C485261E5971763A5F3E5C2A7
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeDefault01.Default__BeeDefault01_C.SessionData.LinesToFuta(0).LinesToFuta
 #: /Game/Dialogue/QueenBee/Default/BeeDefault01.Default__BeeDefault01_C.SessionData.LinesToFuta(0).LinesToFuta
 msgctxt ",4F85128C485261E5971763A5F3E5C2A7"
 msgid "This corner is n-n-nice and safe!"
-msgstr ""
+msgstr "¡Este rincón es a-a-agradable y seguro!"
 
 #. Key:	4F926E9345E810F3C912438E56312AC9
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaGreeting01.Default__LeylannaGreeting01_C.SessionData.Lines(2).Lines
@@ -4309,21 +4328,21 @@ msgstr "Sí... tu nombre es @BREEDER_NAME@. ¡Los espíritus me lo han revelado!
 #: /Game/Dialogue/Widow/Default/WidowSpiders.Default__WidowSpiders_C.SessionData.Lines(1).Lines
 msgctxt ",4FA58F3643C40D88119D81857F7F6815"
 msgid "We are reclusive cavern dwellers, and once a home is found it's not uncommon for us to stay there for many years."
-msgstr ""
+msgstr "Somos solitarios habitantes de las cavernas, y una vez que se encuentra un hogar, no es raro que nos quedemos allí durante muchos años."
 
 #. Key:	4FC454FA455E4284639DF9A235A1B888
 #. SourceLocation:	/Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToFuta(4).LinesToFuta
 #: /Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToFuta(4).LinesToFuta
 msgctxt ",4FC454FA455E4284639DF9A235A1B888"
 msgid "Ahh, plant your delicious seed in my little body! Give me... ohhh... all of it!"
-msgstr "¡Ah, planta tu deliciosa semilla en mi cuerpecito! ¡Dámelo... ohhh… todo!"
+msgstr "¡Ahh, planta tu deliciosa semilla en mi cuerpecito! ¡Dámelo... ohhh… todo!"
 
 #. Key:	4FD31BBE4149189F2C525B911BC63025
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R07.Default__FaleneDefault01_R07_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R07.Default__FaleneDefault01_R07_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",4FD31BBE4149189F2C525B911BC63025"
 msgid "Aww! Someone wants their labia licked!"
-msgstr "¡Aww! ¡Alguien quiere le laman sus labios!"
+msgstr "¡Amm! ¡Alguien quiere le laman sus labios!"
 
 #. Key:	502500DE40F982D4BC3BC1AB282D2040
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(17).LinesToFemale
@@ -4337,21 +4356,21 @@ msgstr "Grrrr… jejeje... ¡debo controlarme!"
 #: /Game/Dialogue/QueenBee/Default/BeeDefault01.Default__BeeDefault01_C.SessionData.LinesToFuta(1).LinesToFuta
 msgctxt ",502599044F833B4F276595B3EAD343C5"
 msgid "Soon my nectar collection will be complete, and I can return to the Hivelands."
-msgstr ""
+msgstr "Pronto mi colección de néctar estará completa y podré regresar a las Tierras-Colmena."
 
 #. Key:	5045176546DDF08434B08ABE881B84B8
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraAboutPawsmaati.Default__PetraAboutPawsmaati_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Petra/Default/PetraAboutPawsmaati.Default__PetraAboutPawsmaati_C.SessionData.Lines(4).Lines
 msgctxt ",5045176546DDF08434B08ABE881B84B8"
 msgid "For me, Pawsmaati decided to manifest a large cock. It felt so good as she thrust it deep inside me..."
-msgstr ""
+msgstr "Para mí, Pawsmaati decidió manifestar una gran polla. Se sintió tan bien cuando la metió profundamente dentro de mí..."
 
 #. Key:	5075655C40C6B014FB7A99AE08709576
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_RL.Default__MirruDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_RL.Default__MirruDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",5075655C40C6B014FB7A99AE08709576"
 msgid "Tell me about Krakens."
-msgstr "Háblame sobre los Krakens."
+msgstr "Háblame de los krakens."
 
 #. Key:	5091F30244DD52A6CED9788A1B9B6A79
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_Princess.Default__MirruDefault01_Princess_C.SessionData.Lines(6).Lines
@@ -4362,38 +4381,41 @@ msgstr "¡Ah! ¡Mirru, princesa del mar no divulgará tales cosas!"
 
 #. Key:	50B849704DFA728D7330279E30E472A8
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(3 - Value).TraitIcons.HelpText
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(3 - Value).TraitIcons.HelpText
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(3 -
+#: Value).TraitIcons.HelpText
 msgctxt ",50B849704DFA728D7330279E30E472A8"
 msgid "Large: Roughly 8ft in height."
-msgstr "Grande: Aproximadamente 2,4m de altura."
+msgstr "Grande: aproximadamente 8 pies (2,4 m) de altura."
 
 #. Key:	50BBFEDE44CEF2DA10124AAE7DBF17B9
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(28 - Value).TraitIcons.DisplayName
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(28 - Value).TraitIcons.DisplayName
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(28 -
+#: Value).TraitIcons.DisplayName
 msgctxt ",50BBFEDE44CEF2DA10124AAE7DBF17B9"
 msgid "Slick"
-msgstr "Resbalosa/o"
+msgstr "Resbaloso"
 
 #. Key:	50E84BD14AFF02C2DD65798A8386C0FE
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",50E84BD14AFF02C2DD65798A8386C0FE"
 msgid "When enough semen accumulates, usually in water, there is a chance for it to turn into a slime."
-msgstr ""
+msgstr "Cuando se acumula suficiente semen, generalmente en agua, existe la posibilidad de que se convierta en un limo."
 
 #. Key:	51444A264763D03D8B5051AEDAB55B5F
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(32 - Value).TraitIcons.HelpText
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(32 - Value).TraitIcons.HelpText
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(32 -
+#: Value).TraitIcons.HelpText
 msgctxt ",51444A264763D03D8B5051AEDAB55B5F"
 msgid "Abomination: This one was the product of incest."
-msgstr "Abominación: Este/a fue producto de un incesto."
+msgstr "Abominación: este fue producto de un incesto."
 
 #. Key:	51891BB34DD1356F61B02FB5FE4F3636
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchQueen.Default__MonarchQueen_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Monarch/Default/MonarchQueen.Default__MonarchQueen_C.SessionData.Lines(0).Lines
 msgctxt ",51891BB34DD1356F61B02FB5FE4F3636"
 msgid "Yes, t-t-the magestic queen bee of Hivelands. All insect @MONSTER_RACE@ serve her."
-msgstr ""
+msgstr "Sí, la majestuosa Abeja Reina de las Tierras-Colmena. Todos los insectos @MONSTER_RACE@ le sirven."
 
 #. Key:	51B5762D4545FEE2F7E8D895B66B031B
 #. SourceLocation:	/Game/Ranch/Upgrades/BovaurShed.Default__BovaurShed_C.Upgrade.Description
@@ -4407,14 +4429,14 @@ msgstr "Esto te permite capturar y almacenar todas las variantes de Bovaurs."
 #: /Game/Dialogue/Romy/Default/RomyDefault01_YourMusic_ToneDeaf.Default__RomyDefault01_YourMusic_ToneDeaf_C.SessionData.Lines(1).Lines
 msgctxt ",51CEBDA94681ACB09279C2A598681796"
 msgid "Do return if you reconsider."
-msgstr "Regresa si lo reconsideras."
+msgstr "Vuelve si lo reconsideras."
 
 #. Key:	51E33E8544C5A1055CF34EA764D9E53C
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R07.Default__CamillaDefault01_R07_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R07.Default__CamillaDefault01_R07_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",51E33E8544C5A1055CF34EA764D9E53C"
 msgid "Amber's tits are bigger than me! Why is this world so cruel..."
-msgstr "¡Las tetas de Amber son más grandes que yo! Por qué es este mundo tan cruel..."
+msgstr "¡Las tetas de Amber son mas grandes que yo! Por qué este mundo es tan cruel..."
 
 #. Key:	51FAB478484E006C8F04E28F37E5D4D3
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_StartRCowgirl.Default__ParvatiDefault01_StartRCowgirl_C.SessionData.Lines(0).Lines
@@ -4425,24 +4447,25 @@ msgstr "..."
 
 #. Key:	5243F67240932D62D7FDFABA63222594
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(26 - Value).TraitIcons.DisplayName
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(26 - Value).TraitIcons.DisplayName
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(26 -
+#: Value).TraitIcons.DisplayName
 msgctxt ",5243F67240932D62D7FDFABA63222594"
 msgid "Hung"
-msgstr "Polludo/a"
+msgstr "Polludo"
 
 #. Key:	52570DF44A9EF55907B4EBBCCC8EFB52
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01_R04.Default__FernDefault01_R04_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Fern/Default/FernDefault01_R04.Default__FernDefault01_R04_C.SessionData.Lines(0).Lines
 msgctxt ",52570DF44A9EF55907B4EBBCCC8EFB52"
 msgid "Ohhhh mastah! Finally Fern can have fluids?!"
-msgstr "¡Ohhh maeztra! ¡¿Finalmente Helecho puede tener líquidos?!"
+msgstr "¡Ohhh, Mastah! ¡¿Finalmente Fern puede tener fluidos?!"
 
 #. Key:	52642BC9475ED06B0EBBA4AA6032CE9D
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(18).LinesToMale
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(18).LinesToMale
 msgctxt ",52642BC9475ED06B0EBBA4AA6032CE9D"
 msgid "*Sigh* As you can tell, we @MONSTER_RACE@ have extremely intense sexual desires."
-msgstr "*Suspiro* Como puedes ver, nosotros @MONSTER_RACE@ tenemos deseos sexuales extremadamente intensos."
+msgstr "*Suspira* Como puedes ver, nosotros los @MONSTER_RACE@ tenemos deseos sexuales extremadamente intensos."
 
 #. Key:	52AF81564974B34FF6A257A0B0BDA77F
 #. SourceLocation:	/Game/Dialogue/Fern/SexScenes/FernCum_01.Default__FernCum_01_C.SessionData.Lines(9).Lines
@@ -4456,21 +4479,21 @@ msgstr "*Chupa* *Chupa*"
 #: /Game/Dialogue/Widow/Default/WidowTaskFullfilled2.Default__WidowTaskFullfilled2_C.SessionData.Lines(3).Lines
 msgctxt ",52FA782943DCF1904C31D0AD39452FE2"
 msgid "Please take the glowing rock on your way out. I feel the hunger creeping up, and my elf is looking full and ready."
-msgstr ""
+msgstr "Por favor, recoge la roca brillante al salir. Siento que el hambre aumenta y mi elfa parece llena y lista."
 
 #. Key:	53133AE5461CD4363425BC8B9E8327F4
 #. SourceLocation:	/Game/Dialogue/Emissary/SexScenes/EmissaryAngelGroinLove.Default__EmissaryAngelGroinLove_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/Emissary/SexScenes/EmissaryAngelGroinLove.Default__EmissaryAngelGroinLove_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",53133AE5461CD4363425BC8B9E8327F4"
 msgid "Indulge yourself human, for I am thy servant."
-msgstr "Complácete humana, pues soy tu sirviente."
+msgstr "Deléitate humana, pues soy tu sirviente."
 
 #. Key:	535696214ED031B7F34A458925D0CEA8
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_RL.Default__CamillaDefault01_RL_C.ResponseData(6).ResponseData.BreederPrompt
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_RL.Default__CamillaDefault01_RL_C.ResponseData(6).ResponseData.BreederPrompt
 msgctxt ",535696214ED031B7F34A458925D0CEA8"
 msgid "Falene brings you stuff?"
-msgstr ""
+msgstr "¿Falene te trae cosas?"
 
 #. Key:	537B245D4CBB8BD28882D3AB47480EA4
 #. SourceLocation:	/Game/Dialogue/Fern/SexScenes/FernCum_01.Default__FernCum_01_C.SessionData.Lines(1).Lines
@@ -4484,7 +4507,7 @@ msgstr "*Chupa* *Chupa*"
 #: /Game/Dialogue/Fern/DefaultP3/FernHadSex03.Default__FernHadSex03_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",53B2E09F4A5C770431651A9B727EA17D"
 msgid "Ahhh... I have never felt so good!"
-msgstr ""
+msgstr "Ahhh... ¡nunca me había sentido tan bien!"
 
 #. Key:	53D49D34442BE0C5E4A971957D2298CD
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_StartLapDance.Default__ParvatiDefault01_StartLapDance_C.SessionData.Lines(0).Lines
@@ -4498,35 +4521,35 @@ msgstr "..."
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_RL.Default__EmissaryDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",5408EE8A4C4CAFF4A2B2F9B2F1F0B779"
 msgid "I have wild @MONSTER_RACE@ to ascend."
-msgstr "Tengo salvajes @MONSTER_RACE@ para ascender."
+msgstr "Tengo @MONSTER_RACE@ silvestres para ascender."
 
 #. Key:	544F5F944F9E5D60454A39A741792497
 #. SourceLocation:	/Game/Dialogue/Fern/SexScenes/FernCum_01.Default__FernCum_01_C.SessionData.Lines(10).Lines
 #: /Game/Dialogue/Fern/SexScenes/FernCum_01.Default__FernCum_01_C.SessionData.Lines(10).Lines
 msgctxt ",544F5F944F9E5D60454A39A741792497"
 msgid "Fern hope this pleases mastah greatly..."
-msgstr "Helecho espera que esto complazca mucho a maestra..."
+msgstr "Fern espera que esto complazca mucho a Mastah..."
 
 #. Key:	5477799C4F9B5398BECB918C51B6CC44
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeSuckJugs_Cancel.Default__AmberMaeSuckJugs_Cancel_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeSuckJugs_Cancel.Default__AmberMaeSuckJugs_Cancel_C.SessionData.Lines(0).Lines
 msgctxt ",5477799C4F9B5398BECB918C51B6CC44"
 msgid "Forgive me if I was com'n on too strong! I hope I didn't offend ye..."
-msgstr "¡Perdóname si fui demasiao fuehte! Espero no haberte ofendio..."
+msgstr "¡Perdóname si fui demasiao fuehte! Espero no habehte ofendio..."
 
 #. Key:	5487409C445EEB5B2C699C8A5253DD30
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFemale(2).LinesToFemale
 #: /Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",5487409C445EEB5B2C699C8A5253DD30"
 msgid "Perhaps you would like a taste of my sparkly elf pussy?"
-msgstr ""
+msgstr "¿Quizás te gustaría probar mi brillante coño de elfa?"
 
 #. Key:	5499C216450B8D38D1D5E48EAB4EAE1A
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeGreeting01.Default__MegaSlimeGreeting01_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeGreeting01.Default__MegaSlimeGreeting01_C.SessionData.Lines(3).Lines
 msgctxt ",5499C216450B8D38D1D5E48EAB4EAE1A"
 msgid "Do you want to meet my best friend?"
-msgstr ""
+msgstr "¿Quieres conocer a mi mejor amiga?"
 
 #. Key:	54A656CF43AE3DD98B149D8CB0E836B1
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R02.Default__FaleneDefault01_R02_C.SessionData.Lines(4).Lines
@@ -4540,21 +4563,21 @@ msgstr "Es frustrante, ni siquiera recuerdo cómo llegué aquí, ni ninguno de l
 #: /Game/Dialogue/OrcChief/Default/OrcFixOwnGate.Default__OrcFixOwnGate_C.SessionData.LinesToFuta(3).LinesToFuta
 msgctxt ",54C74A434002CAD60426198FDDCF4B82"
 msgid "Human fix gate now, or your cock is mine!"
-msgstr ""
+msgstr "¡Ahora arregla el portón humano, o tu polla es mía!"
 
 #. Key:	550D874045EED9CAB4096BB51CD7C32A
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowSpiders.Default__WidowSpiders_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Widow/Default/WidowSpiders.Default__WidowSpiders_C.SessionData.Lines(2).Lines
 msgctxt ",550D874045EED9CAB4096BB51CD7C32A"
 msgid "Patiently we will wait for our mates to come to us... this world is full of lumbering morons oozing with delicious fluids."
-msgstr ""
+msgstr "Esperaremos pacientemente a que nuestros compañeros vengan a nosotros... este mundo está lleno de torpes idiotas rezumando deliciosos fluidos."
 
 #. Key:	554D996445578E57126935A57AEBB8F3
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_R03.Default__FernDefault02_R03_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02_R03.Default__FernDefault02_R03_C.SessionData.Lines(0).Lines
 msgctxt ",554D996445578E57126935A57AEBB8F3"
 msgid "Oh Master... you are too good to me."
-msgstr "Oh maestra... eres demasiado buena para mí."
+msgstr "Oh, Master... eres demasiado bueno para mí."
 
 #. Key:	554F10F14C2C753407F470A787D584FB
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(16).LinesToMale
@@ -4575,21 +4598,22 @@ msgstr "Vulwarg"
 #: /Game/Dialogue/QueenBee/Default/BeeHaveKeystone.Default__BeeHaveKeystone_C.SessionData.Lines(6).Lines
 msgctxt ",558508384A3AD98E8ACC849F53F551A9"
 msgid "Everyone wanted \"personal time\" with me, and it was glorious."
-msgstr ""
+msgstr "Todos querían \"tiempo personal\" conmigo, y fue glorioso."
 
 #. Key:	55894A674E5C647D1DC14EB1951CE50D
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(20 - Value).TraitIcons.HelpText
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(20 - Value).TraitIcons.HelpText
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(20 -
+#: Value).TraitIcons.HelpText
 msgctxt ",55894A674E5C647D1DC14EB1951CE50D"
 msgid "Sadistic: Reduces the loyalty of breeding partners, but gains twice as much XP."
-msgstr "Sádico/a: Reduce la lealtad de los compañeros de reproducción, pero gana el doble de EXP."
+msgstr "Sádico: reduce la Lealtad de los compañeros de reproducción, pero gana el doble de EXP."
 
 #. Key:	55BACC2142DFD6EE2C302A860E4A23FF
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimePlay.Default__MegaSlimePlay_C.SessionData.LinesToFuta(1).LinesToFuta
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePlay.Default__MegaSlimePlay_C.SessionData.LinesToFuta(1).LinesToFuta
 msgctxt ",55BACC2142DFD6EE2C302A860E4A23FF"
 msgid "You will feel so good as I milk your cock for all of its delicious semen..."
-msgstr ""
+msgstr "Te sentirás tan bien mientras ordeño tu polla por todo su delicioso semen..."
 
 #. Key:	55DE769C4C259F81CB55299E36998DA3
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyGreeting01.Default__RomyGreeting01_C.SessionData.LinesGrungy(4).LinesGrungy
@@ -4603,28 +4627,29 @@ msgstr "Quítate la ropa y déjame lavarte."
 #: /Game/Dialogue/Petra/Default/PetraHadSex01.Default__PetraHadSex01_C.SessionData.Lines(1).Lines
 msgctxt ",55F0F60A4D567468043EF687B0A22338"
 msgid "You made me feel so good human. We should \"practice\" again sometime!"
-msgstr ""
+msgstr "Me hiciste sentir tan bien humano. ¡Deberíamos \"practicar\" de nuevo en algún momento!"
 
 #. Key:	560A29014AB558719DDBF6ABAA67FA3F
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeHadSex01.Default__MegaSlimeHadSex01_C.SessionData.LinesToFemale(5).LinesToFemale
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeHadSex01.Default__MegaSlimeHadSex01_C.SessionData.LinesToFemale(5).LinesToFemale
 msgctxt ",560A29014AB558719DDBF6ABAA67FA3F"
 msgid "*Yawn*"
-msgstr ""
+msgstr "*Bosteza*"
 
 #. Key:	560FCF68432946FE1C6D7BA2F8088AB6
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TravelShrines(0 - Value).TravelShrines.ShrineName
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TravelShrines(0 - Value).TravelShrines.ShrineName
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TravelShrines(0 -
+#: Value).TravelShrines.ShrineName
 msgctxt ",560FCF68432946FE1C6D7BA2F8088AB6"
 msgid "Virgin Breaks"
-msgstr "Acantilados Vírgenes"
+msgstr "Rupturas Vírgenes"
 
 #. Key:	56130E5B431626086919BFB37E7FA460
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiWantTongue.Default__FesssiWantTongue_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiWantTongue.Default__FesssiWantTongue_C.SessionData.Lines(1).Lines
 msgctxt ",56130E5B431626086919BFB37E7FA460"
 msgid "I would never pass up a chance to taste the depths of human pussy."
-msgstr ""
+msgstr "Nunca dejaría pasar la oportunidad de saborear las profundidades del coño humano."
 
 #. Key:	5624D94B49EF02787D13EDAFB71F472A
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToFemale(5).LinesToFemale
@@ -4638,7 +4663,7 @@ msgstr "Ohhh... ¿podrías complacer a esta vieja guardiana? Es una vida solitar
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_AboutLamias.Default__NeelaDefault01_AboutLamias_C.SessionData.Lines(6).Lines
 msgctxt ",562919BA4DDFB552659A82ABD2D238A1"
 msgid "Her name is Apopha Fesssi. Come to think of it... I haven't seen her in years."
-msgstr ""
+msgstr "Su nombre es Apopha Fesssi. Ahora que lo pienso... no la he visto en años."
 
 #. Key:	5629D6AE4A1B8ABE39599596DC46FC1C
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(16).Lines
@@ -4652,56 +4677,56 @@ msgstr "Se compadeció de sus creaciones e hizo el amor con ellas, un evento que
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_Daze.Default__EmissaryDefault01_Daze_C.SessionData.Lines(2).Lines
 msgctxt ",566D4E2B458FC3277E49CB91D5CAB649"
 msgid "Then, the dark reaper of the daze will bring back to that body your awareness."
-msgstr ""
+msgstr "Entonces, la Segadora Oscura del aturdimiento traerá de vuelta a ese cuerpo tu conciencia."
 
 #. Key:	567F4EF7487947546DDFE3B0195DFDEB
 #. SourceLocation:	/Game/Dialogue/Neela/SexScenes/NeelaSnakeCuddleF.Default__NeelaSnakeCuddleF_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Neela/SexScenes/NeelaSnakeCuddleF.Default__NeelaSnakeCuddleF_C.SessionData.Lines(0).Lines
 msgctxt ",567F4EF7487947546DDFE3B0195DFDEB"
 msgid "Sweet delicious human pussy, ohhh..."
-msgstr "Dulce delicioso coño humano, ohhh..."
+msgstr "Dulce y delicioso coño humano, ohhh..."
 
 #. Key:	569794004A0E468573BC3689623AE387
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault02.Default__EmissaryDefault02_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault02.Default__EmissaryDefault02_C.SessionData.Lines(3).Lines
 msgctxt ",569794004A0E468573BC3689623AE387"
 msgid "Why the Goddess felt the need to create such worthless lifeforms puzzles me."
-msgstr ""
+msgstr "Me desconcierta por qué la Diosa sintió la necesidad de crear formas de vida tan inútiles."
 
 #. Key:	577526BD4B68AFD89F753E8F9023A937
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMHadSex01.Default__DMHadSex01_C.SessionData.LinesToFuta(1).LinesToFuta
 #: /Game/Dialogue/DragonMatriarch/Default/DMHadSex01.Default__DMHadSex01_C.SessionData.LinesToFuta(1).LinesToFuta
 msgctxt ",577526BD4B68AFD89F753E8F9023A937"
 msgid "Somehow your little cock made me feel amazing."
-msgstr ""
+msgstr "De alguna manera tu pequeña polla me hizo sentir increíble."
 
 #. Key:	57759F684D98A4E1D01E469878BF79D9
 #. SourceLocation:	/Game/Dialogue/Neela/SexScenes/NeelaSnakeCuddleT.Default__NeelaSnakeCuddleT_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Neela/SexScenes/NeelaSnakeCuddleT.Default__NeelaSnakeCuddleT_C.SessionData.Lines(2).Lines
 msgctxt ",57759F684D98A4E1D01E469878BF79D9"
 msgid "*Pleasurable Moaning*"
-msgstr "*Gemido Placentero*"
+msgstr "*Gimiendo placenteramente*"
 
 #. Key:	57C253374563B35B8FD5A2A79361E4CA
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeHowLong.Default__MegaSlimeHowLong_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeHowLong.Default__MegaSlimeHowLong_C.SessionData.Lines(1).Lines
 msgctxt ",57C253374563B35B8FD5A2A79361E4CA"
 msgid "Once they built the new temple above, people stopped coming here to play with me."
-msgstr ""
+msgstr "Una vez que construyeron el nuevo templo arriba, la gente dejó de venir aquí a jugar conmigo."
 
 #. Key:	586C9720448CC48985AE2E8FA3546D05
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchHaveKeystone2.Default__MonarchHaveKeystone2_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Monarch/Default/MonarchHaveKeystone2.Default__MonarchHaveKeystone2_C.SessionData.Lines(1).Lines
 msgctxt ",586C9720448CC48985AE2E8FA3546D05"
 msgid "I will remove the h-h-honeycomb from the Hivelands gate."
-msgstr ""
+msgstr "Quitaré el panal de miel del portón de las Tierras-Colmena."
 
 #. Key:	5881DC0E4C70AE1F56EE70A7C1A4A78A
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon.Default__AmberMaeLockedDungeon_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon.Default__AmberMaeLockedDungeon_C.SessionData.Lines(5).Lines
 msgctxt ",5881DC0E4C70AE1F56EE70A7C1A4A78A"
 msgid "Yer ask'n the wrong lass though, I'm just a simple milkmaid."
-msgstr ""
+msgstr "Sin embargo, le preguntah a la shica equivocaa, solo soy una simple leshera."
 
 #. Key:	589C39424192EF623DC606AE1E6D2D75
 #. SourceLocation:	/Game/Ranch/Upgrades/DemonPool.Default__DemonPool_C.Upgrade.DisplayName
@@ -4715,21 +4740,21 @@ msgstr "Piscina de Demonios"
 #: /Game/Dialogue/Fern/Default/FernBeeFlowers.Default__FernBeeFlowers_C.SessionData.Lines(1).Lines
 msgctxt ",58A8C4EA402471CFC5C6DF9121D86086"
 msgid "..."
-msgstr ""
+msgstr "..."
 
 #. Key:	58BD8EB444FFAA62E1DB458F4B2C10DC
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadFatAssLamia.Default__DryadFatAssLamia_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Autumn/Default/DryadFatAssLamia.Default__DryadFatAssLamia_C.SessionData.Lines(0).Lines
 msgctxt ",58BD8EB444FFAA62E1DB458F4B2C10DC"
 msgid "Oh Fesssi! She's so cute."
-msgstr ""
+msgstr "¡Oh, Fesssi! Ella es tan linda."
 
 #. Key:	58D1FC2449F60C6958E9A78371E3450A
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimePlay1.Default__MegaSlimePlay1_C.SessionData.LinesToFuta(4).LinesToFuta
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePlay1.Default__MegaSlimePlay1_C.SessionData.LinesToFuta(4).LinesToFuta
 msgctxt ",58D1FC2449F60C6958E9A78371E3450A"
 msgid "I'm going to eat all of it and make lots of new slime..."
-msgstr ""
+msgstr "Me lo voy a comer todo y a hacer un montón de nuevos limos..."
 
 #. Key:	58E0621949B1FDAFBD7C18B246C16918
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeSuckJugs_RL.Default__AmberMaeSuckJugs_RL_C.ResponseData(0).ResponseData.BreederPrompt
@@ -4740,31 +4765,32 @@ msgstr "Está bien... realmente quiero tu leche."
 
 #. Key:	58F2132B4EDA616F5343D38BA68240E2
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(35 - Value).TraitIcons.DisplayName
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(35 - Value).TraitIcons.DisplayName
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(35 -
+#: Value).TraitIcons.DisplayName
 msgctxt ",58F2132B4EDA616F5343D38BA68240E2"
 msgid "Gemini"
-msgstr ""
+msgstr "Géminis"
 
 #. Key:	591A0FAA474F00F7E8E2F28C1E009891
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_FutaBalls.Default__FaleneDefault01_FutaBalls_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_FutaBalls.Default__FaleneDefault01_FutaBalls_C.SessionData.Lines(0).Lines
 msgctxt ",591A0FAA474F00F7E8E2F28C1E009891"
 msgid "Well you see human, futas don't need them."
-msgstr "Bueno, verás humana, las futas no las necesitan."
+msgstr "Bueno, verás humano, las futas no las necesitan."
 
 #. Key:	5948418C46289A7006EC59860F4A1739
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcFixOwnGate.Default__OrcFixOwnGate_C.SessionData.LinesToFemale(4).LinesToFemale
 #: /Game/Dialogue/OrcChief/Default/OrcFixOwnGate.Default__OrcFixOwnGate_C.SessionData.LinesToFemale(4).LinesToFemale
 msgctxt ",5948418C46289A7006EC59860F4A1739"
 msgid "You get giant load of cum until chieftain satisfied!"
-msgstr ""
+msgstr "¡Obtienes una carga gigante de semen hasta que la cacique esté satisfecha!"
 
 #. Key:	59A830904A9DC04A6B7B1CB5E274E11A
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleAnyMeans_RL.Default__KybeleAnyMeans_RL_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/Kybele/Default/KybeleAnyMeans_RL.Default__KybeleAnyMeans_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",59A830904A9DC04A6B7B1CB5E274E11A"
 msgid "I will be leaving now..."
-msgstr ""
+msgstr "Me iré ahora..."
 
 #. Key:	59AE8221430C7DB9A85B7BB2B4663795
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01.Default__EmissaryDefault01_C.SessionData.Lines(0).Lines
@@ -4778,28 +4804,29 @@ msgstr "@BREEDER_NAME@, soy tuya, a través de la Diosa."
 #: /Game/Dialogue/Leylanna/Default/LeylannaDefault01_RechargeSpiritForm.Default__LeylannaDefault01_RechargeSpiritForm_C.SessionData.Lines(0).Lines
 msgctxt ",59BDE65E43216BA7D5472BBCEE4B2E25"
 msgid "Now that you have have formed a covenant with the Goddess, you may return to me to recharge your spirit form."
-msgstr "Ahora que has formado un pacto con la Diosa, puedes volver a mí para recargar tu forma espiritual."
+msgstr "Ahora que has formado un pacto con la Diosa, puedes volver a verme para recargar tu forma espiritual."
 
 #. Key:	59C80FA04F36092A693B1DB800804177
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_RL.Default__LeylannaDefault01_RL_C.ResponseData(4).ResponseData.BreederPrompt
 #: /Game/Dialogue/Leylanna/Default/LeylannaDefault01_RL.Default__LeylannaDefault01_RL_C.ResponseData(4).ResponseData.BreederPrompt
 msgctxt ",59C80FA04F36092A693B1DB800804177"
 msgid "What's the deal with Emissary?"
-msgstr "¿Cuál es el problema de la Emisaria?"
+msgstr "¿Cuál es el trato con la Emisaria?"
 
 #. Key:	59EF8E454FA9D93BA790BF92B0EE3873
 #. SourceLocation:	/Game/Dialogue/Neela/SexScenes/NeelaSnakeCuddleF.Default__NeelaSnakeCuddleF_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Neela/SexScenes/NeelaSnakeCuddleF.Default__NeelaSnakeCuddleF_C.SessionData.Lines(2).Lines
 msgctxt ",59EF8E454FA9D93BA790BF92B0EE3873"
 msgid "Ahh... my Lamia tongue will make you feel so good..."
-msgstr "Ahh... mi lengua de Lamia te hará sentir tan bien..."
+msgstr "Ahh... mi lengua de lamia te hará sentir tan bien..."
 
 #. Key:	5A3E7C5348B9CE872B1AC68AF9AEF76B
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(27 - Value).TraitIcons.HelpText
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(27 - Value).TraitIcons.HelpText
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(27 -
+#: Value).TraitIcons.HelpText
 msgctxt ",5A3E7C5348B9CE872B1AC68AF9AEF76B"
 msgid "Slender: This one has less body fat."
-msgstr "Delgado/a: Este/a tiene menos grasa corporal."
+msgstr "Esbelto: este tiene menos grasa corporal."
 
 #. Key:	5A45FE0E4DF250F62CA7DBA9E82E9782
 #. SourceLocation:	/Game/Dialogue/Fern/SexScenes/FernCum_01.Default__FernCum_01_C.SessionData.Lines(11).Lines
@@ -4813,7 +4840,7 @@ msgstr "*Sorbe* *Lame*"
 #: /Game/Dialogue/Cassie/Default/CassieHadSex01.Default__CassieHadSex01_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",5A9731DD46A8ADC8650FC7A682C0D08C"
 msgid "You're going to have lots of cute kittens with how much love butter I gave you!!!"
-msgstr ""
+msgstr "¡¡¡Vas a tener muchos gatitos lindos con la cantidad de mantequilla de amor que te di!!!"
 
 #. Key:	5AA0883E43DAD4AAE0EF269EA3233B0A
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_RL.Default__ParvatiDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
@@ -4827,126 +4854,126 @@ msgstr "¡Enséñame una nueva posición sexual!"
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(6).Lines
 msgctxt ",5AA8E62541EFA61D3ED30CAD3E1D0946"
 msgid "Demons crawled out of the darkness, and immediately started having sex with the Seraphim."
-msgstr "Los Demonios salieron de la oscuridad e inmediatamente comenzaron a tener sexo con las Serafines."
+msgstr "Los demonios salieron de la oscuridad e inmediatamente comenzaron a tener sexo con las Serafines."
 
 #. Key:	5ACEB47B4DC474437836D1BE5DF53CC7
 #. SourceLocation:	/Game/Dialogue/Blossom/Default/BlossomDefault01_RL_F.Default__BlossomDefault01_RL_F_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/Blossom/Default/BlossomDefault01_RL_F.Default__BlossomDefault01_RL_F_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",5ACEB47B4DC474437836D1BE5DF53CC7"
 msgid "Fern, your blossom is talking!"
-msgstr "¡Helecho, tu flor esta hablando!"
+msgstr "¡Fern, tu flor esta hablando!"
 
 #. Key:	5AEA5C7F4EB5E13F37FC0C9552530212
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToFuta(7).LinesToFuta
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToFuta(7).LinesToFuta
 msgctxt ",5AEA5C7F4EB5E13F37FC0C9552530212"
 msgid "I want to feel warm human cum course through me!"
-msgstr "¡Quiero sentir caliente semen humano a través de mí!"
+msgstr "¡Quiero sentir un cálido semen humano a través de mí!"
 
 #. Key:	5B354C0D4D37B6FD0F25BCA917BD6BE1
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeAboutOrb.Default__MegaSlimeAboutOrb_C.SessionData.Lines(6).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeAboutOrb.Default__MegaSlimeAboutOrb_C.SessionData.Lines(6).Lines
 msgctxt ",5B354C0D4D37B6FD0F25BCA917BD6BE1"
 msgid "*Sigh* How I dream of what it would be like to roll around so freely."
-msgstr ""
+msgstr "*Suspira* Cómo sueño con lo que sería rodar tan libremente."
 
 #. Key:	5B50ECD6460E78702D62488307BE2A0A
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_RL.Default__FaleneDefault01_RL_C.ResponseData(7).ResponseData.BreederPrompt
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_RL.Default__FaleneDefault01_RL_C.ResponseData(7).ResponseData.BreederPrompt
 msgctxt ",5B50ECD6460E78702D62488307BE2A0A"
 msgid "Why don't futas have balls?"
-msgstr "¿Por qué las futas no tienen bolas?"
+msgstr "¿Por qué las futas no tienen pelotas?"
 
 #. Key:	5B8BBC574B6A3FC58C5769B04B8923FE
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_RL.Default__RomyDefault01_RL_C.ResponseData(5).ResponseData.BreederPrompt
 #: /Game/Dialogue/Romy/Default/RomyDefault01_RL.Default__RomyDefault01_RL_C.ResponseData(5).ResponseData.BreederPrompt
 msgctxt ",5B8BBC574B6A3FC58C5769B04B8923FE"
 msgid "What is with the locked dungeon?"
-msgstr ""
+msgstr "¿Qué pasa con la mazmorra cerrada?"
 
 #. Key:	5BCD2C4F491787616684ECAD40FE34C6
 #. SourceLocation:	/Game/Dialogue/Reaper/Default/ReaperDefault01_RL.Default__ReaperDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/Reaper/Default/ReaperDefault01_RL.Default__ReaperDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",5BCD2C4F491787616684ECAD40FE34C6"
 msgid "Hello?"
-msgstr ""
+msgstr "¿Hola?"
 
 #. Key:	5C17953A4E43CD3EE715BC8BE3D80889
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R02.Default__CamillaDefault01_R02_C.SessionData.Lines(8).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R02.Default__CamillaDefault01_R02_C.SessionData.Lines(8).Lines
 msgctxt ",5C17953A4E43CD3EE715BC8BE3D80889"
 msgid "Also, keep your eyes peeled for Blessed @MONSTER_RACE@. We can be found in all corners of the land and we would love to... make your aquaintance. "
-msgstr "Además, mantén los ojos bien abiertos para Bendecidos @MONSTER_RACE@. Se nos puede encontrar en todos los rincones de la tierra y nos encantaría... conocerte. "
+msgstr "Además, mantén los ojos bien abiertos para los @MONSTER_RACE@ bendecidos. Se nos puede encontrar en todos los rincones de la tierra y nos encantaría... conocerte. "
 
 #. Key:	5C2066884278BFCE28A098B5E6AE70AE
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_RL_M.Default__FernDefault02_RL_M_C.ResponseData(2).ResponseData.BreederPrompt
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02_RL_M.Default__FernDefault02_RL_M_C.ResponseData(2).ResponseData.BreederPrompt
 msgctxt ",5C2066884278BFCE28A098B5E6AE70AE"
 msgid "What can you do?"
-msgstr "¿Que es lo que puedes hacer?"
+msgstr "¿Qué puedes hacer?"
 
 #. Key:	5C38779E4968CAF3F455C68BDBEDADF9
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDungeon.Default__CassieDungeon_C.SessionData.Lines(7).Lines
 #: /Game/Dialogue/Cassie/Default/CassieDungeon.Default__CassieDungeon_C.SessionData.Lines(7).Lines
 msgctxt ",5C38779E4968CAF3F455C68BDBEDADF9"
 msgid "There! Promise me if you open it... we will have kinky sex in the old temple! Meow!"
-msgstr ""
+msgstr "¡Allí! Prométeme que si lo abres... ¡tendremos sexo pervertido en el viejo templo! ¡Miau!"
 
 #. Key:	5C55705949989D3944ACDD8DE6CAEB1E
 #. SourceLocation:	/Game/Dialogue/Fern/SexScenes/FernMilk_01.Default__FernMilk_01_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Fern/SexScenes/FernMilk_01.Default__FernMilk_01_C.SessionData.Lines(2).Lines
 msgctxt ",5C55705949989D3944ACDD8DE6CAEB1E"
 msgid "Human milky taste so good... ahhhh!"
-msgstr "Humana lechosa sabe tan bien... ¡ahhhh!"
+msgstr "Sabor lechoso humano tan bueno... ¡ahhhh!"
 
 #. Key:	5C9673D0476DF1FF65CB63B5F142C7FE
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(7).LinesToFemale
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(7).LinesToFemale
 msgctxt ",5C9673D0476DF1FF65CB63B5F142C7FE"
 msgid "@MONSTER_RACE@ origins are ancient and unknown, but we desire one thing above all else..."
-msgstr "Los orígenes de @MONSTER_RACE@ son antiguos y desconocidos, pero deseamos una cosa por encima de todo..."
+msgstr "Los orígenes de los @MONSTER_RACE@ son antiguos y desconocidos, pero deseamos una cosa por encima de todo..."
 
 #. Key:	5C98DE6F491C2551F3E059B7839548B4
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeDungeon_RL.Default__AmberMaeDungeon_RL_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/AmberMae/Default/AmberMaeDungeon_RL.Default__AmberMaeDungeon_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",5C98DE6F491C2551F3E059B7839548B4"
 msgid "You couldn't fit in the dungeon?!"
-msgstr ""
+msgstr "¡¿No cabías en la mazmorra ?!"
 
 #. Key:	5D1189D248873A7E95BA20AA8EADCF1C
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_Daze.Default__EmissaryDefault01_Daze_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_Daze.Default__EmissaryDefault01_Daze_C.SessionData.Lines(0).Lines
 msgctxt ",5D1189D248873A7E95BA20AA8EADCF1C"
 msgid "When the Goddess saw that Her creations indulged heavily in the pleasures of breeding that they neglected life, She devised a solution."
-msgstr ""
+msgstr "Cuando la Diosa vio que sus creaciones se entregaban en gran medida a los placeres de la reproducción y descuidaban la vida, ideó una solución."
 
 #. Key:	5D244F6542342816F374B582D37B9B98
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(18).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(18).Lines
 msgctxt ",5D244F6542342816F374B582D37B9B98"
 msgid "Swearing to return again one day, the Goddess departed and faded from sight."
-msgstr "Jurando regresar algún día, la Diosa se fue y desapareció de vista."
+msgstr "Jurando regresar de nuevo algún día, la Diosa se fue y desapareció de la vista."
 
 #. Key:	5D28B49D4DE445D9A31C4FA2B4501737
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.CBGate_Sands.PlaceMessage
 #: /Game/World/Overworld.Overworld:PersistentLevel.CBGate_Sands.PlaceMessage
 msgctxt ",5D28B49D4DE445D9A31C4FA2B4501737"
 msgid "Lewd Desert is now accessible."
-msgstr ""
+msgstr "El Desierto Lascivo ahora es accesible."
 
 #. Key:	5DBBC25548CE64C57F539B87D36558A9
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiIdiots.Default__FesssiIdiots_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiIdiots.Default__FesssiIdiots_C.SessionData.Lines(1).Lines
 msgctxt ",5DBBC25548CE64C57F539B87D36558A9"
 msgid "Now human, we are going to need a mighty creature in order to free my girthy hindquarters."
-msgstr ""
+msgstr "Ahora humano, vamos a necesitar una criatura poderosa para liberar mis orondos cuartos traseros."
 
 #. Key:	5E27E8A74A30D389BBB939B5142249BB
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiGreeting01.Default__ParvatiGreeting01_C.SessionData.LinesToFuta(7).LinesToFuta
 #: /Game/Dialogue/Parvati/Default/ParvatiGreeting01.Default__ParvatiGreeting01_C.SessionData.LinesToFuta(7).LinesToFuta
 msgctxt ",5E27E8A74A30D389BBB939B5142249BB"
 msgid "I greatly desire to experience your fat cock."
-msgstr "Tengo muchas ganas de experimentar tu polla gorda con esmero."
+msgstr "Tengo muchas ganas de experimentar tu gorda polla."
 
 #. Key:	5E335B804845931D253C9186CD06C403
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(8).LinesToFemale
@@ -4960,39 +4987,40 @@ msgstr "¡Reproducirnos!"
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToMale(7).LinesToMale
 msgctxt ",5E3B309B4D79B4A31F6B1786E8B3AB2D"
 msgid "I want to feel warm human cum course through me!"
-msgstr "¡Quiero sentir caliente semen humano a través de mí!"
+msgstr "¡Quiero sentir un cálido semen humano a través de mí!"
 
 #. Key:	5E79231E46C65B7ABB930CBB9EE87267
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernHadSex03.Default__FernHadSex03_C.SessionData.LinesToFuta(2).LinesToFuta
 #: /Game/Dialogue/Fern/DefaultP3/FernHadSex03.Default__FernHadSex03_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",5E79231E46C65B7ABB930CBB9EE87267"
 msgid "You released soooo much cum in here, I love it."
-msgstr ""
+msgstr "Lanzaste taaanto semen aquí, me encanta."
 
 #. Key:	5E8F33C74DE660C4911FD98A332F6BDE
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeKneel.Default__BeeKneel_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/QueenBee/Default/BeeKneel.Default__BeeKneel_C.SessionData.Lines(0).Lines
 msgctxt ",5E8F33C74DE660C4911FD98A332F6BDE"
 msgid "Ahhh yes... place your mouth upon my teat, for it is custom for all subjects to taste of my honey."
-msgstr ""
+msgstr "Ahhh, sí... coloca tu boca sobre mi pezón, porque es costumbre que todos los sujetos prueben mi miel."
 
 #. Key:	5F41B5A04451E1F4E959DA86D6846CB4
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R04.Default__FaleneDefault01_R04_C.SessionData.Lines(6).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R04.Default__FaleneDefault01_R04_C.SessionData.Lines(6).Lines
 msgctxt ",5F41B5A04451E1F4E959DA86D6846CB4"
 msgid "Unlike human females, @MONSTER_RACE@ females' breasts are always producing milk... and lots of it."
-msgstr "A diferencia de las hembras humanas, los senos de @MONSTER_RACE@ hembras siempre producen leche... y mucha."
+msgstr "A diferencia de las hembras humanas, los pechos de las hembras @MONSTER_RACE@ siempre producen leche... y mucha."
 
 #. Key:	5F4FDDD7441D663752F3D78544042EEA
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadCherryHelp.Default__DryadCherryHelp_C.SessionData.LinesToFuta(2).LinesToFuta
 #: /Game/Dialogue/Autumn/Default/DryadCherryHelp.Default__DryadCherryHelp_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",5F4FDDD7441D663752F3D78544042EEA"
 msgid "I'm getting wet just thinking about your thick cock seeding me."
-msgstr ""
+msgstr "Me estoy mojando solo de pensar en tu gruesa polla sembrándome."
 
 #. Key:	5F71A084478332FD553228BF6DB08550
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(2 - Value).TraitIcons.DisplayName
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(2 - Value).TraitIcons.DisplayName
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(2 -
+#: Value).TraitIcons.DisplayName
 msgctxt ",5F71A084478332FD553228BF6DB08550"
 msgid "Huge Size"
 msgstr "Tamaño Enorme"
@@ -5002,7 +5030,7 @@ msgstr "Tamaño Enorme"
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01.Default__ParvatiDefault01_C.SessionData.Lines(2).Lines
 msgctxt ",5F895A6648E5FFD934EC86AD63AB82BC"
 msgid "We can learn the origins of the universe."
-msgstr "Podemos aprender los orígenes del universo."
+msgstr "Podemos conocer los orígenes del universo."
 
 #. Key:	5F9984824BEBBCD016F7B7BF5D1C25E3
 #. SourceLocation:	/Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToFemale(1).LinesToFemale
@@ -5023,56 +5051,56 @@ msgstr "Ah, bueno, podría concederte acceso, pero... hay algo que quiero a camb
 #: /Game/Dialogue/Emissary/Default/EmissaryHadSex01.Default__EmissaryHadSex01_C.SessionData.LinesToFuta(3).LinesToFuta
 msgctxt ",604FA2154312C173E208F3949C0C0A75"
 msgid "Judging by the mess on the temple floor, quite good."
-msgstr ""
+msgstr "A juzgar por el desorden en el suelo del templo, bastante buena."
 
 #. Key:	60635C454CEF8341039602B6529EEE22
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowSpiders.Default__WidowSpiders_C.SessionData.Lines(6).Lines
 #: /Game/Dialogue/Widow/Default/WidowSpiders.Default__WidowSpiders_C.SessionData.Lines(6).Lines
 msgctxt ",60635C454CEF8341039602B6529EEE22"
 msgid "Since humans are, or were, a myth, spiders crave the next best thing: elves."
-msgstr ""
+msgstr "Dado que los humanos son, o fueron, un mito, las arañas anhelan la siguiente mejor opción: los elfos."
 
 #. Key:	609D904E4D1F23007D88028804202202
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_HowToSpiritForm_RL_F.Default__LeylannaDefault01_HowToSpiritForm_RL_F_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/Leylanna/Default/LeylannaDefault01_HowToSpiritForm_RL_F.Default__LeylannaDefault01_HowToSpiritForm_RL_F_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",609D904E4D1F23007D88028804202202"
 msgid "I have caught the variant you requested."
-msgstr "He captado la variante que solicitaste."
+msgstr "He capturado la variante que solicitaste."
 
 #. Key:	60B6EB594571EB46AAF53EAF5A1EF34C
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R03.Default__FaleneDefault01_R03_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R03.Default__FaleneDefault01_R03_C.SessionData.Lines(2).Lines
 msgctxt ",60B6EB594571EB46AAF53EAF5A1EF34C"
 msgid "That instinct draws them to what the temple calls \"Avatars of the Goddess\"."
-msgstr "Ese instinto los atrae a lo que el templo llama \"Avatares de la Diosa\"."
+msgstr "Ese instinto los atrae hacia lo que el templo llama \"Avatares de la Diosa\"."
 
 #. Key:	60F7E0894814D89ADDD7CDBD0B8BDFA5
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaHadSex01.Default__LeylannaHadSex01_C.SessionData.LinesToFemale(3).LinesToFemale
 #: /Game/Dialogue/Leylanna/Default/LeylannaHadSex01.Default__LeylannaHadSex01_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",60F7E0894814D89ADDD7CDBD0B8BDFA5"
 msgid "Bring those soft breasts to me... I want to feel them."
-msgstr ""
+msgstr "Tráeme esos suaves pechos... quiero sentirlos."
 
 #. Key:	610937E54B5168894FBCF992E5728C73
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01.Default__MirruDefault01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Mirru/Default/MirruDefault01.Default__MirruDefault01_C.SessionData.Lines(0).Lines
 msgctxt ",610937E54B5168894FBCF992E5728C73"
 msgid "The human of the drylands returns."
-msgstr "La humana de las tierras secas regresa."
+msgstr "El humano de tierra firme regresa."
 
 #. Key:	611DA9BB4817A59AE6891B9EEF129C59
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_SpiritForm.Default__LeylannaDefault01_SpiritForm_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Leylanna/Default/LeylannaDefault01_SpiritForm.Default__LeylannaDefault01_SpiritForm_C.SessionData.Lines(2).Lines
 msgctxt ",611DA9BB4817A59AE6891B9EEF129C59"
 msgid "Some adore you so greatly, they are willing to bind themselves to your physical body, allowing you to take on their form."
-msgstr "Algunos te adoran tanto que están dispuestos a unirse a tu cuerpo físico, lo que te permite adoptar su forma."
+msgstr "Algunos te adoran tanto que están dispuestos a unirse a tu cuerpo físico, permitiéndote tomar su forma."
 
 #. Key:	611DEEEA4F0BEB84BE76FDAD70AB9B96
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeTaskFulfilled.Default__BeeTaskFulfilled_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/QueenBee/Default/BeeTaskFulfilled.Default__BeeTaskFulfilled_C.SessionData.Lines(2).Lines
 msgctxt ",611DEEEA4F0BEB84BE76FDAD70AB9B96"
 msgid "You came through for us human, and for that you have my thanks. My girls have removed the honey preventing you from entering Sultry Plateau."
-msgstr ""
+msgstr "Viniste por nosotras, humano, y por eso tienes mi agradecimiento. Mis chicas te han quitado la miel que te impide entrar en la Meseta Bochornosa."
 
 #. Key:	61341EBA4A04883698FF08BF81A229FB
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_RL.Default__EmissaryDefault01_RL_C.ResponseData(5).ResponseData.BreederPrompt
@@ -5086,28 +5114,28 @@ msgstr "¿Qué es la Gran Concepción?"
 #: /Game/Dialogue/DragonMatriarch/Default/DMTaskFulfilled.Default__DMTaskFulfilled_C.SessionData.Lines(0).Lines
 msgctxt ",613E368A449069B472AC11842731C6AB"
 msgid "Ahhh so sweet and creamy! I haven't felt this good in decades."
-msgstr ""
+msgstr "¡Ahhh, tan dulce y cremoso! No me había sentido tan bien en décadas."
 
 #. Key:	61A8146D43CCAA9D468CCC9D2CB22F42
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon.Default__AmberMaeLockedDungeon_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon.Default__AmberMaeLockedDungeon_C.SessionData.Lines(4).Lines
 msgctxt ",61A8146D43CCAA9D468CCC9D2CB22F42"
 msgid "If I recall... they rigged up some switch 'an pulley system."
-msgstr ""
+msgstr "Si mah no recuerdo... inhtalaron un interrustor y sihtema de poleah."
 
 #. Key:	61C3C47B425E2ACFE03921A38EDBD93D
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.CBGate_Glade.PlaceMessage
 #: /Game/World/Overworld.Overworld:PersistentLevel.CBGate_Glade.PlaceMessage
 msgctxt ",61C3C47B425E2ACFE03921A38EDBD93D"
 msgid "Esoteric Glade is now accessible."
-msgstr ""
+msgstr "El Claro Esotérico ahora es accesible."
 
 #. Key:	61DD0F8342D2EFAE9232248215EADFB4
 #. SourceLocation:	/Game/Ranch/Upgrades/NekoCondo.Default__NekoCondo_C.Upgrade.Description
 #: /Game/Ranch/Upgrades/NekoCondo.Default__NekoCondo_C.Upgrade.Description
 msgctxt ",61DD0F8342D2EFAE9232248215EADFB4"
 msgid "This allows you to catch and store all variants of Nekos."
-msgstr "Algunos te adoran tanto que están dispuestos a unirse a tu cuerpo físico, lo que te permite adoptar su forma."
+msgstr "Esto te permite capturar y almacenar todas las variantes de Nekos."
 
 #. Key:	61DEC1574FD90C69A68E04B4E3BD4DDB
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_RL.Default__FaleneDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
@@ -5121,105 +5149,105 @@ msgstr "Háblame de la reproducción @MONSTER_RACE@."
 #: /Game/Dialogue/Petra/Default/PetraAboutPawsmaati.Default__PetraAboutPawsmaati_C.SessionData.Lines(3).Lines
 msgctxt ",6200B02D4EBCCEB4A3E6E2A95F82F6FA"
 msgid "She has the unique ability to change her body, both in size and... \"features\"."
-msgstr ""
+msgstr "Tiene la capacidad única de cambiar su cuerpo, tanto en tamaño como en... \"características\"."
 
 #. Key:	620C1C684C2E93329AEAD78099B4E620
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R01.Default__FaleneDefault01_R01_C.SessionData.Lines(9).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R01.Default__FaleneDefault01_R01_C.SessionData.Lines(9).Lines
 msgctxt ",620C1C684C2E93329AEAD78099B4E620"
 msgid "Both enter another dimension where gestation begins, and what is years for the @MONSTER_RACE@ offspring is but seconds for us."
-msgstr "Ambos ingresan a otra dimensión donde comienza la gestación, y lo que son años para la descendencia @MONSTER_RACE@ son apenas segundos para nosotros."
+msgstr "Ambos entran en otra dimensión donde comienza la gestación, y lo que son años para la descendencia @MONSTER_RACE@ son apenas segundos para nosotros."
 
 #. Key:	6229EDF2456AA517D405ACBDBBD6D488
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcBrashDumb.Default__OrcBrashDumb_C.SessionData.Lines(8).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcBrashDumb.Default__OrcBrashDumb_C.SessionData.Lines(8).Lines
 msgctxt ",6229EDF2456AA517D405ACBDBBD6D488"
 msgid "Sometimes a tribe sister comes up here to challenge me. She will leave with her pussy and mouth full of my seed!"
-msgstr ""
+msgstr "A veces, una hermana de la tribu viene aquí para desafiarme. ¡Ella se irá con el coño y la boca llenos de mi semilla!"
 
 #. Key:	623951124677DCB7B08E31B3C53CABCC
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadFlowers.Default__DryadFlowers_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Autumn/Default/DryadFlowers.Default__DryadFlowers_C.SessionData.Lines(0).Lines
 msgctxt ",623951124677DCB7B08E31B3C53CABCC"
 msgid "Hmm... I believe I can."
-msgstr ""
+msgstr "Hmm... creo que puedo."
 
 #. Key:	6266DCAA4BE349E65FF6D89994B5E9C6
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03_RL_F.Default__FernDefault03_RL_F_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03_RL_F.Default__FernDefault03_RL_F_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",6266DCAA4BE349E65FF6D89994B5E9C6"
 msgid "Why did you call me master?"
-msgstr "¿Por qué me llamaste maestra?"
+msgstr "¿Por qué me llamaste, Master?"
 
 #. Key:	627219374671317BBA6148B048EA7B8F
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(13).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(13).Lines
 msgctxt ",627219374671317BBA6148B048EA7B8F"
 msgid "Such creations roamed in weak forms purely by instinct, what you call animals."
-msgstr "Tales creaciones vagaron en formas débiles por puro instinto, lo que vosotros llamais animales."
+msgstr "Tales creaciones vagaban en formas débiles puramente por instinto, lo que llamais animales."
 
 #. Key:	6272317B4A4AE3E76212F6A3B94CDAAA
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleTaskFulfilled.Default__KybeleTaskFulfilled_C.SessionData.LinesToFuta(2).LinesToFuta
 #: /Game/Dialogue/Kybele/Default/KybeleTaskFulfilled.Default__KybeleTaskFulfilled_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",6272317B4A4AE3E76212F6A3B94CDAAA"
 msgid "Such strength... ahhh!"
-msgstr ""
+msgstr "Tanta fuerza... ¡ahhh!"
 
 #. Key:	62B5CF3C40893752840CAEBF4C8159C3
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault02.Default__EmissaryDefault02_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault02.Default__EmissaryDefault02_C.SessionData.Lines(4).Lines
 msgctxt ",62B5CF3C40893752840CAEBF4C8159C3"
 msgid "It did not deserve the pleasures you granted it, and I would advise never speaking with it again."
-msgstr ""
+msgstr "No merecía los placeres que le concediste, y te aconsejaría que no volvieras a hablar con ella."
 
 #. Key:	62DABAA04453893D6FCD5390D28CB19A
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_R02.Default__FernDefault02_R02_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02_R02.Default__FernDefault02_R02_C.SessionData.Lines(2).Lines
 msgctxt ",62DABAA04453893D6FCD5390D28CB19A"
 msgid "Soon, I will fully bloom and not be able to move. We can have a lot of fun with my flower body!"
-msgstr "Pronto floreceré por completo y no podré moverme. ¡Podemos divertirnos mucho con mi cuerpo florido!"
+msgstr "Pronto, floreceré completamente y no podré moverme. ¡Podemos divertirnos mucho con mi cuerpo de flores!"
 
 #. Key:	62FF5D604699246B05ECEDA19F98F1BA
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",62FF5D604699246B05ECEDA19F98F1BA"
 msgid "You have no idea how much restraint I am putting forth at this moment..."
-msgstr "No tienes idea de cuánta contención estoy poniendo en este momento..."
+msgstr "No tienes idea de cuánto me estoy conteniendo en este momento..."
 
 #. Key:	630D79B54CCF1CADC252DB970D8C7327
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleTittyPony_T.Default__KybeleTittyPony_T_C.SessionData.LinesToMale(2).LinesToMale
 #: /Game/Dialogue/Kybele/Default/KybeleTittyPony_T.Default__KybeleTittyPony_T_C.SessionData.LinesToMale(2).LinesToMale
 msgctxt ",630D79B54CCF1CADC252DB970D8C7327"
 msgid "That should teach you to cross this titty po--I mean mighty centaur warmaiden, again!"
-msgstr ""
+msgstr "Eso debería enseñarte a cruzar esta poni tet-: ¡otra vez, me refiero a la poderosa doncella-guerrera centauro!"
 
 #. Key:	63185F8D44DB00B8514792BA4971889F
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_SexPositions.Default__FaleneDefault01_SexPositions_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_SexPositions.Default__FaleneDefault01_SexPositions_C.SessionData.Lines(4).Lines
 msgctxt ",63185F8D44DB00B8514792BA4971889F"
 msgid "She will probably know more, she sleeps... I mean gets... around."
-msgstr "Probablemente ella sabrá más, duerme... quiero decir, se mueve alrededor..."
+msgstr "Probablemente ella sabrá más, duerme... quiero decir, se mueve... alrededor."
 
 #. Key:	6340E0A045F87C6E35C3348C97609B67
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01.Default__ParvatiDefault01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01.Default__ParvatiDefault01_C.SessionData.Lines(1).Lines
 msgctxt ",6340E0A045F87C6E35C3348C97609B67"
 msgid "I want to make love with you, I will not lie."
-msgstr "Quiero hacer el amor contigo, no puedo mentir y me sonrojo."
+msgstr "Quiero hacer el amor contigo, no mentiré."
 
 #. Key:	639BDE8A40D4ABAD77555A89D2C8E86B
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeMasturbate.Default__BeeMasturbate_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/QueenBee/Default/BeeMasturbate.Default__BeeMasturbate_C.SessionData.Lines(2).Lines
 msgctxt ",639BDE8A40D4ABAD77555A89D2C8E86B"
 msgid "Or being your sex toy. Don't think I haven't noticed you defiling their adorable fuzzy bodies."
-msgstr ""
+msgstr "O ser tu juguete sexual. No creas que no te he visto profanando sus adorables cuerpos peludos."
 
 #. Key:	63A38D02485080C06D6E03A71640D251
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01_RL_T.Default__FernDefault01_RL_T_C.ResponseData(5).ResponseData.BreederPrompt
 #: /Game/Dialogue/Fern/Default/FernDefault01_RL_T.Default__FernDefault01_RL_T_C.ResponseData(5).ResponseData.BreederPrompt
 msgctxt ",63A38D02485080C06D6E03A71640D251"
 msgid "The Queen Bee demands flowers."
-msgstr ""
+msgstr "La Abeja Reina exige flores."
 
 #. Key:	63A5E9734DC0420DD97A739128DEEF85
 #. SourceLocation:	/Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToFuta(3).LinesToFuta
@@ -5233,14 +5261,14 @@ msgstr "*Lame* *Sorbe*"
 #: /Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon.Default__AmberMaeLockedDungeon_C.SessionData.Lines(0).Lines
 msgctxt ",63ACAC1E4A5D5DFE164A168EAFEE76BC"
 msgid "Aye, 'tis been countless years since anyone's been down there!"
-msgstr ""
+msgstr "¡Seh, han pasao incontableh añoh dehde que arguien ehtuvo allí!"
 
 #. Key:	63B540744119014025598C8555237076
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMHadSex01.Default__DMHadSex01_C.SessionData.LinesToFemale(2).LinesToFemale
 #: /Game/Dialogue/DragonMatriarch/Default/DMHadSex01.Default__DMHadSex01_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",63B540744119014025598C8555237076"
 msgid "Humans... I can understand why the world is obsessed with you now."
-msgstr ""
+msgstr "Humanos... puedo entender por qué el mundo está obsesionado contigo ahora."
 
 #. Key:	63B6296840BB64E725E7219F715EEAB1
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToFuta(4).LinesToFuta
@@ -5254,7 +5282,7 @@ msgstr "Algo mítico... algo prohibido... algo... ¡humano!"
 #: /Game/Dialogue/Autumn/Default/DryadFatAssLamia.Default__DryadFatAssLamia_C.SessionData.Lines(2).Lines
 msgctxt ",63C3A400466ECFE75FCDA58BBC7954C9"
 msgid "She was... eh... doing interesting things with a massive spider!"
-msgstr ""
+msgstr "Ella estaba... eh... ¡haciendo cosas interesantes con una inmensa araña!"
 
 #. Key:	63F3737B48B4C916545D1D8159EB762C
 #. SourceLocation:	/Game/Breeding/Positions/Cowgirl.Default__Cowgirl_C.SessionData.PositionName
@@ -5268,14 +5296,14 @@ msgstr "Vaquera"
 #: /Game/Dialogue/Leylanna/Default/LeylannaDefault01_BlueSmoke.Default__LeylannaDefault01_BlueSmoke_C.SessionData.Lines(1).Lines
 msgctxt ",642A06E64C62D0AA35E17FB7181BDBD8"
 msgid "By inhaling it all day it grants me visions into worlds beyond."
-msgstr "Al inhalarlo todo el día me otorga visiones de mundos más allá."
+msgstr "Al inhalarlo todo el día, me concede visiones de mundos más allá."
 
 #. Key:	643311E64814ADA6B66E4AB03B31A666
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraAboutPawsmaati.Default__PetraAboutPawsmaati_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Petra/Default/PetraAboutPawsmaati.Default__PetraAboutPawsmaati_C.SessionData.Lines(2).Lines
 msgctxt ",643311E64814ADA6B66E4AB03B31A666"
 msgid "In her long years, she has mastered the magical arts of flesh transmogrify and sexual pleasure."
-msgstr ""
+msgstr "En sus largos años, ha dominado las artes mágicas de la transfiguración de la carne y el placer sexual."
 
 #. Key:	644065F84B0F2E772BE21695810A2F0F
 #. SourceLocation:	/Game/Characters/Procedural/Variants/Bovaur/Harvest/BovaurHarvest.Default__BovaurHarvest_C.Harvest.Description
@@ -5289,28 +5317,28 @@ msgstr "Fluidos corporales de Bovaur."
 #: /Game/World/Events/EM_Pearl.Default__EM_Pearl_C.ActivateMessage
 msgctxt ",6447F38E4E2E302612E297856123386E"
 msgid "Take Pearl"
-msgstr ""
+msgstr "Toma la Perla"
 
 #. Key:	646A76464079BB23F12A50A6B8512B75
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(27).LinesToFemale
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(27).LinesToFemale
 msgctxt ",646A76464079BB23F12A50A6B8512B75"
 msgid "We just love you too much, and sometimes our desires spiral out of control!"
-msgstr "¡Te amamos demasiado y, a veces, nuestros deseos se descontrolan!"
+msgstr "Te amamos demasiado y, a veces, ¡nuestros deseos se descontrolan!"
 
 #. Key:	646F99EA498DD1E54CCB8AB5413F39DB
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiGreeting01.Default__ParvatiGreeting01_C.SessionData.LinesToFemale(2).LinesToFemale
 #: /Game/Dialogue/Parvati/Default/ParvatiGreeting01.Default__ParvatiGreeting01_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",646F99EA498DD1E54CCB8AB5413F39DB"
 msgid "Different ways of seducing your mates, but all with the same goal."
-msgstr "Diferentes formas de seducir tus compañeras/os buscas, pero todas con el mismo final."
+msgstr "Diferentes formas de seducir tus compañeros/as buscas, pero todas con el mismo final."
 
 #. Key:	6472B92C4C77BC77E4D51599F203425B
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_RL.Default__CamillaDefault01_RL_C.ResponseData(5).ResponseData.BreederPrompt
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_RL.Default__CamillaDefault01_RL_C.ResponseData(5).ResponseData.BreederPrompt
 msgctxt ",6472B92C4C77BC77E4D51599F203425B"
 msgid "Girthy lump? More like... delicious fuck lump!"
-msgstr "Bulto circunscrito? Mas bien... ¡delicioso bulto que joder!"
+msgstr "¿Bulto orondo? Mas bien... ¡delicioso bulto que joder!"
 
 #. Key:	6473C6F3408A6FDB0321298B46707D81
 #. SourceLocation:	/Game/Dialogue/Blossom/Default/BlossomDefault01.Default__BlossomDefault01_C.SessionData.Lines(1).Lines
@@ -5331,84 +5359,85 @@ msgstr "Tu cuerpo sería un gran juguete sexual."
 #: /Game/Dialogue/QueenBee/Default/BeeMasturbate.Default__BeeMasturbate_C.SessionData.Lines(1).Lines
 msgctxt ",64CC71FD416D9657B85C8B867FC921DE"
 msgid "As queen, I am entitled to constant pleasure. Yet, my daughters are busy collecting nectar."
-msgstr ""
+msgstr "Como reina, tengo derecho al placer constante. Sin embargo, mis hijas están ocupadas recolectando néctar."
 
 #. Key:	64D03AEC41B764C9BCFB0CAAED5A58DD
 #. SourceLocation:	/Game/Dialogue/Yasmine/Default/YasmineDefault01.Default__YasmineDefault01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Yasmine/Default/YasmineDefault01.Default__YasmineDefault01_C.SessionData.Lines(0).Lines
 msgctxt ",64D03AEC41B764C9BCFB0CAAED5A58DD"
 msgid "*Strange moans and squishy noises can be heard within.*"
-msgstr ""
+msgstr "*Se pueden escuchar extraños gemidos y ruidos blandos en el interior.*"
 
 #. Key:	64DDB04B426866024F9EFC98D34E99E5
 #. SourceLocation:	/Game/Dialogue/Blossom/Default/BlossomDefault01_RL_F.Default__BlossomDefault01_RL_F_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/Blossom/Default/BlossomDefault01_RL_F.Default__BlossomDefault01_RL_F_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",64DDB04B426866024F9EFC98D34E99E5"
 msgid "Why did you call me master?"
-msgstr "¿Por qué me llamaste maestra?"
+msgstr "¿Por qué me llamaste, Master?"
 
 #. Key:	64E952FE4B46D2DBE99FAD9370462318
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_RL.Default__CamillaDefault01_RL_C.ResponseData(3).ResponseData.BreederPrompt
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_RL.Default__CamillaDefault01_RL_C.ResponseData(3).ResponseData.BreederPrompt
 msgctxt ",64E952FE4B46D2DBE99FAD9370462318"
 msgid "Do you always stand on that barrel?"
-msgstr "¿Siempre te pones de pie sobre ese barril?"
+msgstr "¿Siempre estás de pie sobre ese barril?"
 
 #. Key:	650E3F124AAD112733D65B9F0D095FA8
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01.Default__CamillaDefault01_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01.Default__CamillaDefault01_C.SessionData.Lines(2).Lines
 msgctxt ",650E3F124AAD112733D65B9F0D095FA8"
 msgid "When I came back covered in cum from every creature in @WORLD_NAME@, she laughed for hours."
-msgstr "Cuando volví cubierta de esperma de cada criatura en @WORLD_NAME@, se rió por horas."
+msgstr "Cuando regresé cubierta de semen de todas las criaturas en @WORLD_NAME@, se rió durante horas."
 
 #. Key:	653BCE96424AE552DCA4D7853B50BC39
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFuta(6).LinesToFuta
 #: /Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFuta(6).LinesToFuta
 msgctxt ",653BCE96424AE552DCA4D7853B50BC39"
 msgid "Actually, fat ass reminds me of something!"
-msgstr ""
+msgstr "En realidad, ¡el culo gordo me recuerda algo!"
 
 #. Key:	657B8CAA4F7FC96AAD9188A418E914E3
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchPrettyButterfly.Default__MonarchPrettyButterfly_C.SessionData.Lines(6).Lines
 #: /Game/Dialogue/Monarch/Default/MonarchPrettyButterfly.Default__MonarchPrettyButterfly_C.SessionData.Lines(6).Lines
 msgctxt ",657B8CAA4F7FC96AAD9188A418E914E3"
 msgid "To start s-s-sex and... control it."
-msgstr ""
+msgstr "Para iniciar el s-s-sexo y ... controlarlo."
 
 #. Key:	659F65A5454F216DBCA2DE943F3D816D
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_R04.Default__FernDefault02_R04_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02_R04.Default__FernDefault02_R04_C.SessionData.Lines(0).Lines
 msgctxt ",659F65A5454F216DBCA2DE943F3D816D"
 msgid "Oh Master... you are too good to me."
-msgstr "Oh maestra... eres demasiado buena para mí."
+msgstr "Oh, Master... eres demasiado bueno para mí."
 
 #. Key:	65F2B1384977D80660A4E4A91389BC9D
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(12 - Value).TraitIcons.DisplayName
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(12 - Value).TraitIcons.DisplayName
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(12 -
+#: Value).TraitIcons.DisplayName
 msgctxt ",65F2B1384977D80660A4E4A91389BC9D"
 msgid "Grungy"
-msgstr "Sucio/a"
+msgstr "Sucio"
 
 #. Key:	660193204E5DEA727DEC1C858BA2467E
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMClimaxPeak.Default__DMClimaxPeak_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMClimaxPeak.Default__DMClimaxPeak_C.SessionData.Lines(4).Lines
 msgctxt ",660193204E5DEA727DEC1C858BA2467E"
 msgid "Legends say, when a blessed dragon consumes the milk she will be granted new vigor."
-msgstr ""
+msgstr "Las leyendas dicen que cuando un dragón bendecido consume la leche, se le otorgará un nuevo vigor."
 
 #. Key:	664C0BE948989DEEE1185793CB1EEE77
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiGreeting01.Default__ParvatiGreeting01_C.SessionData.LinesToFemale(5).LinesToFemale
 #: /Game/Dialogue/Parvati/Default/ParvatiGreeting01.Default__ParvatiGreeting01_C.SessionData.LinesToFemale(5).LinesToFemale
 msgctxt ",664C0BE948989DEEE1185793CB1EEE77"
 msgid "My teachings are not for those who desire to keep their virginity."
-msgstr "Mis enseñanzas no son para aquellas que desean mantener su virginidad."
+msgstr "Mis enseñanzas no son para aquellos que desean mantener su virginidad."
 
 #. Key:	6658580C407404A28C6BD1875A2920D2
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01_RL_T.Default__FernDefault01_RL_T_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/Fern/Default/FernDefault01_RL_T.Default__FernDefault01_RL_T_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",6658580C407404A28C6BD1875A2920D2"
 msgid "What a lovely talking fern..."
-msgstr "Qué hermoso helecho parlante..."
+msgstr "Qué encantador helecho parlante..."
 
 #. Key:	668D13F146AB0A33AF196F814E2CAA98
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_RL.Default__RomyDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
@@ -5422,14 +5451,14 @@ msgstr "Bañarse."
 #: /Game/Dialogue/Fesssi/Default/FesssiIdiots.Default__FesssiIdiots_C.SessionData.Lines(7).Lines
 msgctxt ",6692103B4B53269229DB388B380B520F"
 msgid "Do hurry human, I am very horny and ready to mate with the world... starting with you."
-msgstr ""
+msgstr "Date prisa humana, estoy muy cachonda y dispuesta a aparearme con el mundo... empezando por ti."
 
 #. Key:	66E2EA9044A750BB60AD308B87FE3071
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadHaveKeystone.Default__DryadHaveKeystone_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Autumn/Default/DryadHaveKeystone.Default__DryadHaveKeystone_C.SessionData.Lines(3).Lines
 msgctxt ",66E2EA9044A750BB60AD308B87FE3071"
 msgid "They eat the bossom cherries faster than I can make them."
-msgstr ""
+msgstr "Se comen las cerezas de seno más rápido de lo que puedo hacerlas."
 
 #. Key:	66E8E5AB4E2D126AFBE3A7858C3E70EF
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_PussyPortals.Default__NeelaDefault01_PussyPortals_C.SessionData.Lines(0).Lines
@@ -5443,35 +5472,35 @@ msgstr "¿Se te ocurre un nombre mejor? Sólo mira las malditas cosas."
 #: /Game/Dialogue/Cassie/SexScenes/CassieButterButtF.Default__CassieButterButtF_C.SessionData.Lines(5).Lines
 msgctxt ",66F6289345C29C0CE3AFC2A1AB411CEE"
 msgid "Ohhh yes... meow... ahhh..."
-msgstr "Ohhh sí... miau... ahhh..."
+msgstr "Ohhh, sí... miau... ahhh..."
 
 #. Key:	66FF732B48A05F6D56007DA56AA83546
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault02.Default__FaleneDefault02_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault02.Default__FaleneDefault02_C.SessionData.Lines(4).Lines
 msgctxt ",66FF732B48A05F6D56007DA56AA83546"
 msgid "Hehehe... she is going to love what I brought her."
-msgstr ""
+msgstr "Jejeje... le va a encantar lo que le traje."
 
 #. Key:	6704B8A54849F885661105A85287867D
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaFaleneWeek.Default__CamillaFaleneWeek_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaFaleneWeek.Default__CamillaFaleneWeek_C.SessionData.Lines(3).Lines
 msgctxt ",6704B8A54849F885661105A85287867D"
 msgid "First, I have to be naked."
-msgstr ""
+msgstr "Primero, tengo que estar desnuda."
 
 #. Key:	6779B6F54EA9811CDA01BB899D8E10A4
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(2).Lines
 msgctxt ",6779B6F54EA9811CDA01BB899D8E10A4"
 msgid "I'm Amber-Mae, yer Bovaur dairy lass!"
-msgstr "¡Soy Amber-Mae, tu mosa leshera Bovaur!"
+msgstr "¡Soy Amber-Mae, tu mosa leshera bovaur!"
 
 #. Key:	679174774B8AE81A6C98AE933C6D1BF3
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_Formuria.Default__MirruDefault01_Formuria_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_Formuria.Default__MirruDefault01_Formuria_C.SessionData.Lines(5).Lines
 msgctxt ",679174774B8AE81A6C98AE933C6D1BF3"
 msgid "Let me just say, \"experience\" what you drylanders have to offer."
-msgstr "Permíteme decir, \"experimenta\" lo que tienen para ofrecer los habitantes de las tierras secanas."
+msgstr "Permíteme sólo decir, \"experimenta\" lo que tienen para ofrecer los de suelo firme."
 
 #. Key:	679B9CA8446900121B93359B9CD3CC08
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_YourMusic_ToneDeaf.Default__RomyDefault01_YourMusic_ToneDeaf_C.SessionData.Lines(0).Lines
@@ -5485,14 +5514,14 @@ msgstr "Qué lástima... qué hermosos sonidos podríamos hacer."
 #: /Game/Dialogue/Fesssi/Default/FesssiHowLong.Default__FesssiHowLong_C.SessionData.Lines(8).Lines
 msgctxt ",67B0B0EE4398E581F4E9B6AF9761BCCE"
 msgid "Captivated by my buxom behind, they would worship it or stick their fat cocks deep inside. I took more loads in my ass than any other @MONSTER_RACE@. Hiss!"
-msgstr ""
+msgstr "Cautivados por mi trasero exuberante, lo adorarían o meterían sus gordas pollas hasta el fondo. Tomé más cargas en mi culo que cualquier otro @MONSTER_RACE@. ¡Sss!"
 
 #. Key:	67B51FA5454DB188B081BFACCC583F71
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_RL_F.Default__FernDefault02_RL_F_C.ResponseData(4).ResponseData.BreederPrompt
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02_RL_F.Default__FernDefault02_RL_F_C.ResponseData(4).ResponseData.BreederPrompt
 msgctxt ",67B51FA5454DB188B081BFACCC583F71"
 msgid "The Queen Bee demands flowers."
-msgstr ""
+msgstr "La Abeja Reina exige flores."
 
 #. Key:	67E8752E482B4F96EC745D8BB55B5F68
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_StartCowgirl.Default__ParvatiDefault01_StartCowgirl_C.SessionData.Lines(0).Lines
@@ -5506,21 +5535,21 @@ msgstr "..."
 #: /Game/Dialogue/Cassie/Default/CassieDefault01_Meow.Default__CassieDefault01_Meow_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",67EB3E22466BD62D9BC182899350E3AF"
 msgid "*Purr*"
-msgstr "*Ronroneo*"
+msgstr "*Ronronea*"
 
 #. Key:	6829983E4E26EA5122F484ADF8FB4FD0
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchStartShySex.Default__MonarchStartShySex_C.SessionData.LinesToFuta(3).LinesToFuta
 #: /Game/Dialogue/Monarch/Default/MonarchStartShySex.Default__MonarchStartShySex_C.SessionData.LinesToFuta(3).LinesToFuta
 msgctxt ",6829983E4E26EA5122F484ADF8FB4FD0"
 msgid "So I can, y-y-you know... feel your cock deep inside me."
-msgstr ""
+msgstr "Entonces puedo, y-y-ya sabes... sentir tu polla profundamente dentro de mí."
 
 #. Key:	6850165B47861B4D0E47B1AFBC409B6A
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToFemale(5).LinesToFemale
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToFemale(5).LinesToFemale
 msgctxt ",6850165B47861B4D0E47B1AFBC409B6A"
 msgid "It's a nutritious aphrodisiac, a very powerful one so be careful!"
-msgstr ""
+msgstr "Es un afrodisíaco nutritivo, uno muy poderoso, ¡así que ten cuidado!"
 
 #. Key:	688E1D934E2D63E60F30488E807E8643
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_AboutKrakens.Default__MirruDefault01_AboutKrakens_C.SessionData.Lines(5).Lines
@@ -5534,77 +5563,78 @@ msgstr "Si bien nunca queremos hacer daño, nuestros deseos deben satisfacerse a
 #: /Game/Dialogue/Monarch/Default/MonarchDefault01.Default__MonarchDefault01_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",68A15FB749BF4A36B88C4C82CBC3166E"
 msgid "Soon my nectar collection will be complete, and I can return to the Hivelands."
-msgstr ""
+msgstr "Pronto mi colección de néctar estará completa y podré regresar a las Tierras-Colmena."
 
 #. Key:	68CDC1534D4397A3A7211A8ED7C2F578
 #. SourceLocation:	/Game/Dialogue/Cassie/SexScenes/CassieSplintersT.Default__CassieSplintersT_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Cassie/SexScenes/CassieSplintersT.Default__CassieSplintersT_C.SessionData.Lines(5).Lines
 msgctxt ",68CDC1534D4397A3A7211A8ED7C2F578"
 msgid "Ohhh yes... meow... ahhh..."
-msgstr "Ohhh si... miau... ahhh..."
+msgstr "Ohhh, sí... miau... ahhh..."
 
 #. Key:	6928C04F4EBC681B1BF676BB56435E32
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(8 - Value).TraitIcons.DisplayName
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(8 - Value).TraitIcons.DisplayName
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(8 -
+#: Value).TraitIcons.DisplayName
 msgctxt ",6928C04F4EBC681B1BF676BB56435E32"
 msgid "Charmer"
-msgstr "Encantador/a"
+msgstr "Encantador"
 
 #. Key:	693F4313487D2153C164CFBF808F1814
 #. SourceLocation:	/Game/Breeding/Positions/Test3.Default__Test3_C.SessionData.PositionName
 #: /Game/Breeding/Positions/Test3.Default__Test3_C.SessionData.PositionName
 msgctxt ",693F4313487D2153C164CFBF808F1814"
 msgid "Test3"
-msgstr "Test3"
+msgstr ""
 
 #. Key:	694BFC904B3397B73FEBEF836CD65954
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeAboutOrb.Default__MegaSlimeAboutOrb_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeAboutOrb.Default__MegaSlimeAboutOrb_C.SessionData.Lines(4).Lines
 msgctxt ",694BFC904B3397B73FEBEF836CD65954"
 msgid "We have been best friends ever since, even though she won't tell me her name."
-msgstr ""
+msgstr "Hemos sido mejores amigos desde entonces, aunque ella no me dirá su nombre."
 
 #. Key:	695409264F52725B30031E8F0FB4052C
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_RL_F.Default__FernDefault02_RL_F_C.ResponseData(2).ResponseData.BreederPrompt
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02_RL_F.Default__FernDefault02_RL_F_C.ResponseData(2).ResponseData.BreederPrompt
 msgctxt ",695409264F52725B30031E8F0FB4052C"
 msgid "What can you do?"
-msgstr "¿Que es lo que puedes hacer?"
+msgstr "¿Qué puedes hacer?"
 
 #. Key:	69736B6847FFEF0E503D5B911CB4FE32
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadBossomCherries.Default__DryadBossomCherries_C.SessionData.Lines(6).Lines
 #: /Game/Dialogue/Autumn/Default/DryadBossomCherries.Default__DryadBossomCherries_C.SessionData.Lines(6).Lines
 msgctxt ",69736B6847FFEF0E503D5B911CB4FE32"
 msgid "I may or may not take advantage of cute sleeping cows..."
-msgstr ""
+msgstr "Puedo o no aprovecharme de las lindas vacas durmientes..."
 
 #. Key:	697AC02A4A47BBBD70150ABE216F79E9
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_StartForgotten.Default__ParvatiDefault01_StartForgotten_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_StartForgotten.Default__ParvatiDefault01_StartForgotten_C.SessionData.Lines(1).Lines
 msgctxt ",697AC02A4A47BBBD70150ABE216F79E9"
 msgid "Contemplate for moment while I apply some lube."
-msgstr "Contempla por un momento mientras de lubricante aplico una muda."
+msgstr "Contempla por un momento mientras aplico un poco de lubricante."
 
 #. Key:	698288A146113C1492125B891EA3456D
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleDefault01_RL.Default__KybeleDefault01_RL_C.ResponseData(4).ResponseData.BreederPrompt
 #: /Game/Dialogue/Kybele/Default/KybeleDefault01_RL.Default__KybeleDefault01_RL_C.ResponseData(4).ResponseData.BreederPrompt
 msgctxt ",698288A146113C1492125B891EA3456D"
 msgid "Can I have that keystone?"
-msgstr ""
+msgstr "¿Puedo tener esa piedra-llave?"
 
 #. Key:	6993DD7B4964C190B75F98AABA008FAA
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieGreeting01.Default__CassieGreeting01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Cassie/Default/CassieGreeting01.Default__CassieGreeting01_C.SessionData.Lines(0).Lines
 msgctxt ",6993DD7B4964C190B75F98AABA008FAA"
 msgid "Well butter my butt and slap me with a biscuit. A human!"
-msgstr "Bueno, ponme mantequilla en el trasero y dame una bofetada. ¡Una humana!"
+msgstr "Bueno, unta mi trasero con mantequilla y dame una bofetada con una galleta. ¡Un humano!"
 
 #. Key:	69F9118A434154DE440203AEBAD52F22
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_AboutKrakens.Default__MirruDefault01_AboutKrakens_C.SessionData.Lines(6).Lines
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_AboutKrakens.Default__MirruDefault01_AboutKrakens_C.SessionData.Lines(6).Lines
 msgctxt ",69F9118A434154DE440203AEBAD52F22"
 msgid "If that means keeping our mates wrapped for hours while we milk every last drop of seed from them, so be it."
-msgstr "Si eso significa mantener a nuestros compañeros envueltos durante horas mientras ordeñamos hasta la última gota de semilla de ellos, que así sea."
+msgstr "Si eso significa mantener a nuestros compañeros envueltos durante horas mientras les ordeñamos hasta la última gota de semilla, que así sea."
 
 #. Key:	6A26D99744982C7F05898A800D9AB807
 #. SourceLocation:	/Game/Ranch/Upgrades/HarpyAviary.Default__HarpyAviary_C.Upgrade.TypeDisplay
@@ -5625,28 +5655,28 @@ msgstr "¿Barra de mantequilla? ¿En serio?"
 #: /Game/Dialogue/Cassie/SexScenes/CassieSplintersT.Default__CassieSplintersT_C.SessionData.Lines(0).Lines
 msgctxt ",6AAA8DC54239107FC4E476B1F67AD574"
 msgid "Ohhh... big human dick feels amazing!"
-msgstr "Ohhh… gran polla humana se siente increíble!"
+msgstr "¡Ohhh... el gran pene humano se siente increíble!"
 
 #. Key:	6AADAD5D41D98C207B7FEB993604434A
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.EM_Keystone_QueenBee.FailMessage
 #: /Game/World/Overworld.Overworld:PersistentLevel.EM_Keystone_QueenBee.FailMessage
 msgctxt ",6AADAD5D41D98C207B7FEB993604434A"
 msgid "It will not move."
-msgstr ""
+msgstr "No se moverá."
 
 #. Key:	6AD76D124EA5FF55B998D39AD1070F08
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeSuckJugs_Start.Default__AmberMaeSuckJugs_Start_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeSuckJugs_Start.Default__AmberMaeSuckJugs_Start_C.SessionData.Lines(0).Lines
 msgctxt ",6AD76D124EA5FF55B998D39AD1070F08"
 msgid "Oh my! Ohhhh!"
-msgstr "¡Oh mi! ¡Ohhhh!"
+msgstr "¡Oh cielos! ¡Ohhhh!"
 
 #. Key:	6AFADD1A416223C71B86159050C16A67
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchShySexT_RL.Default__MonarchShySexT_RL_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/Monarch/Default/MonarchShySexT_RL.Default__MonarchShySexT_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",6AFADD1A416223C71B86159050C16A67"
 msgid "My body is ready."
-msgstr ""
+msgstr "Mi cuerpo está listo."
 
 #. Key:	6B00C5C74D9E87523316E2827BCF76F6
 #. SourceLocation:	/Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToFuta(1).LinesToFuta
@@ -5660,70 +5690,71 @@ msgstr "*Chupa* *Chupa*"
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_Princess.Default__MirruDefault01_Princess_C.SessionData.Lines(4).Lines
 msgctxt ",6B7696AA4F7FC59BCCFABC996AED1F8B"
 msgid "I envy my lesser siblings in a way, they are not required to embark on a 30 year pilgrimage like me."
-msgstr "Envidio de alguna manera a mis hermanos menores, no están obligados a embarcarse en una peregrinación de 30 años como yo."
+msgstr "En cierto modo, envidio a mis hermanos menores, no están obligados a embarcarse en una peregrinación de 30 años como yo."
 
 #. Key:	6BC585A94AB919791876E989ABC6AFC2
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon.Default__AmberMaeLockedDungeon_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon.Default__AmberMaeLockedDungeon_C.SessionData.Lines(2).Lines
 msgctxt ",6BC585A94AB919791876E989ABC6AFC2"
 msgid "Didn't get very far though, me jugs 'an buxom hips said no!"
-msgstr ""
+msgstr "Sin embargo, no llegué muy lejoh, ¡mis cántaroh de leshe y caderah ezuberanteh dijeron que no!"
 
 #. Key:	6BD3487945B18914AE271E871E682D15
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiTaskFulfilled.Default__FesssiTaskFulfilled_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiTaskFulfilled.Default__FesssiTaskFulfilled_C.SessionData.Lines(3).Lines
 msgctxt ",6BD3487945B18914AE271E871E682D15"
 msgid "Now... come closer, for I wish to mate with you."
-msgstr ""
+msgstr "Ahora... acércate, porque deseo aparearme contigo."
 
 #. Key:	6BD4BB9B462B18C1771C5C8CE331DDAC
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchPrettyButterfly.Default__MonarchPrettyButterfly_C.SessionData.Lines(7).Lines
 #: /Game/Dialogue/Monarch/Default/MonarchPrettyButterfly.Default__MonarchPrettyButterfly_C.SessionData.Lines(7).Lines
 msgctxt ",6BD4BB9B462B18C1771C5C8CE331DDAC"
 msgid "I'm too shy... so I just collect nectar for our queen."
-msgstr ""
+msgstr "Soy demasiado tímida... así que solo recojo néctar para nuestra reina."
 
 #. Key:	6C9735694D5FA2594461AF9E28110F5C
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(26).LinesToFemale
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(26).LinesToFemale
 msgctxt ",6C9735694D5FA2594461AF9E28110F5C"
 msgid "Gently of course. To date there has never been an instance where a @MONSTER_RACE@ has intentionally harmed a human."
-msgstr "Gentilmente por supuesto. Hasta la fecha, nunca ha habido una instancia en la que un @MONSTER_RACE@ haya dañado intencionalmente a un humano."
+msgstr "Gentilmente por supuesto. Hasta la fecha, nunca ha habido un caso en el que un @MONSTER_RACE@ haya lastimado intencionalmente a un humano."
 
 #. Key:	6CE8D4CC4972C62CFCB7FE9919BBA235
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleTittyPony.Default__KybeleTittyPony_C.SessionData.LinesToFuta(2).LinesToFuta
 #: /Game/Dialogue/Kybele/Default/KybeleTittyPony.Default__KybeleTittyPony_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",6CE8D4CC4972C62CFCB7FE9919BBA235"
 msgid "That should teach you to cross this titty po--I mean mighty centaur warmaiden, again!"
-msgstr ""
+msgstr "Eso debería enseñarte a cruzar esta poni tet-: ¡otra vez, me refiero a la poderosa doncella-guerrera centauro!"
 
 #. Key:	6CEBE4ED41B379988D725290EDC4FE95
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaHadSex01.Default__CamillaHadSex01_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/Camilla/Default/CamillaHadSex01.Default__CamillaHadSex01_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",6CEBE4ED41B379988D725290EDC4FE95"
 msgid "This little body experienced a lot of pleasure..."
-msgstr ""
+msgstr "Este cuerpecito experimentó mucho placer..."
 
 #. Key:	6D0C594D4C4F236FB6A4E28627184737
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R02.Default__CamillaDefault01_R02_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R02.Default__CamillaDefault01_R02_C.SessionData.Lines(1).Lines
 msgctxt ",6D0C594D4C4F236FB6A4E28627184737"
 msgid "Foxen and Vulwargs like the shade and trees of the Lustwood."
-msgstr "A Zorros y Vulwargs les gusta la sombra y los árboles del Bosque de la Lujuria."
+msgstr "A los foxen y los vulwarg les gusta la sombra y los árboles del Bosque de la Lujuria."
 
 #. Key:	6D1219CB453AA152B8E0548996E8123B
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiCave.Default__FesssiCave_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiCave.Default__FesssiCave_C.SessionData.Lines(3).Lines
 msgctxt ",6D1219CB453AA152B8E0548996E8123B"
 msgid "Apparently, if you go deep enough, you will find hell itself. Filled to the brim with lusty demons and dark magic."
-msgstr ""
+msgstr "Aparentemente, si profundizas lo suficiente, encontrarás el infierno mismo. Lleno hasta el borde de lujuriosos demonios y magia oscura."
 
 #. Key:	6D1431474F1C713E9D755F93772C653C
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(15 - Value).TraitIcons.HelpText
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(15 - Value).TraitIcons.HelpText
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(15 -
+#: Value).TraitIcons.HelpText
 msgctxt ",6D1431474F1C713E9D755F93772C653C"
 msgid "Juicy: Produces 50% extra body fluid when harvested."
-msgstr "Jugoso: Produce un 50% de líquido corporal adicional cuando se cosecha."
+msgstr "Jugoso: produce un 50% de fluido corporal adicional cuando se cosecha."
 
 #. Key:	6D1721A840C5FB9C772FA0B710043ADC
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_Forgot_RL.Default__ParvatiDefault01_Forgot_RL_C.ResponseData(6).ResponseData.BreederPrompt
@@ -5737,28 +5768,28 @@ msgstr "¡Cascada!"
 #: /Game/Dialogue/Autumn/Default/DryadHaveKeystone.Default__DryadHaveKeystone_C.SessionData.Lines(4).Lines
 msgctxt ",6D1F8DD440DBF92518A5E6833EB831FA"
 msgid "I've heard legends of the daughters of the queen bee in Hivelands."
-msgstr ""
+msgstr "He escuchado leyendas de las hijas de la Abeja Reina en las Tierras-Colmena."
 
 #. Key:	6D4E481742B09428791263B3A820281E
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeDefault01_SuckJugs.Default__AmberMaeDefault01_SuckJugs_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeDefault01_SuckJugs.Default__AmberMaeDefault01_SuckJugs_C.SessionData.Lines(4).Lines
 msgctxt ",6D4E481742B09428791263B3A820281E"
 msgid "Oh my... I'm so embarrassed, 'mai urges got the best o' me!"
-msgstr "Oh mi... ¡Ehtoy tan avergosaa, mih impursoh consiguieron lo mejoh de mí!"
+msgstr "Oh cieloh... ehtoy tan avergonsaa, ¡mih impursoh se apoderarón de mí!"
 
 #. Key:	6D4FCB5345397A3D9726C1AAA8B438D6
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernBeeFlowers2.Default__FernBeeFlowers2_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Fern/DefaultP2/FernBeeFlowers2.Default__FernBeeFlowers2_C.SessionData.Lines(0).Lines
 msgctxt ",6D4FCB5345397A3D9726C1AAA8B438D6"
 msgid "I am not powerful enough to control the plants in other lands."
-msgstr ""
+msgstr "No soy lo suficientemente poderosa para controlar las plantas en otras tierras."
 
 #. Key:	6D77CB43488C767A611292B40E89506D
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeGreeting01.Default__MegaSlimeGreeting01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeGreeting01.Default__MegaSlimeGreeting01_C.SessionData.Lines(1).Lines
 msgctxt ",6D77CB43488C767A611292B40E89506D"
 msgid "No one ever comes down here, let alone a human."
-msgstr ""
+msgstr "Nadie viene aquí, y mucho menos un humano."
 
 #. Key:	6D839EC343F5CB6DF39F048E74C3A3F6
 #. SourceLocation:	/Game/Breeding/Positions/LapDance.Default__LapDance_C.SessionData.PositionName
@@ -5772,7 +5803,7 @@ msgstr "Baile Erótico"
 #: /Game/Dialogue/Kybele/Default/KybeleTittyPony_T.Default__KybeleTittyPony_T_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",6DBA71B949F9F1ABB3D362AB777D197E"
 msgid "It's been sometime since I have released, so this is going to get messy."
-msgstr ""
+msgstr "Ha pasado algún tiempo desde que he descargado, así que esto se va a complicar."
 
 #. Key:	6DCC52994B8322D169A47299585B1FFA
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_SpiritForm.Default__LeylannaDefault01_SpiritForm_C.SessionData.Lines(3).Lines
@@ -5786,14 +5817,14 @@ msgstr "Debido a que esto sucede desde el Vacío, existen algunas limitaciones. 
 #: /Game/Dialogue/Kybele/Default/KybeleAnyMeans.Default__KybeleAnyMeans_C.SessionData.LinesToFuta(4).LinesToFuta
 msgctxt ",6DD6D2E84735C26D7103ADA9DEA53E81"
 msgid "If you do not leave this place, you will mount me with that modest sized cock until I'm satisfied!"
-msgstr ""
+msgstr "Si no abandonas este lugar, ¡me montarás con esa polla de tamaño modesto hasta quedar satisfecha!"
 
 #. Key:	6DFA50D843F564F540771EAD2DCC848B
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleHaveKeystone.Default__KybeleHaveKeystone_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Kybele/Default/KybeleHaveKeystone.Default__KybeleHaveKeystone_C.SessionData.Lines(3).Lines
 msgctxt ",6DFA50D843F564F540771EAD2DCC848B"
 msgid "Just don't tell her if you see her! If you do, you will feel my wrath again!"
-msgstr ""
+msgstr "¡Simplemente no le digas si la ves! Si lo haces, ¡sentirás mi ira de nuevo!"
 
 #. Key:	6DFC948B4585FAC19AED8692ED4B45F2
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_RechargeSpiritForm_RL_F.Default__LeylannaDefault01_RechargeSpiritForm_RL_F_C.ResponseData(1).ResponseData.BreederPrompt
@@ -5821,7 +5852,7 @@ msgstr "No tienes idea de cuánto me estoy conteniendo en este momento..."
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(23).LinesToMale
 msgctxt ",6E5A40D849715A40BDC9ECBCE9E3F1C1"
 msgid "Blessed @MONSTER_RACE@ like me have human-level intelligence. Sometimes even greater!"
-msgstr "Bendecidos @MONSTER_RACE@ como yo tienen una inteligencia a nivel humano. ¡A veces incluso mayor!"
+msgstr "@MONSTER_RACE@ bendecidos como yo tienen una inteligencia a nivel humano. ¡A veces incluso mayor!"
 
 #. Key:	6E673F5644EA7EA6CE684F9AD751AAA9
 #. SourceLocation:	/Game/Dialogue/Mirru/SexScenes/MirruSnatchT.Default__MirruSnatchT_C.SessionData.Lines(5).Lines
@@ -5835,7 +5866,7 @@ msgstr "Oh... ah... se siente tan bien. Me voy a correr."
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R05.Default__FaleneDefault01_R05_C.SessionData.Lines(5).Lines
 msgctxt ",6E7585B44800A93D4B9E9AB43E129A72"
 msgid "Hehehehe... you practically can already--I barely wear anything!"
-msgstr "Jejejeje... prácticamente ya puedes - ¡Apenas uso algo!"
+msgstr "Jejejeje... prácticamente ya puedes: ¡apenas uso algo!"
 
 #. Key:	6E9F24A04A1B818667C201B33366EB1B
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFuta(24).LinesToFuta
@@ -5849,35 +5880,35 @@ msgstr "Sin duda te encontrarás con bendecidos en este mundo que simplemente qu
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R08.Default__CamillaDefault01_R08_C.SessionData.Lines(0).Lines
 msgctxt ",6EA72B844C05F4F77473C38011839AB4"
 msgid "Oh wait... I uh..."
-msgstr "Oh espera... yo eh..."
+msgstr "Oh, espera... yo eh..."
 
 #. Key:	6EB1D4054ABCE1E3818FC39FB5A8415A
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMHadSex01.Default__DMHadSex01_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/DragonMatriarch/Default/DMHadSex01.Default__DMHadSex01_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",6EB1D4054ABCE1E3818FC39FB5A8415A"
 msgid "Somehow you took a cock larger than you and still made it feel amazing."
-msgstr ""
+msgstr "De alguna manera tomaste una polla más grande que tú y aún así haces que se sienta increíble."
 
 #. Key:	6ED67799423B871587B12E8DEC3D1BE1
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(0).Lines
 msgctxt ",6ED67799423B871587B12E8DEC3D1BE1"
 msgid "Oh! A cute li'l human! Nary in all me puff did I expect te see such a thing!"
-msgstr "¡Oh! ¡Una linda humana! ¡Ni en mi bocanaa ehperaba veh argo así!"
+msgstr "¡Oh! ¡Un lindo peke humano! ¡Ni en toda mi bocanaa ehperaba veh argo así!"
 
 #. Key:	6F1214E04CFF55C4F15CF6B9593AE091
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToFuta(3).LinesToFuta
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToFuta(3).LinesToFuta
 msgctxt ",6F1214E04CFF55C4F15CF6B9593AE091"
 msgid "Ahhh... yes. My desires are surging, won't you indulge in my body? I will try to be gentle."
-msgstr "Ahhh... si. Mis deseos están surgiendo, ¿no te complacerás en mi cuerpo? Intentaré ser gentil."
+msgstr "Ahhh... si. Mis deseos están aumentando, ¿no te complacerás con mi cuerpo? Trataré de ser gentil."
 
 #. Key:	6F1DCF64442949FA9CD221911F8540AD
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(2).LinesToMale
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(2).LinesToMale
 msgctxt ",6F1DCF64442949FA9CD221911F8540AD"
 msgid "You have just become @WORLD_NAME@'s newest resident!"
-msgstr "¡Acabas de convertirte en el nuevo residente de @WORLD_NAME@!"
+msgstr "¡Te acabas de convertir en el residente más nuevo de @WORLD_NAME@!"
 
 #. Key:	6F314EC947FA4FB92B59FFB3E0E4AC10
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_SexPositions.Default__FaleneDefault01_SexPositions_C.SessionData.Lines(3).Lines
@@ -5891,84 +5922,85 @@ msgstr "Habla con esa súper linda dama serpiente con el sombrero gracioso."
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_RaiseTraitLvl.Default__EmissaryDefault01_RaiseTraitLvl_C.SessionData.Lines(1).Lines
 msgctxt ",6F4E36894BE6D32AB2BF92B2FB1F5697"
 msgid "But first, a donation to the Goddess most high. Praise be Her name."
-msgstr "Pero primero, una donación a la más alta Diosa. Alabado sea Su nombre."
+msgstr "Pero primero, una donación altísima Diosa. Alabado sea Su nombre."
 
 #. Key:	6F5E6DAB49A4FDFA3CF6ADB4F98239E5
 #. SourceLocation:	/Game/Dialogue/AmberMae/SexScenes/AmberMilkyF.Default__AmberMilkyF_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/AmberMae/SexScenes/AmberMilkyF.Default__AmberMilkyF_C.SessionData.Lines(0).Lines
 msgctxt ",6F5E6DAB49A4FDFA3CF6ADB4F98239E5"
 msgid "Ahhhh! Suck 'em hard, 'mai milk is all for you!"
-msgstr "¡Ahhhh! ¡Chúpalah fuerte, mi leshe es toa pa ti!"
+msgstr "¡Ahhhh! Chúpalah fuerte, ¡mi leshe es toa pa ti!"
 
 #. Key:	6F8F41154136EFB2D479DCB4A853DC48
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcBrashDumb.Default__OrcBrashDumb_C.SessionData.Lines(9).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcBrashDumb.Default__OrcBrashDumb_C.SessionData.Lines(9).Lines
 msgctxt ",6F8F41154136EFB2D479DCB4A853DC48"
 msgid "Hahaha! *snarl*"
-msgstr ""
+msgstr "¡Jajaja! *gruñido*"
 
 #. Key:	6FA3A5FA4FAB4D57D0E13D8815C6D5E7
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeGreeting01.Default__MegaSlimeGreeting01_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeGreeting01.Default__MegaSlimeGreeting01_C.SessionData.Lines(4).Lines
 msgctxt ",6FA3A5FA4FAB4D57D0E13D8815C6D5E7"
 msgid "My beloved orb!! It's so beautiful, I will cherish it always."
-msgstr ""
+msgstr "¡Mi amado orbe! Es tan hermoso, lo apreciaré siempre."
 
 #. Key:	6FB79F1B4245887D7C56A197959DA2A1
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03.Default__FernDefault03_C.SessionData.LinesToFuta(1).LinesToFuta
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03.Default__FernDefault03_C.SessionData.LinesToFuta(1).LinesToFuta
 msgctxt ",6FB79F1B4245887D7C56A197959DA2A1"
 msgid "Look at my beautiful flower, it bloomed! Oh my did it feel weird..."
-msgstr "Mira mi hermosa flor, ¡floreció! Oh, se sintió raro..."
+msgstr "Mira mi hermosa flor, ¡floreció! Oh cielos, se sintió raro..."
 
 #. Key:	6FBC636D494A40330AAEBDBCD6886299
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMGrasslandsTrees.Default__DMGrasslandsTrees_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMGrasslandsTrees.Default__DMGrasslandsTrees_C.SessionData.Lines(0).Lines
 msgctxt ",6FBC636D494A40330AAEBDBCD6886299"
 msgid "What do you know human!"
-msgstr ""
+msgstr "¡Qué sabes humano!"
 
 #. Key:	6FD7E94044B57DA992A79BA4422CF69C
 #. SourceLocation:	/Game/Dialogue/Yasmine/Default/YasmineDefault01_RL.Default__YasmineDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/Yasmine/Default/YasmineDefault01_RL.Default__YasmineDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",6FD7E94044B57DA992A79BA4422CF69C"
 msgid "You make pearls?"
-msgstr ""
+msgstr "¿Haces perlas?"
 
 #. Key:	6FED048C4BF38E565F2ADC90DC3F4390
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(16 - Value).TraitIcons.DisplayName
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(16 - Value).TraitIcons.DisplayName
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(16 -
+#: Value).TraitIcons.DisplayName
 msgctxt ",6FED048C4BF38E565F2ADC90DC3F4390"
 msgid "Kindhearted"
-msgstr "Amable"
+msgstr "Bondadoso"
 
 #. Key:	6FF789054D56C91D6CC53C8148D8EFCD
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDefault01_RL.Default__CassieDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/Cassie/Default/CassieDefault01_RL.Default__CassieDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",6FF789054D56C91D6CC53C8148D8EFCD"
 msgid "What's with the dungeon by the temple?"
-msgstr ""
+msgstr "¿Qué pasa con la mazmorra junto al templo?"
 
 #. Key:	703D9D7D4CD9D794DDE1929CCE0E5D1C
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMDefault_RL5_F.Default__DMDefault_RL5_F_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/DragonMatriarch/Default/DMDefault_RL5_F.Default__DMDefault_RL5_F_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",703D9D7D4CD9D794DDE1929CCE0E5D1C"
 msgid "Bring it on dragon."
-msgstr ""
+msgstr "Tráela en dragón."
 
 #. Key:	703E8E554AE59D97908541A592216732
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcFixOwnGate.Default__OrcFixOwnGate_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/OrcChief/Default/OrcFixOwnGate.Default__OrcFixOwnGate_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",703E8E554AE59D97908541A592216732"
 msgid "Grrrrrrrr!!!"
-msgstr ""
+msgstr "¡¡¡Grrrrrrrr!!!"
 
 #. Key:	703FABE24E96D3592AA524833F23CA4D
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDefault01_RL.Default__CassieDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
 #: /Game/Dialogue/Cassie/Default/CassieDefault01_RL.Default__CassieDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
 msgctxt ",703FABE24E96D3592AA524833F23CA4D"
 msgid "Remind me about that dungeon under the temple."
-msgstr ""
+msgstr "Recuérdame algo de esa mazmorra debajo del templo."
 
 #. Key:	705BCA1D4ACA54FF178C9DA094C9DBA1
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_R01.Default__FernDefault02_R01_C.SessionData.Lines(1).Lines
@@ -5982,28 +6014,28 @@ msgstr "¡Crecí en tu suelo, y pronto será mi hogar permanente!"
 #: /Game/Dialogue/Leylanna/SexScenes/LeylannaLeyCov.Default__LeylannaLeyCov_C.SessionData.LinesToFuta(1).LinesToFuta
 msgctxt ",7063E832426D1615683CF5A75DC53A4E"
 msgid "Yes, please me with your cock and the spirits shall grant you favor."
-msgstr "Sí, compláceme con tu polla y los espíritus te concederán favor."
+msgstr "Sí, compláceme con tu polla y los espíritus te concederán su favor."
 
 #. Key:	708DC59B48E375114559229ED41F492F
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToFemale(4).LinesToFemale
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToFemale(4).LinesToFemale
 msgctxt ",708DC59B48E375114559229ED41F492F"
 msgid "We convert semen that would go to waste into new life, you can even eat my slime!"
-msgstr ""
+msgstr "Convertimos el semen que se desperdiciaría en una nueva vida, ¡incluso puedes comer mi limo!"
 
 #. Key:	709579B446D8D4D2C2F3EE98857ED27A
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMDefault_RL5_T.Default__DMDefault_RL5_T_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/DragonMatriarch/Default/DMDefault_RL5_T.Default__DMDefault_RL5_T_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",709579B446D8D4D2C2F3EE98857ED27A"
 msgid "Bring it on dragon."
-msgstr ""
+msgstr "Tráela en dragón."
 
 #. Key:	709C1A4748A9B0773A823DB8EB5B31E0
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeHadSex01.Default__BeeHadSex01_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/QueenBee/Default/BeeHadSex01.Default__BeeHadSex01_C.SessionData.Lines(2).Lines
 msgctxt ",709C1A4748A9B0773A823DB8EB5B31E0"
 msgid "What brings you before me?"
-msgstr ""
+msgstr "¿Qué te trae ante mí?"
 
 #. Key:	70A96E9D4322ED35C13DF78AF12A5931
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_BlueSmoke.Default__LeylannaDefault01_BlueSmoke_C.SessionData.Lines(0).Lines
@@ -6017,14 +6049,14 @@ msgstr "Me permite comunicarme con los espíritus."
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFuta(16).LinesToFuta
 msgctxt ",70B4299E404BAC657357D7AD12E3DF68"
 msgid "I want that delicious futa dick inside me... ohhh, right now!"
-msgstr "Quiero esa deliciosa polla futa dentro de mí... ohhh, ¡ahora mismo!"
+msgstr "Quiero ese delicioso pene futa dentro de mí... ¡ohhh, ahora mismo!"
 
 #. Key:	70CF21944D42682E43C6EBB4A8757DB0
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_FutaBalls.Default__FaleneDefault01_FutaBalls_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_FutaBalls.Default__FaleneDefault01_FutaBalls_C.SessionData.Lines(3).Lines
 msgctxt ",70CF21944D42682E43C6EBB4A8757DB0"
 msgid "Like we say here in @WORLD_NAME@: SUGAR WALLS BEFORE BALLS!!"
-msgstr "Como decimos aquí en @WORLD_NAME@: ¡AZÚCAR EN OLAS ANTES QUE BOLAS!"
+msgstr "Como decimos aquí en @WORLD_NAME@: ¡¡AZÚCAR EN GOTAS ANTES QUE PELOTAS!!"
 
 #. Key:	70D390BA48724A55513FB282118180B9
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R04.Default__CamillaDefault01_R04_C.SessionData.Lines(1).Lines
@@ -6038,63 +6070,63 @@ msgstr "Falene me hace ponerme de pie sobre él. Ella dice que se supone que mej
 #: /Game/Dialogue/Widow/Default/WidowSpiders.Default__WidowSpiders_C.SessionData.Lines(3).Lines
 msgctxt ",711B52C8486478B27C9236A70F6DABAC"
 msgid "You have probably noticed that by now."
-msgstr ""
+msgstr "Probablemente ya lo hayas notado."
 
 #. Key:	715058EB4BEB5B309FE658A485A718AA
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R04.Default__FaleneDefault01_R04_C.SessionData.Lines(9).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R04.Default__FaleneDefault01_R04_C.SessionData.Lines(9).Lines
 msgctxt ",715058EB4BEB5B309FE658A485A718AA"
 msgid "It's a miracle we have been able to establish a functional civilization... and even a temple full of weird cultists."
-msgstr "Es un milagro que hayamos podido establecer una civilización funcional... e incluso un templo lleno de cultistas extraños."
+msgstr "Es un milagro que hayamos podido establecer una civilización funcional... e incluso un templo lleno de extraños cultistas."
 
 #. Key:	7174EE904D1E0F90C113AD9B67763E6B
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDefault01_Meow_RL_T.Default__CassieDefault01_Meow_RL_T_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/Cassie/Default/CassieDefault01_Meow_RL_T.Default__CassieDefault01_Meow_RL_T_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",7174EE904D1E0F90C113AD9B67763E6B"
 msgid "Brace yourself little kitty!"
-msgstr "¡Prepárate pequeña gatita!"
+msgstr "¡Prepárate, pequeño gatito!"
 
 #. Key:	717D6D564578FC099110B6899F65067E
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFuta(7).LinesToFuta
 #: /Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFuta(7).LinesToFuta
 msgctxt ",717D6D564578FC099110B6899F65067E"
 msgid "That creepy golden seraphim, the one in the temple. She appeared only a few days ago, constantly asking to speak with \"the human\"."
-msgstr ""
+msgstr "Esa espeluznante serafín dorada, la del templo. Ella apareció hace solo unos días, constantemente pidiendo hablar con \"el humano\"."
 
 #. Key:	71914E004F66CB40BEDE07BF85D0FDC5
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcBrashDumb.Default__OrcBrashDumb_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcBrashDumb.Default__OrcBrashDumb_C.SessionData.Lines(0).Lines
 msgctxt ",71914E004F66CB40BEDE07BF85D0FDC5"
 msgid "Brash? Chieftain no understand fancy words!"
-msgstr ""
+msgstr "¿Temeraria? ¡La cacique no entiende palabras elegantes!"
 
 #. Key:	71AEDBFC4C75BF861690DB96D8D3E7D4
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R01.Default__FaleneDefault01_R01_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R01.Default__FaleneDefault01_R01_C.SessionData.Lines(2).Lines
 msgctxt ",71AEDBFC4C75BF861690DB96D8D3E7D4"
 msgid "@MONSTER_RACE@ genitalia functions mostly the same as human genitalia--albeit much more... robust."
-msgstr "Los genitales @MONSTER_RACE@ funcionan casi igual que los de los humanos, aunque mucho más... robustamente."
+msgstr "Los genitales @MONSTER_RACE@ funcionan casi igual que los de los humanos: aunque mucho más... robustamente."
 
 #. Key:	72107B4B47CB1F5DE578558788562BE0
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernBeeFlowers2.Default__FernBeeFlowers2_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Fern/DefaultP2/FernBeeFlowers2.Default__FernBeeFlowers2_C.SessionData.Lines(1).Lines
 msgctxt ",72107B4B47CB1F5DE578558788562BE0"
 msgid "Only a dryad would have such an ability."
-msgstr ""
+msgstr "Solo una dríada tendría tal habilidad."
 
 #. Key:	7216159047B371957AA4BBB677FF8B34
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03_R04.Default__FernDefault03_R04_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03_R04.Default__FernDefault03_R04_C.SessionData.Lines(1).Lines
 msgctxt ",7216159047B371957AA4BBB677FF8B34"
 msgid "You will experience ecstasy as you cum inside my flower over and over."
-msgstr "Experimentarás éxtasis mientras te corres dentro de mi flor una y otra vez."
+msgstr "Experimentarás el éxtasis mientras te corres dentro de mi flor una y otra vez."
 
 #. Key:	721BAB5440338ECB3CE2EB9A27D969B0
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiHadSex01.Default__ParvatiHadSex01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Parvati/Default/ParvatiHadSex01.Default__ParvatiHadSex01_C.SessionData.Lines(0).Lines
 msgctxt ",721BAB5440338ECB3CE2EB9A27D969B0"
 msgid "Returning to me with that familiar glint in your eye."
-msgstr ""
+msgstr "Volviendo a mí con ese brillo familiar en tus ojos."
 
 #. Key:	722820CF485DAAEF312AD7B7C497D3AD
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03_R05.Default__FernDefault03_R05_C.SessionData.Lines(0).Lines
@@ -6108,28 +6140,28 @@ msgstr "¡¿No es hermosa?!"
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_Forgot.Default__ParvatiDefault01_Forgot_C.SessionData.Lines(6).Lines
 msgctxt ",72570AA14FB2D285DAAB6584C841B08C"
 msgid "Which position shall we review?"
-msgstr "¿A qué posición de revisar te intrigo?"
+msgstr "¿Qué posición revisaremos?"
 
 #. Key:	725969164426D429929F949920B9A0BD
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadGreeting01.Default__DryadGreeting01_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Autumn/Default/DryadGreeting01.Default__DryadGreeting01_C.SessionData.Lines(2).Lines
 msgctxt ",725969164426D429929F949920B9A0BD"
 msgid "Delicious bosom cherries for all of my lovely dairies."
-msgstr ""
+msgstr "Deliciosas cerezas de seno para todas mis encantadoras lecheras."
 
 #. Key:	72676A264244C7A242C2688B7B60F6A5
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01.Default__MirruDefault01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Mirru/Default/MirruDefault01.Default__MirruDefault01_C.SessionData.Lines(1).Lines
 msgctxt ",72676A264244C7A242C2688B7B60F6A5"
 msgid "Have you come to please this Kraken princess?"
-msgstr ""
+msgstr "¿Has venido a complacer a esta princesa kraken?"
 
 #. Key:	729B81554E3D9EF979C07FB7C419E3C5
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R07.Default__FaleneDefault01_R07_C.SessionData.LinesToFuta(0).LinesToFuta
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R07.Default__FaleneDefault01_R07_C.SessionData.LinesToFuta(0).LinesToFuta
 msgctxt ",729B81554E3D9EF979C07FB7C419E3C5"
 msgid "Aww! Someone wants their dick sucked!"
-msgstr "¡Aww! ¡Alguien quiere que le chupen la polla!"
+msgstr "¡Amm! ¡Alguien quiere que le chupen el pene!"
 
 #. Key:	72B372C34FD32D2D5F30B7854FF7D95B
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryBlessedInquiry02_RL.Default__EmissaryBlessedInquiry02_RL_C.ResponseData(0).ResponseData.BreederPrompt
@@ -6143,49 +6175,50 @@ msgstr "En ese caso, ¡voy a lamer cada rincón de tu vagina!"
 #: /Game/Dialogue/Fern/Default/FernHadSex01.Default__FernHadSex01_C.SessionData.Lines(1).Lines
 msgctxt ",72D1FC5F42F98687EDAE5AB4FD366E18"
 msgid "More! More!"
-msgstr ""
+msgstr "¡Más! ¡Más!"
 
 #. Key:	7329381C44D0F4921C47709DC7891BC4
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraDefault01_RL.Default__PetraDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
 #: /Game/Dialogue/Petra/Default/PetraDefault01_RL.Default__PetraDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
 msgctxt ",7329381C44D0F4921C47709DC7891BC4"
 msgid "You can practice with me!"
-msgstr ""
+msgstr "¡Puedes practicar conmigo!"
 
 #. Key:	737ACFDE44717F24FCFA89B1A6780AA2
 #. SourceLocation:	/Game/Dialogue/Neela/SexScenes/NeelaSnakeCuddleT.Default__NeelaSnakeCuddleT_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Neela/SexScenes/NeelaSnakeCuddleT.Default__NeelaSnakeCuddleT_C.SessionData.Lines(4).Lines
 msgctxt ",737ACFDE44717F24FCFA89B1A6780AA2"
 msgid "Ahhh yes! Fill it with your human seed... ohhh."
-msgstr "¡Ahhh si! Llénalo con tu semilla humana... ohhh."
+msgstr "¡Ahhh, sí! Llénalo con tu semilla humana... ohhh."
 
 #. Key:	73986546438B9C190B8B769537B05047
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TravelShrines(12 - Value).TravelShrines.ShrineName
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TravelShrines(12 - Value).TravelShrines.ShrineName
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TravelShrines(12 -
+#: Value).TravelShrines.ShrineName
 msgctxt ",73986546438B9C190B8B769537B05047"
 msgid "Climax Peak"
-msgstr "Pico de Climax"
+msgstr "Cumbre del Clímax"
 
 #. Key:	73B062844EF9F666A3FC88A79A97D47A
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(0).Lines
 msgctxt ",73B062844EF9F666A3FC88A79A97D47A"
 msgid "The Goddess in Her infinite wisdom became filled with desire after eons of loneliness."
-msgstr ""
+msgstr "La Diosa en Su infinita sabiduría se llenó de deseo después de eones de soledad."
 
 #. Key:	73B3AE3C43F892A09044CD8CAABBE3B3
 #. SourceLocation:	/Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToFuta(2).LinesToFuta
 #: /Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",73B3AE3C43F892A09044CD8CAABBE3B3"
 msgid "Feel my velvet tongue stroke the shaft as your dick touches the back of my mouth. Ahhh..."
-msgstr "Siente mi lengua aterciopelada acariciando el tallo mientras tu polla toca el fondo de mi boca. Ahhh..."
+msgstr "Siente mi lengua aterciopelada acariciando el tallo mientras tu pene toca el fondo de mi boca. Ahhh..."
 
 #. Key:	73B59191487A1B6CCB6E58B4159D8060
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernGreeting02.Default__FernGreeting02_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/Fern/DefaultP2/FernGreeting02.Default__FernGreeting02_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",73B59191487A1B6CCB6E58B4159D8060"
 msgid "Oh Master, you have fed me well."
-msgstr "Oh Maestra, me has alimentado bien."
+msgstr "Oh, Master, me has alimentado bien."
 
 #. Key:	73C9D0AC49FFC3AEB6CFA59DB5E4FB92
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_RL.Default__LeylannaDefault01_RL_C.ResponseData(5).ResponseData.BreederPrompt
@@ -6199,14 +6232,14 @@ msgstr "Ese humo azul huele... bien..."
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R02.Default__CamillaDefault01_R02_C.SessionData.Lines(2).Lines
 msgctxt ",73F68F1D4C449AE1E1ECBCB61358B27E"
 msgid "Harpies prefer the hot sands of the Lewd Desert."
-msgstr ""
+msgstr "Las arpías prefieren las arenas calientes del Desierto Lascivo."
 
 #. Key:	74017161472DC2AF18D66788ABE8AF78
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeDefault01.Default__BeeDefault01_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/QueenBee/Default/BeeDefault01.Default__BeeDefault01_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",74017161472DC2AF18D66788ABE8AF78"
 msgid "This corner is n-n-nice and safe!"
-msgstr ""
+msgstr "¡Este rincón es a-a-agradable y seguro!"
 
 #. Key:	740E4D7D44C42EC222B32AAF3DB022F4
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R01.Default__FaleneDefault01_R01_C.SessionData.Lines(11).Lines
@@ -6220,14 +6253,14 @@ msgstr "Es probable que apenas hayamos arañado la superficie de lo que es capaz
 #: /Game/Dialogue/Mirru/SexScenes/MirruKrakVag.Default__MirruKrakVag_C.SessionData.Lines(5).Lines
 msgctxt ",7413D71A4AAA4CA135368D8D6BD67DC1"
 msgid "I am going to cum... ahhh... it will be messy."
-msgstr "Me voy a correr... ahhh... será un lío."
+msgstr "Me voy a correr... ahhh... será un desastre."
 
 #. Key:	744AC6EA4EF6E8F4298079829B209661
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimePlay1.Default__MegaSlimePlay1_C.SessionData.LinesToFuta(0).LinesToFuta
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePlay1.Default__MegaSlimePlay1_C.SessionData.LinesToFuta(0).LinesToFuta
 msgctxt ",744AC6EA4EF6E8F4298079829B209661"
 msgid "You are so kind! No one has ever been so nice to me!"
-msgstr ""
+msgstr "¡Eres muy amable! ¡Nadie ha sido tan amable conmigo!"
 
 #. Key:	744F4E844CF281ADE05939B86FCE678E
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy_RL_T.Default__MirruDefault01_BodySexToy_RL_T_C.ResponseData(2).ResponseData.BreederPrompt
@@ -6241,21 +6274,21 @@ msgstr "¡¿Tienes múltiples corazones?!"
 #: /Game/Dialogue/QueenBee/Default/BeeDefault03_RL.Default__BeeDefault03_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",7468ACB44E64BE348C44FFAF36EB756D"
 msgid "I will figure out how to make the flowers grow."
-msgstr ""
+msgstr "Descubriré cómo hacer crecer las flores."
 
 #. Key:	748A7C25489A4B1CEC2B5D91B815FE8D
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimePearl.Default__MegaSlimePearl_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePearl.Default__MegaSlimePearl_C.SessionData.Lines(2).Lines
 msgctxt ",748A7C25489A4B1CEC2B5D91B815FE8D"
 msgid "I want to give you something in return."
-msgstr ""
+msgstr "Quiero darte algo a cambio."
 
 #. Key:	74AA1A6D401AC350EC36AA9E8E34202A
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeHadSex01.Default__MegaSlimeHadSex01_C.SessionData.LinesToFuta(1).LinesToFuta
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeHadSex01.Default__MegaSlimeHadSex01_C.SessionData.LinesToFuta(1).LinesToFuta
 msgctxt ",74AA1A6D401AC350EC36AA9E8E34202A"
 msgid "*Yawn*"
-msgstr ""
+msgstr "*Bosteza*"
 
 #. Key:	74E667E542A1B2DD54B1A4852E0B5BDE
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_RL_T.Default__FernDefault02_RL_T_C.ResponseData(1).ResponseData.BreederPrompt
@@ -6269,21 +6302,22 @@ msgstr "¡Has cambiado!"
 #: /Game/World/Events/EM_Keystone.Default__EM_Keystone_C.FailMessage
 msgctxt ",750AE2DA411665A89B7126BAB42FC805"
 msgid "It's stuck in slime."
-msgstr ""
+msgstr "Está atascada en el limo."
 
 #. Key:	7519309946A12CD84883FC98FC964091
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.CBGate_Peak.PlaceMessage
 #: /Game/World/Overworld.Overworld:PersistentLevel.CBGate_Peak.PlaceMessage
 msgctxt ",7519309946A12CD84883FC98FC964091"
 msgid "Climax Peak is now accessible."
-msgstr ""
+msgstr "La Cumbre del Clímax ahora es accesible."
 
 #. Key:	752BA5D9498A3D0A3B274BA6E3AFDDAE
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TravelShrines(11 - Value).TravelShrines.ShrineName
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TravelShrines(11 - Value).TravelShrines.ShrineName
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TravelShrines(11 -
+#: Value).TravelShrines.ShrineName
 msgctxt ",752BA5D9498A3D0A3B274BA6E3AFDDAE"
 msgid "Lewd Desert"
-msgstr ""
+msgstr "Desierto Lascivo"
 
 #. Key:	7531D7CC4B4C50FC4972DB878B5DEDCA
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_RL.Default__LeylannaDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
@@ -6297,21 +6331,21 @@ msgstr "¿Cómo obtengo la forma espiritual?"
 #: /Game/Dialogue/Parvati/Default/ParvatiGreeting01.Default__ParvatiGreeting01_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",7553E8614616B738728FC0BCAFAFD4D2"
 msgid "For knowledge of contorting the body can I bestow."
-msgstr "Tras el conocimiento del cuerpo contorsionar que puedo dar, eso puedo visualizar."
+msgstr "Para el conocimiento de contorsionar el cuerpo, puedo otorgar."
 
 #. Key:	75848F9C47DF47B57018B9BD12602720
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_GettingWeird.Default__LeylannaDefault01_GettingWeird_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Leylanna/Default/LeylannaDefault01_GettingWeird.Default__LeylannaDefault01_GettingWeird_C.SessionData.Lines(0).Lines
 msgctxt ",75848F9C47DF47B57018B9BD12602720"
 msgid "Return to me when you change your mind."
-msgstr "Vuelve a mí cuando cambies de opinión."
+msgstr "Vuelve a verme cuando cambies de opinión."
 
 #. Key:	758A181D4F348EDE373A33ADB8F3CB08
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_RL.Default__NeelaDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_RL.Default__NeelaDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",758A181D4F348EDE373A33ADB8F3CB08"
 msgid "Pussy portals... really?"
-msgstr "Coño portales... ¿En serio?"
+msgstr "Coño portales... ¿en serio?"
 
 #. Key:	7618202D4A38C8CACBFF19A33C3F1E02
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01.Default__RomyDefault01_C.SessionData.Lines(1).Lines
@@ -6325,7 +6359,7 @@ msgstr "¿Qué puede hacer esta humilde sirena por ti?"
 #: /Game/Dialogue/Falene/Default/FaleneDefault02.Default__FaleneDefault02_C.SessionData.Lines(1).Lines
 msgctxt ",76389D804BFE8383064F778E692DD2D9"
 msgid "The tiny little adorable nugget over there is my assistant Camilla."
-msgstr ""
+msgstr "La pequeña y adorable pepita de allí es mi asistente Camilla."
 
 #. Key:	76894E414F0E86A40CDEB69862E1A67C
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R01.Default__FaleneDefault01_R01_C.SessionData.Lines(1).Lines
@@ -6339,21 +6373,22 @@ msgstr "Para ser honesta, no entendemos completamente cómo funciona, pero he cr
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeVerySad3.Default__MegaSlimeVerySad3_C.SessionData.Lines(0).Lines
 msgctxt ",768DD9E6434228B7421D599AE774A24C"
 msgid "*ENDLESS SOBBING*"
-msgstr ""
+msgstr "*SOLLOZOS INTERMINABLES*"
 
 #. Key:	76C3B8B24ADB1D21C1F205A4E3B35D2A
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(31 - Value).TraitIcons.HelpText
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(31 - Value).TraitIcons.HelpText
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(31 -
+#: Value).TraitIcons.HelpText
 msgctxt ",76C3B8B24ADB1D21C1F205A4E3B35D2A"
 msgid "Atypical: Inherited an unusual size for its variant."
-msgstr "Atípica/o: Heredó un inusual tamaño para su variante."
+msgstr "Atípico: heredó un inusual tamaño para su variante."
 
 #. Key:	76DCFBB44EA9841F910FB9BE2CBD16B7
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault02.Default__FaleneDefault02_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault02.Default__FaleneDefault02_C.SessionData.Lines(3).Lines
 msgctxt ",76DCFBB44EA9841F910FB9BE2CBD16B7"
 msgid "Of course we make love! What else are assistants for?"
-msgstr ""
+msgstr "¡Por supuesto que hacemos el amor! ¿Para qué más son los asistentes?"
 
 #. Key:	76DD724248BA7178346EC59171F3BDF4
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyGreeting01.Default__RomyGreeting01_C.SessionData.LinesGrungy(5).LinesGrungy
@@ -6367,21 +6402,21 @@ msgstr "No, yo quiero. Confía en mí... Quiero sentir cada rincón de ese cuerp
 #: /Game/Dialogue/Leylanna/SexScenes/LeylannaLeyCov.Default__LeylannaLeyCov_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",7738600347E52873B1AB5D8B148524AC"
 msgid "Yes, please me with your tongue and the spirits shall grant you favor."
-msgstr "Sí, compláceme con tu lengua y los espíritus te concederán favor."
+msgstr "Sí, compláceme con tu lengua y los espíritus te concederán su favor."
 
 #. Key:	774EB8DD4A26316F99CA678113DB2B19
 #. SourceLocation:	/Game/UI/TaskDescriptions.TaskDescriptions.TextEntries(7).TextEntries
 #: /Game/UI/TaskDescriptions.TaskDescriptions.TextEntries(7).TextEntries
 msgctxt ",774EB8DD4A26316F99CA678113DB2B19"
 msgid "Wet! I am wet and horny, only you can help. This time I want something to suck on, so breed me an adorable Nephelym with all sorts of suckables. Yes, suckables, you heard it here first.  -Falene"
-msgstr ""
+msgstr "¡Mojada! Estoy mojada y cachonda, solo tu puedes ayudar. Esta vez quiero algo para chupar, así que críame un adorable Nephelym con todo tipo de chupables. Sí, chupables, lo escuchaste aquí primero. -Falene"
 
 #. Key:	77D22B994A5CAE9D14BE2DA1F7D43473
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R04.Default__FaleneDefault01_R04_C.SessionData.Lines(7).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R04.Default__FaleneDefault01_R04_C.SessionData.Lines(7).Lines
 msgctxt ",77D22B994A5CAE9D14BE2DA1F7D43473"
 msgid "Want to taste mine? Hehehe! You can if you want... I would love to feel you sucking on my nipples!"
-msgstr "¿Quieres probar el mío? Jejeje! Puedes hacerlo si quieres... ¡Me encantaría sentirte chupando mis pezones!"
+msgstr "¿Quieres probar el mío? ¡Jejeje! Puedes si quieres... ¡me encantaría sentirte chupando mis pezones!"
 
 #. Key:	77DDFABE4F632A4183C2FE891D6AC9EA
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(24).LinesToMale
@@ -6395,77 +6430,79 @@ msgstr "Sin duda te encontrarás con bendecidos en este mundo que simplemente qu
 #: /Game/Dialogue/Romy/Default/RomyDefault01_AboutMusic.Default__RomyDefault01_AboutMusic_C.SessionData.Lines(5).Lines
 msgctxt ",77E7C4FC4287147D1A10F5BD3D5F5081"
 msgid "Bathe them of course, if they're dirty. Fortunately, @MONSTER_RACE@ are very clean naturally."
-msgstr "Báñalos, por supuesto, si están sucios. Afortunadamente, @MONSTER_RACE@ son muy limpios naturalmente."
+msgstr "Báñalos, por supuesto, si están sucios. Afortunadamente, los @MONSTER_RACE@ son muy limpios por instintito."
 
 #. Key:	786684AF43E49B03AB1575A2054AC196
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(3 - Value).TraitIcons.DisplayName
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(3 - Value).TraitIcons.DisplayName
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(3 -
+#: Value).TraitIcons.DisplayName
 msgctxt ",786684AF43E49B03AB1575A2054AC196"
 msgid "Large Size"
 msgstr "Tamaño Grande"
 
 #. Key:	78B7319E49FA8E32267F09898482F929
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(27 - Value).TraitIcons.DisplayName
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(27 - Value).TraitIcons.DisplayName
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(27 -
+#: Value).TraitIcons.DisplayName
 msgctxt ",78B7319E49FA8E32267F09898482F929"
 msgid "Slender"
-msgstr "Delgado/a"
+msgstr "Esbelto"
 
 #. Key:	78BE7208419A717547042586055934C2
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(13).LinesToFemale
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(13).LinesToFemale
 msgctxt ",78BE7208419A717547042586055934C2"
 msgid "Just looking at you is filling me with burning desire... "
-msgstr "Solo de mirarte me estoy llenando de ardiente deseo... "
+msgstr "Solo mirarte me llena de ardiente deseo... "
 
 #. Key:	78C065C7473E103C41FCDA893D7F14FF
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_Leylanna.Default__EmissaryDefault01_Leylanna_C.SessionData.Lines(6).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_Leylanna.Default__EmissaryDefault01_Leylanna_C.SessionData.Lines(6).Lines
 msgctxt ",78C065C7473E103C41FCDA893D7F14FF"
 msgid "Frequently, she will wander over here naked with a glazed look in her eye."
-msgstr "Con frecuencia, vagará por aquí desnuda con una mirada vidriosa en sus ojos."
+msgstr "Con frecuencia, ella deambula por aquí desnuda con una mirada vidriosa en sus ojos."
 
 #. Key:	78CE278740CEF8CBD44C7699C20FEA54
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_AboutLamias.Default__NeelaDefault01_AboutLamias_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_AboutLamias.Default__NeelaDefault01_AboutLamias_C.SessionData.Lines(1).Lines
 msgctxt ",78CE278740CEF8CBD44C7699C20FEA54"
 msgid "I have been a warden of the Void for countless years and drifted far from Lamia customs."
-msgstr "He sido una guardiana del Vacío durante incontables años y me he alejado mucho de las costumbres de las Lamias."
+msgstr "He sido una guardiana del Vacío durante incontables años y me he alejado mucho de las costumbres de las lamias."
 
 #. Key:	79024D21459BC365A01399ABC4581F9B
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeVerySad.Default__MegaSlimeVerySad_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeVerySad.Default__MegaSlimeVerySad_C.SessionData.Lines(1).Lines
 msgctxt ",79024D21459BC365A01399ABC4581F9B"
 msgid "It was so beautiful..."
-msgstr ""
+msgstr "Fue tan hermoso..."
 
 #. Key:	7921ED37459363625C14BEAA60B51F49
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_Pregnancy.Default__FaleneDefault01_Pregnancy_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_Pregnancy.Default__FaleneDefault01_Pregnancy_C.SessionData.Lines(4).Lines
 msgctxt ",7921ED37459363625C14BEAA60B51F49"
 msgid "Isn't that just fantastic and adorable?!!!"
-msgstr "¡¡¡¿No es eso simplemente fantástico y adorable ?!!!"
+msgstr "¡¡¡¿No es eso simplemente fantástico y adorable?!!!"
 
 #. Key:	7989199A4B0BA24F0B904493FCC965AC
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleHadSex01.Default__KybeleHadSex01_C.SessionData.LinesToFemale(3).LinesToFemale
 #: /Game/Dialogue/Kybele/Default/KybeleHadSex01.Default__KybeleHadSex01_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",7989199A4B0BA24F0B904493FCC965AC"
 msgid "Still... you took my fat horse cock well. That's amazing for one of your size!"
-msgstr ""
+msgstr "Aún así... tomaste bien mi gruesa polla de caballo. ¡Eso es asombroso para alguien de tu tamaño!"
 
 #. Key:	7A0924884575833B8154E88AE733B3E4
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.EM_Keystone_Kybele.FailMessage
 #: /Game/World/Overworld.Overworld:PersistentLevel.EM_Keystone_Kybele.FailMessage
 msgctxt ",7A0924884575833B8154E88AE733B3E4"
 msgid "Kybele fiercely guards this keystone."
-msgstr ""
+msgstr "Kybele guarda ferozmente esta piedra-llave."
 
 #. Key:	7A22D0874255FC1001174C8C01466911
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimePearl.Default__MegaSlimePearl_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePearl.Default__MegaSlimePearl_C.SessionData.Lines(3).Lines
 msgctxt ",7A22D0874255FC1001174C8C01466911"
 msgid "My beloved orb wishes to move on, and I want you to take it."
-msgstr ""
+msgstr "Mi amado orbe desea seguir adelante y quiero que lo aceptes."
 
 #. Key:	7A37639548189268575986A48C480863
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_TheVoid.Default__NeelaDefault01_TheVoid_C.SessionData.Lines(2).Lines
@@ -6486,21 +6523,21 @@ msgstr "Mi nombre es Mirru."
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_Teach.Default__ParvatiDefault01_Teach_C.SessionData.LinesToFuta(1).LinesToFuta
 msgctxt ",7A6479A946793FED41931F8AF7F6B4DE"
 msgid "Relax while I slather your dick with lube."
-msgstr "Relájate mientras a tu polla de lubricante aplico una muda."
+msgstr "Relájate mientras unto tu pene con lubricante."
 
 #. Key:	7A69F5FB4A97FC4EE925589FFD78142E
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiIdiots.Default__FesssiIdiots_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiIdiots.Default__FesssiIdiots_C.SessionData.Lines(0).Lines
 msgctxt ",7A69F5FB4A97FC4EE925589FFD78142E"
 msgid "Indeed, sexy horny idiots. Hiss!"
-msgstr ""
+msgstr "De hecho, idiotas cachondos y sexys. ¡Sss!"
 
 #. Key:	7A7EFCC44E743CC63CBCBB86D21C890C
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcBrashDumb.Default__OrcBrashDumb_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcBrashDumb.Default__OrcBrashDumb_C.SessionData.Lines(1).Lines
 msgctxt ",7A7EFCC44E743CC63CBCBB86D21C890C"
 msgid "Orcs are strong... maybe dumb, but strong."
-msgstr ""
+msgstr "Los orcos son fuertes... tal vez tontos, pero fuertes."
 
 #. Key:	7AE87BF645B6A4B1D35071A966CCF13E
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_RL.Default__EmissaryDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
@@ -6514,7 +6551,7 @@ msgstr "Aumentar el nivel del rasgo."
 #: /Game/World/Overworld.Overworld:PersistentLevel.EM_Keystone_DM.FailMessage
 msgctxt ",7AF5BE374EF5FF228013EAB5CEA00E2E"
 msgid "Don't touch this."
-msgstr ""
+msgstr "No toques esto."
 
 #. Key:	7B46D37346081D01CB0C9B8C6CAEE2DF
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_RL.Default__NeelaDefault01_RL_C.ResponseData(4).ResponseData.BreederPrompt
@@ -6525,87 +6562,88 @@ msgstr "Quiero atravesar tu coño... portal."
 
 #. Key:	7B5F72194EE494B66BEC5CAD05253722
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(15 - Value).TraitIcons.DisplayName
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(15 - Value).TraitIcons.DisplayName
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(15 -
+#: Value).TraitIcons.DisplayName
 msgctxt ",7B5F72194EE494B66BEC5CAD05253722"
 msgid "Juicy"
-msgstr "Jugoso/a"
+msgstr "Jugoso"
 
 #. Key:	7BA3471A456AB33D0F6E1AB523E14EBC
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruHadSex01.Default__MirruHadSex01_C.SessionData.LinesToFemale(3).LinesToFemale
 #: /Game/Dialogue/Mirru/Default/MirruHadSex01.Default__MirruHadSex01_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",7BA3471A456AB33D0F6E1AB523E14EBC"
 msgid "Believe it or not, I held back and could have drenched you with more kraken cum."
-msgstr ""
+msgstr "Lo creas o no, me contuve y podría haberte empapado con más semen kraken."
 
 #. Key:	7BA8039A45383C5B11EEA9AC428E3158
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToMale(0).LinesToMale
 #: /Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToMale(0).LinesToMale
 msgctxt ",7BA8039A45383C5B11EEA9AC428E3158"
 msgid "Ohhh @BREEDER_NAME@... you were amazing."
-msgstr ""
+msgstr "Ohhh, @BREEDER_NAME@... estuviste increíble."
 
 #. Key:	7BD230084E2B289F72FCC48F4E4B7CB8
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraPracticeMe.Default__PetraPracticeMe_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Petra/Default/PetraPracticeMe.Default__PetraPracticeMe_C.SessionData.Lines(0).Lines
 msgctxt ",7BD230084E2B289F72FCC48F4E4B7CB8"
 msgid "How sweet! Awww..."
-msgstr ""
+msgstr "¡Que dulce! Ammm..."
 
 #. Key:	7BF991CE424A23FC457D0E9B71CACEBE
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMGreeting01.Default__DMGreeting01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMGreeting01.Default__DMGreeting01_C.SessionData.Lines(1).Lines
 msgctxt ",7BF991CE424A23FC457D0E9B71CACEBE"
 msgid "Is this a dream? Humans aren't supposed to exist."
-msgstr ""
+msgstr "¿Es esto un sueño? Se supone que los humanos no existen."
 
 #. Key:	7C125E5D4D9517525ACC16A414D5C0E1
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadGreeting01.Default__DryadGreeting01_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Autumn/Default/DryadGreeting01.Default__DryadGreeting01_C.SessionData.Lines(4).Lines
 msgctxt ",7C125E5D4D9517525ACC16A414D5C0E1"
 msgid "I didn't notice I had a visitor. A human visitor... how interesting."
-msgstr ""
+msgstr "No me di cuenta de que tenía una visita. Un visitante humano... qué interesante."
 
 #. Key:	7C3236894BBFE97A5B89BC84CF6B44F2
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraDefault01.Default__PetraDefault01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Petra/Default/PetraDefault01.Default__PetraDefault01_C.SessionData.Lines(0).Lines
 msgctxt ",7C3236894BBFE97A5B89BC84CF6B44F2"
 msgid "Aww the cute human has returned."
-msgstr ""
+msgstr "Amm, el lindo humano ha vuelto."
 
 #. Key:	7C3F628D4E83DBC5016EC8A8263D2372
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowDefault01_RL.Default__WidowDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/Widow/Default/WidowDefault01_RL.Default__WidowDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",7C3F628D4E83DBC5016EC8A8263D2372"
 msgid "Scary!"
-msgstr ""
+msgstr "¡De miedo!"
 
 #. Key:	7C4054234127D8843978CD80C4B540B7
 #. SourceLocation:	/Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToMale(1).LinesToMale
 #: /Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToMale(1).LinesToMale
 msgctxt ",7C4054234127D8843978CD80C4B540B7"
 msgid "Yes... oh yes, it feels so good! Penetrate me deeper!"
-msgstr "Sí... oh sí, ¡se siente tan bien! ¡Penetrarme más profundo!"
+msgstr "¡Sí... oh sí, se siente tan bien! ¡Penetrarme más profundo!"
 
 #. Key:	7C47118C4A51AA8F9E612C99BCE37ABF
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleAnyMeans_RL_T.Default__KybeleAnyMeans_RL_T_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/Kybele/Default/KybeleAnyMeans_RL_T.Default__KybeleAnyMeans_RL_T_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",7C47118C4A51AA8F9E612C99BCE37ABF"
 msgid "I will be leaving now..."
-msgstr ""
+msgstr "Me iré ahora..."
 
 #. Key:	7C5554A44E14D8611780E99EAC37F747
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyLockedDungeon.Default__RomyLockedDungeon_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Romy/Default/RomyLockedDungeon.Default__RomyLockedDungeon_C.SessionData.Lines(0).Lines
 msgctxt ",7C5554A44E14D8611780E99EAC37F747"
 msgid "I don't know how to access it, but beware."
-msgstr ""
+msgstr "No sé cómo acceder a él, pero cuidado."
 
 #. Key:	7C5853BA4383F9B61021B3A6AD59FA09
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01.Default__ParvatiDefault01_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01.Default__ParvatiDefault01_C.SessionData.Lines(3).Lines
 msgctxt ",7C5853BA4383F9B61021B3A6AD59FA09"
 msgid "Using our bodies in ways all too perverse."
-msgstr "Usando nuestros cuerpos de formas todas de un modo muy perverso."
+msgstr "Usando nuestros cuerpos de formas demasiado perversas."
 
 #. Key:	7CBF0BC045EF15D872E4EC89A2B54116
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_HowToSpiritForm_RL_F.Default__LeylannaDefault01_HowToSpiritForm_RL_F_C.ResponseData(2).ResponseData.BreederPrompt
@@ -6619,7 +6657,7 @@ msgstr "Esto se está volviendo raro..."
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R01.Default__FaleneDefault01_R01_C.SessionData.Lines(18).Lines
 msgctxt ",7D03678540D6F71FEFDE1D85CC57028E"
 msgid "Wow, there I go rambling again... This topic is very fascinating to me as you can tell!"
-msgstr "Wow, ahí voy divagando otra vez... ¡Este tema es muy fascinante para mí, como puedes ver!"
+msgstr "Guau, ahí voy divagando de nuevo... ¡Este tema me resulta fascinante, como puedes ver!"
 
 #. Key:	7D427552463EADBEB57082A7FE3BC4A6
 #. SourceLocation:	/Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToMale(3).LinesToMale
@@ -6633,95 +6671,97 @@ msgstr "*Lame* *Sorbe*"
 #: /Game/Dialogue/Petra/Default/PetraDefault01_RL.Default__PetraDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",7D4C4BD949BF041F9FA20CB373FAA9DB"
 msgid "Tell me about Pawsmatti."
-msgstr ""
+msgstr "Háblame de Pawsmatti."
 
 #. Key:	7D4DC0064FB622869AA3E3B8CFCF2444
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryCockblockGates.Default__EmissaryCockblockGates_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryCockblockGates.Default__EmissaryCockblockGates_C.SessionData.Lines(0).Lines
 msgctxt ",7D4DC0064FB622869AA3E3B8CFCF2444"
 msgid "Ah you mean the Cockblock Gates."
-msgstr ""
+msgstr "Ah, te refieres a los Portones Bloque-polla."
 
 #. Key:	7D9B8CD848A3DAA68B924CA2B1E60858
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToFemale(2).LinesToFemale
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",7D9B8CD848A3DAA68B924CA2B1E60858"
 msgid "Our preference is always for semen from the source, if you know what I mean."
-msgstr ""
+msgstr "Nuestra preferencia es siempre por el semen de origen, si sabes a qué me refiero."
 
 #. Key:	7DC88423439E72249A6A439C756B59B8
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeDefault01.Default__BeeDefault01_C.SessionData.LinesToFemale(2).LinesToFemale
 #: /Game/Dialogue/QueenBee/Default/BeeDefault01.Default__BeeDefault01_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",7DC88423439E72249A6A439C756B59B8"
 msgid "Good thing I have my toy!"
-msgstr ""
+msgstr "¡Menos mal que tengo mi juguete!"
 
 #. Key:	7DEDC34249AC42CB6EF8018004CA4FF0
 #. SourceLocation:	/Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToFemale(3).LinesToFemale
 #: /Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",7DEDC34249AC42CB6EF8018004CA4FF0"
 msgid "The way you lick my ear... ahhh, it tickles hehe!"
-msgstr "La forma en que me lames la oreja... ahhh, ¡hace cosquillas jeje!"
+msgstr "La forma en que me lames la oreja... ¡ahhh, hace cosquillas jeje!"
 
 #. Key:	7E36966C48C520604CCDB1B0B9BC0D6E
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadDefault01_RL.Default__DryadDefault01_RL_C.ResponseData(3).ResponseData.BreederPrompt
 #: /Game/Dialogue/Autumn/Default/DryadDefault01_RL.Default__DryadDefault01_RL_C.ResponseData(3).ResponseData.BreederPrompt
 msgctxt ",7E36966C48C520604CCDB1B0B9BC0D6E"
 msgid "So I met this lamia with a huge ass..."
-msgstr ""
+msgstr "Así que conocí a esta lamia con un culo enorme..."
 
 #. Key:	7E841B634D3F978AEFAC20B8445DB231
 #. SourceLocation:	/Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToMale(2).LinesToMale
 #: /Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToMale(2).LinesToMale
 msgctxt ",7E841B634D3F978AEFAC20B8445DB231"
 msgid "Feel my velvet tongue stroke the shaft as your dick touches the back of my mouth. Ahhh..."
-msgstr "Siente mi lengua aterciopelada acariciando el tallo mientras tu polla toca el fondo de mi boca. Ahhh..."
+msgstr "Siente mi lengua aterciopelada acariciando el tallo mientras tu pene toca el fondo de mi boca. Ahhh..."
 
 #. Key:	7E871257404E27C20903A3877220C69A
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TravelShrines(10 - Value).TravelShrines.ShrineName
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TravelShrines(10 - Value).TravelShrines.ShrineName
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TravelShrines(10 -
+#: Value).TravelShrines.ShrineName
 msgctxt ",7E871257404E27C20903A3877220C69A"
 msgid "Pleasure Pastures"
-msgstr "Pastos de Placer"
+msgstr "Pastos del Placer"
 
 #. Key:	7E8B7E764E94AEB05F7AEBA0A2B30442
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiDefault03_RL_F.Default__FesssiDefault03_RL_F_C.ResponseData(2).ResponseData.BreederPrompt
 #: /Game/Dialogue/Fesssi/Default/FesssiDefault03_RL_F.Default__FesssiDefault03_RL_F_C.ResponseData(2).ResponseData.BreederPrompt
 msgctxt ",7E8B7E764E94AEB05F7AEBA0A2B30442"
 msgid "Where does that cave lead?"
-msgstr ""
+msgstr "¿A dónde lleva esa cueva?"
 
 #. Key:	7EB70BCB424768DDF719C0A18F381AB6
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiStuck.Default__FesssiStuck_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiStuck.Default__FesssiStuck_C.SessionData.Lines(0).Lines
 msgctxt ",7EB70BCB424768DDF719C0A18F381AB6"
 msgid "Oh... yessss I suppose it would be easier to mate if I was free."
-msgstr ""
+msgstr "Oh... ssssí supongo que sería más fácil aparearme si fuera libre."
 
 #. Key:	7ECA06BA481C3327A91288A9BFF1F23D
 #. SourceLocation:	/Game/Dialogue/Mirru/SexScenes/MirruKrakVag.Default__MirruKrakVag_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Mirru/SexScenes/MirruKrakVag.Default__MirruKrakVag_C.SessionData.Lines(1).Lines
 msgctxt ",7ECA06BA481C3327A91288A9BFF1F23D"
 msgid "Ahh... ohhhh... yes!"
-msgstr "Ahh... ohhhh... si!"
+msgstr "¡Ahh... ohhhh... sí!"
 
 #. Key:	7ED8B0A7419F30B18D98B1BF4842D4A5
 #. SourceLocation:	/Game/Dialogue/Blossom/Default/BlossomDefault01_R03.Default__BlossomDefault01_R03_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Blossom/Default/BlossomDefault01_R03.Default__BlossomDefault01_R03_C.SessionData.Lines(1).Lines
 msgctxt ",7ED8B0A7419F30B18D98B1BF4842D4A5"
 msgid "When mastah not want harvest... Blossom do it."
-msgstr "Cuando maestra no quiere cosechar... Flor lo hace."
+msgstr "Cuando Mastah no quiere cosechar... Blossom lo hace."
 
 #. Key:	7EF1ACD74571884FC8F3A9B17EC12FEC
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.SylvanTreehouse.ManageActionMessage
 #: /Game/World/Overworld.Overworld:PersistentLevel.SylvanTreehouse.ManageActionMessage
 msgctxt ",7EF1ACD74571884FC8F3A9B17EC12FEC"
 msgid "Manage your Sylvan"
-msgstr "Gestiona tus Silvestres"
+msgstr "Gestiona tus Silvanos"
 
 #. Key:	7EF6E26243EE042D016B90AFA2F62AE7
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(10 - Value).TraitIcons.DisplayName
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(10 - Value).TraitIcons.DisplayName
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(10 -
+#: Value).TraitIcons.DisplayName
 msgctxt ",7EF6E26243EE042D016B90AFA2F62AE7"
 msgid "Divergent"
 msgstr "Divergente"
@@ -6731,49 +6771,49 @@ msgstr "Divergente"
 #: /Game/Dialogue/Kybele/Default/KybeleTaskFulfilled.Default__KybeleTaskFulfilled_C.SessionData.LinesToFemale(4).LinesToFemale
 msgctxt ",7F23CD5A4568538ECF60ED883E7BBAFA"
 msgid "Her large mouth can take a lot of it, and I make sure to shoot loads down her throat."
-msgstr ""
+msgstr "Su gran boca puede aguantar mucho, y me aseguro de disparar montones bajando por su garganta."
 
 #. Key:	7F6924F64E3D07A056BFC7903542E0AB
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeHaveKeystone.Default__BeeHaveKeystone_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/QueenBee/Default/BeeHaveKeystone.Default__BeeHaveKeystone_C.SessionData.Lines(4).Lines
 msgctxt ",7F6924F64E3D07A056BFC7903542E0AB"
 msgid "If you thought my honey was delicious now, it is but a shadow of what it once was."
-msgstr ""
+msgstr "Si pensabas que mi miel era deliciosa ahora, es solo una sombra de lo que fue antes."
 
 #. Key:	7FD5123E4461F41BFB2CAF8A15B94955
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraGreeting01.Default__PetraGreeting01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Petra/Default/PetraGreeting01.Default__PetraGreeting01_C.SessionData.Lines(1).Lines
 msgctxt ",7FD5123E4461F41BFB2CAF8A15B94955"
 msgid "Have you also come to this jungle to seek the Enlightened One?"
-msgstr ""
+msgstr "¿Has venido también a esta jungla a buscar al Iluminado?"
 
 #. Key:	7FEBA6A748A632320A5759BABB317345
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R02.Default__CamillaDefault01_R02_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R02.Default__CamillaDefault01_R02_C.SessionData.Lines(4).Lines
 msgctxt ",7FEBA6A748A632320A5759BABB317345"
 msgid "Dragons like the canyons of Virgin Breaks."
-msgstr "A los dragones les gustan los cañones de los Acantilados Vírgenes."
+msgstr "A los dragones les gustan los cañones de las Rupturas Vírgenes."
 
 #. Key:	7FEBDCF1488DFD58CEB8F28DF96358B3
 #. SourceLocation:	/Game/Dialogue/Neela/SexScenes/NeelaSnakeCuddleF.Default__NeelaSnakeCuddleF_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Neela/SexScenes/NeelaSnakeCuddleF.Default__NeelaSnakeCuddleF_C.SessionData.Lines(5).Lines
 msgctxt ",7FEBDCF1488DFD58CEB8F28DF96358B3"
 msgid "Your ass is so beautiful, ohhhh... let me bury my face in it!"
-msgstr "Tu trasero es tan hermoso, ohhhh... ¡déjame enterrar mi cara en él!"
+msgstr "Tu culo es tan hermoso, ohhhh... ¡déjame enterrar mi cara en él!"
 
 #. Key:	7FF4B7A846AB31C139AAB39A8D7D52E6
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaHadSex02.Default__CamillaHadSex02_C.SessionData.LinesToFuta(2).LinesToFuta
 #: /Game/Dialogue/Camilla/Default/CamillaHadSex02.Default__CamillaHadSex02_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",7FF4B7A846AB31C139AAB39A8D7D52E6"
 msgid "Ohhh but I did!"
-msgstr ""
+msgstr "¡Ohhh, pero lo hice!"
 
 #. Key:	7FFABE9A47E55779EE09758A40C05E71
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowTaskFullfilled2.Default__WidowTaskFullfilled2_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Widow/Default/WidowTaskFullfilled2.Default__WidowTaskFullfilled2_C.SessionData.Lines(0).Lines
 msgctxt ",7FFABE9A47E55779EE09758A40C05E71"
 msgid "No human... it is love."
-msgstr ""
+msgstr "No humano... es amor."
 
 #. Key:	803D82954112367C37478B894372AB5A
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_FloatRhyme.Default__ParvatiDefault01_FloatRhyme_C.SessionData.Lines(5).Lines
@@ -6794,91 +6834,92 @@ msgstr ""
 #: /Game/Dialogue/Romy/Default/RomyDefault01.Default__RomyDefault01_C.SessionData.Lines(0).Lines
 msgctxt ",8044648D4BB5A708D0C1658B377C01A4"
 msgid "Warm bath, sweet music, and now the pleasant company of the human."
-msgstr "Baño tibio, dulce música, y ahora la agradable compañía de la humana."
+msgstr "Baño tibio, música dulce y ahora la agradable compañía del humano."
 
 #. Key:	809919A3474406E99443B39588E9EAE7
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimePlay1.Default__MegaSlimePlay1_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePlay1.Default__MegaSlimePlay1_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",809919A3474406E99443B39588E9EAE7"
 msgid "You are so kind! No one has ever been so nice to me!"
-msgstr ""
+msgstr "¡Eres muy amable! ¡Nadie ha sido tan amable conmigo!"
 
 #. Key:	80E41C3F423650528E6EDA8372C9D9E8
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMAboutDragons.Default__DMAboutDragons_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMAboutDragons.Default__DMAboutDragons_C.SessionData.Lines(0).Lines
 msgctxt ",80E41C3F423650528E6EDA8372C9D9E8"
 msgid "We are the masters of this mountain range."
-msgstr ""
+msgstr "Somos los señores de esta cordillera."
 
 #. Key:	8103840A43F7351F6B263C98CC5A6335
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeDefault01_SuckJugs.Default__AmberMaeDefault01_SuckJugs_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeDefault01_SuckJugs.Default__AmberMaeDefault01_SuckJugs_C.SessionData.Lines(2).Lines
 msgctxt ",8103840A43F7351F6B263C98CC5A6335"
 msgid "Me jugs are get'n full, are ye sure that 'lil body can handle it all?"
-msgstr "Mih jarrah están llenah, ¿estáh segura de que ese cuerpesín puede manejarlah?"
+msgstr "Mih cántaroh de leshe están llenoh, ¿estáh seguro de que ese cuerpesín puede manejahlo todo?"
 
 #. Key:	8169C4CD4FCCAEC60B1417A262737D1E
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleHadSex01.Default__KybeleHadSex01_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/Kybele/Default/KybeleHadSex01.Default__KybeleHadSex01_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",8169C4CD4FCCAEC60B1417A262737D1E"
 msgid "Oh that felt amazing!!"
-msgstr ""
+msgstr "¡¡Oh, eso se sintió increíble!!"
 
 #. Key:	8178665B4810CB468AA548A496C72040
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaHadSex01.Default__LeylannaHadSex01_C.SessionData.LinesToMale(3).LinesToMale
 #: /Game/Dialogue/Leylanna/Default/LeylannaHadSex01.Default__LeylannaHadSex01_C.SessionData.LinesToMale(3).LinesToMale
 msgctxt ",8178665B4810CB468AA548A496C72040"
 msgid "Bring that hard cock over here... I want to feel it inside me."
-msgstr ""
+msgstr "Trae esa polla dura aquí... quiero sentirla dentro de mí."
 
 #. Key:	81AE34CA41E9CDDCF3756EBC867EF3A5
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_NoSpiritVariant.Default__LeylannaDefault01_NoSpiritVariant_C.SessionData.LinesToFuta(0).LinesToFuta
 #: /Game/Dialogue/Leylanna/Default/LeylannaDefault01_NoSpiritVariant.Default__LeylannaDefault01_NoSpiritVariant_C.SessionData.LinesToFuta(0).LinesToFuta
 msgctxt ",81AE34CA41E9CDDCF3756EBC867EF3A5"
 msgid "Return to me when you have caught a futa Foxen."
-msgstr "Vuelve a mí cuando hayas atrapado a una Zorro futa."
+msgstr "Vuelve a verme cuando hayas atrapado una futa foxen."
 
 #. Key:	81AEB34842855FDDE393E2B3B0568109
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDungeon2.Default__CassieDungeon2_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Cassie/Default/CassieDungeon2.Default__CassieDungeon2_C.SessionData.Lines(0).Lines
 msgctxt ",81AEB34842855FDDE393E2B3B0568109"
 msgid "It's the old temple because I guess the new one is better."
-msgstr ""
+msgstr "Es el templo viejo porque supongo que el nuevo es mejor."
 
 #. Key:	81BA7F3C4947D886880CA687DA5D133F
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TravelShrines(7 - Value).TravelShrines.ShrineName
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TravelShrines(7 - Value).TravelShrines.ShrineName
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TravelShrines(7 -
+#: Value).TravelShrines.ShrineName
 msgctxt ",81BA7F3C4947D886880CA687DA5D133F"
 msgid "Homestead"
-msgstr "Caserío"
+msgstr "Granja"
 
 #. Key:	821ABD64418D426631CB80AA3EE0629D
 #. SourceLocation:	/Game/Breeding/Positions/Test2.Default__Test2_C.SessionData.PositionName
 #: /Game/Breeding/Positions/Test2.Default__Test2_C.SessionData.PositionName
 msgctxt ",821ABD64418D426631CB80AA3EE0629D"
 msgid "Test2"
-msgstr "Test2"
+msgstr ""
 
 #. Key:	8249C21F4D54352D41F755B9013E7ACE
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowTaskFullfilled2.Default__WidowTaskFullfilled2_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Widow/Default/WidowTaskFullfilled2.Default__WidowTaskFullfilled2_C.SessionData.Lines(1).Lines
 msgctxt ",8249C21F4D54352D41F755B9013E7ACE"
 msgid "She loves my soft silky webs, and especially my tongue."
-msgstr ""
+msgstr "A ella le encantan mis suaves y sedosas telarañas, y especialmente mi lengua."
 
 #. Key:	827D026847F470B33C9BA5B6E24201F5
 #. SourceLocation:	/Game/Breeding/Positions/Lifted.Default__Lifted_C.SessionData.PositionName
 #: /Game/Breeding/Positions/Lifted.Default__Lifted_C.SessionData.PositionName
 msgctxt ",827D026847F470B33C9BA5B6E24201F5"
 msgid "Lifted"
-msgstr "Levantado/a"
+msgstr "Levantado"
 
 #. Key:	829C4F164806E6C664338C969BCB960E
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_RL_M.Default__FernDefault02_RL_M_C.ResponseData(4).ResponseData.BreederPrompt
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02_RL_M.Default__FernDefault02_RL_M_C.ResponseData(4).ResponseData.BreederPrompt
 msgctxt ",829C4F164806E6C664338C969BCB960E"
 msgid "The Queen Bee demands flowers."
-msgstr ""
+msgstr "La Abeja Reina exige flores."
 
 #. Key:	8323A0B240DA89AE9385A6970E54FC26
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryBlessedInquiry01_R01.Default__EmissaryBlessedInquiry01_R01_C.SessionData.Lines(3).Lines
@@ -6892,28 +6933,28 @@ msgstr "Como tu sirviente, mi cuerpo es tuyo. Complácete, pues no me importa."
 #: /Game/Dialogue/Mirru/Default/MirruHadSex01.Default__MirruHadSex01_C.SessionData.LinesToFuta(3).LinesToFuta
 msgctxt ",833370124F1D6AF95E5FC9844AB0DA75"
 msgid "It's not often one so small has the courage to dick a kraken. I hope my fleshy body pleased you."
-msgstr ""
+msgstr "No es frecuente que alguien tan pequeño tenga el coraje de follar a un kraken. Espero que mi cuerpo carnoso te haya complacido."
 
 #. Key:	8362C8D747AF6B672FEF0CB58B2B5B0C
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R02.Default__FaleneDefault01_R02_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R02.Default__FaleneDefault01_R02_C.SessionData.Lines(3).Lines
 msgctxt ",8362C8D747AF6B672FEF0CB58B2B5B0C"
 msgid "Why some @MONSTER_RACE@ are blessed and others aren't is a problem I've been trying to solve for ages. It's possible to see both a wild and blessed variant from the same race! Why?!!"
-msgstr "El por qué algunos @MONSTER_RACE@ son bendecidos y otros no, es un problema que he estado tratando de resolver durante años. ¡Es posible ver una variante salvaje y bendecida de la misma raza! ¡¡¿Por qué?!!"
+msgstr "El por qué algunos @MONSTER_RACE@ son bendecidos y otros no, es un problema que he estado tratando de resolver durante años. ¡Es posible ver una variante silvestre y bendecida de la misma raza! ¡¡¿Por qué?!!"
 
 #. Key:	83A7F89A4658D8B1BD522891AAAC0578
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaFaleneWeek.Default__CamillaFaleneWeek_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaFaleneWeek.Default__CamillaFaleneWeek_C.SessionData.Lines(5).Lines
 msgctxt ",83A7F89A4658D8B1BD522891AAAC0578"
 msgid "Majority of the time, I end up stuffed in all holes."
-msgstr ""
+msgstr "La mayoría de las veces, termino metida en todos los agujeros."
 
 #. Key:	83B1D0DD4F37A2E70289CEAAC491EB74
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaHadSex02.Default__CamillaHadSex02_C.SessionData.LinesToFuta(0).LinesToFuta
 #: /Game/Dialogue/Camilla/Default/CamillaHadSex02.Default__CamillaHadSex02_C.SessionData.LinesToFuta(0).LinesToFuta
 msgctxt ",83B1D0DD4F37A2E70289CEAAC491EB74"
 msgid "Wow human, you must have been desperate to give this nugget your love."
-msgstr ""
+msgstr "Guau, humana, debes haber estado desesperada por darle a esta pepita tu amor."
 
 #. Key:	83C8B41F462880323A7E26B8AE678AA1
 #. SourceLocation:	/Game/Dialogue/Mirru/SexScenes/MirruSnatchT.Default__MirruSnatchT_C.SessionData.Lines(6).Lines
@@ -6927,35 +6968,36 @@ msgstr "Sí, ohh... alimenta a mi voluptuoso cuerpo con toda tu semilla. Ahhhhh.
 #: /Game/Dialogue/Kybele/Default/KybeleHaveKeystone.Default__KybeleHaveKeystone_C.SessionData.Lines(1).Lines
 msgctxt ",83F4F4214C815B64605575ADD36AEAC7"
 msgid "Tell you what, since you're a breeder, if you give me one of your best offspring, I will let you use the keystone."
-msgstr ""
+msgstr "Te diré algo, ya que eres un criador, si me das uno de tus mejores descendientes, te dejaré usar la piedra-llave."
 
 #. Key:	83F96FD847C509C2689331A208A49D12
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault02.Default__EmissaryDefault02_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault02.Default__EmissaryDefault02_C.SessionData.Lines(5).Lines
 msgctxt ",83F96FD847C509C2689331A208A49D12"
 msgid "Now... cometh thy to offer @MONSTER_RACE@?"
-msgstr ""
+msgstr "Ahora... ¿vienes para ofrecer @MONSTER_RACE@?"
 
 #. Key:	840B179B496FE7BBE7487EAE11227191
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TravelShrines(9 - Value).TravelShrines.ShrineName
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TravelShrines(9 - Value).TravelShrines.ShrineName
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TravelShrines(9 -
+#: Value).TravelShrines.ShrineName
 msgctxt ",840B179B496FE7BBE7487EAE11227191"
 msgid "Lustwood"
-msgstr "Bosque de Lujuria"
+msgstr "Bosque de la Lujuria"
 
 #. Key:	84434E3542D0C07128FBC2B58AED1250
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchDefault01_RL.Default__MonarchDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
 #: /Game/Dialogue/Monarch/Default/MonarchDefault01_RL.Default__MonarchDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
 msgctxt ",84434E3542D0C07128FBC2B58AED1250"
 msgid "Can I have that keystone?"
-msgstr ""
+msgstr "¿Puedo tener esa piedra-llave?"
 
 #. Key:	844B2E20423E6D2A12D638A2DC6596BE
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_RL.Default__FaleneDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_RL.Default__FaleneDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",844B2E20423E6D2A12D638A2DC6596BE"
 msgid "What are blessed @MONSTER_RACE@?"
-msgstr "¿Qué son los bendecidos @MONSTER_RACE@?"
+msgstr "¿Qué son los @MONSTER_RACE@ bendecidos?"
 
 #. Key:	8454BE804490F6C78727A5972F42BB8F
 #. SourceLocation:	/Game/Dialogue/Fern/SexScenes/FernMilk_01.Default__FernMilk_01_C.SessionData.Lines(7).Lines
@@ -6969,35 +7011,35 @@ msgstr "*Lame* *Lame*"
 #: /Game/Dialogue/Leylanna/Default/LeylannaDefault01_RL.Default__LeylannaDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",8466D57D4CB68BF73561ECBC20AE8C25"
 msgid "What is spirit form?"
-msgstr "¿Que es la forma spiritual?"
+msgstr "¿Qué es la forma spiritual?"
 
 #. Key:	84A341BF4990E1976FD7BDBD84B9102F
 #. SourceLocation:	/Game/Dialogue/Yasmine/Default/YasminePearls.Default__YasminePearls_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Yasmine/Default/YasminePearls.Default__YasminePearls_C.SessionData.Lines(0).Lines
 msgctxt ",84A341BF4990E1976FD7BDBD84B9102F"
 msgid "Yeah!"
-msgstr ""
+msgstr "¡Sí!"
 
 #. Key:	84B9634D4CF62651B1D08F9FBD40F8DD
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01.Default__FaleneDefault01_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01.Default__FaleneDefault01_C.SessionData.Lines(2).Lines
 msgctxt ",84B9634D4CF62651B1D08F9FBD40F8DD"
 msgid "If I stick around here much longer, desire will overwhelm me and we will make love!"
-msgstr "¡Si me quedo aquí mucho más tiempo, el deseo me abrumará y haremos el amor!"
+msgstr "Si me quedo por aquí mucho más tiempo, ¡el deseo me abrumará y haremos el amor!"
 
 #. Key:	84B9704445972C08434F0F82443C6CDA
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R03.Default__CamillaDefault01_R03_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R03.Default__CamillaDefault01_R03_C.SessionData.Lines(3).Lines
 msgctxt ",84B9704445972C08434F0F82443C6CDA"
 msgid "I'm tired of just licking Titans until I get drenched in their warm sticky pleasure! I want to feel a Titan deep inside me."
-msgstr "¡Estoy cansada de lamer a las titanes hasta que me empape de su cálido y pegajoso placer! Quiero sentir una Titán dentro de mí."
+msgstr "¡Estoy cansada de lamer titanes hasta que me empape de su cálido y pegajoso placer! Quiero sentir un titán profundo dentro de mí."
 
 #. Key:	84C1FC4348F6E50C24A897A279A2655C
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_Emissary.Default__LeylannaDefault01_Emissary_C.SessionData.Lines(7).Lines
 #: /Game/Dialogue/Leylanna/Default/LeylannaDefault01_Emissary.Default__LeylannaDefault01_Emissary_C.SessionData.Lines(7).Lines
 msgctxt ",84C1FC4348F6E50C24A897A279A2655C"
 msgid "Don't let her cold demeanor make you dismissive. She was trained by the Goddess to resist all temptation."
-msgstr "No dejes que su actitud fría te haga desprecio. Ella fue entrenada por la Diosa para resistir toda tentación."
+msgstr "No dejes que su comportamiento frío te haga desprecio. Fue entrenada por la Diosa para resistir toda tentación."
 
 #. Key:	84C4480D4F8374778DDEEAA7A0195EC1
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_TheVoid.Default__NeelaDefault01_TheVoid_C.SessionData.Lines(4).Lines
@@ -7011,7 +7053,7 @@ msgstr "Desafortunadamente, solo se puede usar para viajar."
 #: /Game/Dialogue/Parvati/Default/ParvatiGreeting01.Default__ParvatiGreeting01_C.SessionData.LinesToFemale(4).LinesToFemale
 msgctxt ",84E329854997BD3064CA67922BD88726"
 msgid "One with the Goddess, one with infinity."
-msgstr "Una con la Diosa, una con la del universo infinidad."
+msgstr "Uno con la Diosa, uno con el infinito."
 
 #. Key:	84ECDF64481524BC47B862968D5475BE
 #. SourceLocation:	/Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToMale(7).LinesToMale
@@ -7025,14 +7067,14 @@ msgstr "*Chupa* *Chupa*"
 #: /Game/Ranch/Upgrades/SeraphimLoft.Default__SeraphimLoft_C.Upgrade.Description
 msgctxt ",850118264E28125C1BEFE4B4C33B1F6D"
 msgid "This allows you to catch and store all variants of Seraphim."
-msgstr "Esto te permite capturar y almacenar todas las variantes de Serafínes."
+msgstr "Esto te permite capturar y almacenar todas las variantes de Serafines."
 
 #. Key:	852A10F045E59BFFF8DD789EE5504277
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R03.Default__FaleneDefault01_R03_C.SessionData.Lines(6).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R03.Default__FaleneDefault01_R03_C.SessionData.Lines(6).Lines
 msgctxt ",852A10F045E59BFFF8DD789EE5504277"
 msgid "By breeding them, you will be constantly filling their desires and making them happy."
-msgstr "Al reproducirte con ellos, estarás constantemente cumpliendo sus deseos y haciéndolos felices."
+msgstr "Al reproducirte con ellos, estarás constantemente satisfaciendo sus deseos y haciéndolos felices."
 
 #. Key:	8545E75D449A74E403CC9990E08D65FD
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(28).LinesToMale
@@ -7046,18 +7088,20 @@ msgstr "Bueno, debo irme, ¡buena suerte criador!"
 #: /Game/Dialogue/OrcChief/Default/OrcWantWrestle.Default__OrcWantWrestle_C.SessionData.Lines(0).Lines
 msgctxt ",85468CFB4BEE917F4F0BBAA2DF296686"
 msgid "Grrrrrrr!!!!!!!! Hahaha! You weak little human."
-msgstr ""
+msgstr "¡¡¡¡¡¡¡¡Grrrrrrr!!!!!!!! ¡Jajaja! Eres un pequeño humano débil."
 
 #. Key:	854AE3F2484BF88BB14875815FEE38B4
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(20 - Value).TraitIcons.DisplayName
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(20 - Value).TraitIcons.DisplayName
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(20 -
+#: Value).TraitIcons.DisplayName
 msgctxt ",854AE3F2484BF88BB14875815FEE38B4"
 msgid "Sadistic"
 msgstr "Sádico"
 
 #. Key:	855B7EB248E6DF97FE4486BAE527851B
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(6 - Value).TraitIcons.DisplayName
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(6 - Value).TraitIcons.DisplayName
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(6 -
+#: Value).TraitIcons.DisplayName
 msgctxt ",855B7EB248E6DF97FE4486BAE527851B"
 msgid "Small Size"
 msgstr "Tamaño Pequeño"
@@ -7067,7 +7111,7 @@ msgstr "Tamaño Pequeño"
 #: /Game/World/Overworld.Overworld:PersistentLevel.EM_OrcSwitch.ActivateMessage
 msgctxt ",856492FE47B9932F7B6974BC6ADA5EE7"
 msgid "Open Gate"
-msgstr ""
+msgstr "Portón abierto"
 
 #. Key:	8583D0EF44A4998B0C96F2AD09B65314
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDefault01_Meow.Default__CassieDefault01_Meow_C.SessionData.LinesToFemale(2).LinesToFemale
@@ -7088,77 +7132,77 @@ msgstr "Oh... tan hermoso... ahhhhhhh."
 #: /Game/Dialogue/Kybele/Default/KybeleAnyMeans.Default__KybeleAnyMeans_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",85C0F318409CD0EE03C6A0866A2BC236"
 msgid "My greatest weapon is my spear, the massive one between my legs!"
-msgstr ""
+msgstr "Mi mayor arma es mi lanza, ¡la inmensa que tengo entre las piernas!"
 
 #. Key:	85D697914BECD8CA4AD94DB4BE76C00A
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMAboutDragons.Default__DMAboutDragons_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMAboutDragons.Default__DMAboutDragons_C.SessionData.Lines(4).Lines
 msgctxt ",85D697914BECD8CA4AD94DB4BE76C00A"
 msgid "Dragons are old, very old. We were the first to claim these mountains."
-msgstr ""
+msgstr "Los dragones son viejos, muy viejos. Fuimos los primeros en reclamar estas montañas."
 
 #. Key:	85E58BD244C80942385F1793A5D30333
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiCave.Default__FesssiCave_C.SessionData.Lines(6).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiCave.Default__FesssiCave_C.SessionData.Lines(6).Lines
 msgctxt ",85E58BD244C80942385F1793A5D30333"
 msgid "Hidden in the depths, away from judging eyes, one can indulge in untold hedonism. The cavern dwellers have perfected the pleasurable arts of dark magic."
-msgstr ""
+msgstr "Escondido en las profundidades, lejos de ojos juzgadores, uno puede disfrutar de un hedonismo incalculable. Los habitantes de las cavernas han perfeccionado las placenteras artes de la magia oscura."
 
 #. Key:	85EBB13040FCB54F971A719C5A67F240
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_Leylanna.Default__EmissaryDefault01_Leylanna_C.SessionData.Lines(8).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_Leylanna.Default__EmissaryDefault01_Leylanna_C.SessionData.Lines(8).Lines
 msgctxt ",85EBB13040FCB54F971A719C5A67F240"
 msgid "She will then play with my breasts and pussy for hours, begging me to return the favor."
-msgstr "Luego jugará con mis senos y mi coño durante horas, rogándome que le devuelva el favor."
+msgstr "Luego jugará con mis pechos y mi coño durante horas, suplicándome que le devuelva el favor."
 
 #. Key:	85F4F7D540B5915CFE03BCB33A1C34E7
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02.Default__FernDefault02_C.SessionData.LinesToFuta(3).LinesToFuta
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02.Default__FernDefault02_C.SessionData.LinesToFuta(3).LinesToFuta
 msgctxt ",85F4F7D540B5915CFE03BCB33A1C34E7"
 msgid "Let me wrap my lips around that fat cock of yours, my body longs for your warm cum."
-msgstr "Déjame envolver mis labios alrededor de esa polla gorda tuya, mi cuerpo anhela tu semen caliente."
+msgstr "Déjame envolver mis labios alrededor de esa gorda polla tuya, mi cuerpo anhela tu cálido semen."
 
 #. Key:	85F88762464249CF2ADFD0AFB3D92DB4
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R05.Default__FaleneDefault01_R05_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R05.Default__FaleneDefault01_R05_C.SessionData.Lines(3).Lines
 msgctxt ",85F88762464249CF2ADFD0AFB3D92DB4"
 msgid "Our stripes and spots are natural birth marks, and they look like paint strokes!"
-msgstr "¡Nuestras rayas y manchas son marcas de nacimiento naturales y parecen trazos de pintura!"
+msgstr "Nuestras rayas y manchas son marcas de nacimiento naturales, ¡y parecen trazos de pintura!"
 
 #. Key:	8608CD3E4A24FE889A9114BB9C69E23E
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcHadSex01.Default__OrcHadSex01_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/OrcChief/Default/OrcHadSex01.Default__OrcHadSex01_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",8608CD3E4A24FE889A9114BB9C69E23E"
 msgid "Human feel very good. Swallowed tons of cum hahaha!"
-msgstr ""
+msgstr "La humana se siente muy bien. ¡Tragaste toneladas de semen, jajaja!"
 
 #. Key:	86354AD5497243D13289CF9220240F60
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleDefault01_RL.Default__KybeleDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
 #: /Game/Dialogue/Kybele/Default/KybeleDefault01_RL.Default__KybeleDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
 msgctxt ",86354AD5497243D13289CF9220240F60"
 msgid "Can I ride you?"
-msgstr ""
+msgstr "¿Puedo montarte?"
 
 #. Key:	863580FA480DA6167885D1A2BBF22B9C
 #. SourceLocation:	/Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToMale(8).LinesToMale
 #: /Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToMale(8).LinesToMale
 msgctxt ",863580FA480DA6167885D1A2BBF22B9C"
 msgid "Sweet delicious human seed, let it all go! Ahhh..."
-msgstr "Dulce y deliciosa semilla humana, ¡déjala salir! Ahhh..."
+msgstr "Dulce y deliciosa semilla humana, ¡déjala ir toda! Ahhh..."
 
 #. Key:	863C3850414A8A0B8C0C45907E4898EA
 #. SourceLocation:	/Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToFemale(4).LinesToFemale
 #: /Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToFemale(4).LinesToFemale
 msgctxt ",863C3850414A8A0B8C0C45907E4898EA"
 msgid "Oh... ah... yes! Human... ohhhh."
-msgstr "Oh... ah... si! Humana... ohhhh."
+msgstr "¡Oh... ah... sí! Humano... ohhhh."
 
 #. Key:	86705CF240B11C01C39F05BA7F02F512
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R02.Default__FaleneDefault01_R02_C.SessionData.Lines(15).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R02.Default__FaleneDefault01_R02_C.SessionData.Lines(15).Lines
 msgctxt ",86705CF240B11C01C39F05BA7F02F512"
 msgid "Be sure to look out for needy blessed @MONSTER_RACE@, just be vigilant as you venture around the world, you can't miss them!"
-msgstr "Asegúrate de estar atenta a los necesitados bendecidos @MONSTER_RACE@, solo presta atención mientras te aventuras por el mundo, ¡no los puedes perder!"
+msgstr "Asegúrate de estar atento a los @MONSTER_RACE@ bendecidos necesitados, solo mantente alerta mientras te aventuras por el mundo, ¡no los puedes perder!"
 
 #. Key:	86818D694AB04782DD1A299E28AC5BAF
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R03.Default__FaleneDefault01_R03_C.SessionData.Lines(11).Lines
@@ -7172,21 +7216,21 @@ msgstr "O... puedes vencerlos y salirte con la tuya."
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePearl.Default__MegaSlimePearl_C.SessionData.Lines(0).Lines
 msgctxt ",86BA29A64B876404EC611EBF5E4E3F55"
 msgid "Wow! It's so beautiful."
-msgstr ""
+msgstr "¡Guau! Es tan hermoso."
 
 #. Key:	86C230E147542961EF516C854DF91DDB
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiGreeting01.Default__ParvatiGreeting01_C.SessionData.LinesToFemale(9).LinesToFemale
 #: /Game/Dialogue/Parvati/Default/ParvatiGreeting01.Default__ParvatiGreeting01_C.SessionData.LinesToFemale(9).LinesToFemale
 msgctxt ",86C230E147542961EF516C854DF91DDB"
 msgid "Now let's make love, or you shall find the Her ire."
-msgstr "Ahora hagamos el amor, o su cólera tu ser vivirá."
+msgstr "Ahora hagamos el amor, o encontrarás la ira de Ella."
 
 #. Key:	86DA9E6A4C65102E4B28A3968C3DA8FC
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_Teach.Default__ParvatiDefault01_Teach_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_Teach.Default__ParvatiDefault01_Teach_C.SessionData.Lines(4).Lines
 msgctxt ",86DA9E6A4C65102E4B28A3968C3DA8FC"
 msgid "I can assure you this will feel so good."
-msgstr "Te puedo asegurar que esto se sentirá tan bien."
+msgstr "Te puedo asegurar que esto se sentirá muy bien."
 
 #. Key:	86DCDE444C6876DE3F3C6D8EC7E6FC20
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R05.Default__FaleneDefault01_R05_C.SessionData.Lines(4).Lines
@@ -7200,28 +7244,28 @@ msgstr "¿Quieres ver todo lo mío?"
 #: /Game/World/Overworld.Overworld:PersistentLevel.DemonPool.ManageActionMessage
 msgctxt ",86DE4E4645DF60181C48AD85C95C97BA"
 msgid "Manage your Demons"
-msgstr "Gestiona tus Demonios"
+msgstr "Gestiona tus Demons"
 
 #. Key:	86F7371A4137035AE44922A31E9A0F25
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeVerySad.Default__MegaSlimeVerySad_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeVerySad.Default__MegaSlimeVerySad_C.SessionData.Lines(3).Lines
 msgctxt ",86F7371A4137035AE44922A31E9A0F25"
 msgid "*Sniff*"
-msgstr ""
+msgstr "*Olfatea*"
 
 #. Key:	86F7401346D43F3587BFEFAB87819829
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R03.Default__FaleneDefault01_R03_C.SessionData.Lines(8).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R03.Default__FaleneDefault01_R03_C.SessionData.Lines(8).Lines
 msgctxt ",86F7401346D43F3587BFEFAB87819829"
 msgid "Go wander around an Avatar, you will find wild @MONSTER_RACE@ roaming about aimlessly."
-msgstr "Deambula cerca de un Avatar, encontraras @MONSTER_RACE@ salvajes paseándose sin rumbo fijo."
+msgstr "Pasean alrededor de un Avatar, encontraras @MONSTER_RACE@ silvestres deambulando sin rumbo fijo."
 
 #. Key:	8702885F4AD8627AC254029214EED99B
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_R02_R01.Default__FernDefault02_R02_R01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02_R02_R01.Default__FernDefault02_R02_R01_C.SessionData.Lines(1).Lines
 msgctxt ",8702885F4AD8627AC254029214EED99B"
 msgid "Sure, it can be tempting to drink all of the fluids, but I love you Master and know you need them."
-msgstr "Claro, puede ser tentador beber todos los líquidos, pero te amo Maestra y sé que los necesitas."
+msgstr "Claro, puede ser tentador beber todos los fluidos, pero te amo Master y sé que los necesitas."
 
 #. Key:	870E3E9A4756B06E4D8C9FB1967261E9
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_BatheAllDay.Default__RomyDefault01_BatheAllDay_C.SessionData.Lines(0).Lines
@@ -7235,77 +7279,77 @@ msgstr "Se siente tan bien, y como sirena debo estar cerca del agua."
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePlay.Default__MegaSlimePlay_C.SessionData.LinesToMale(3).LinesToMale
 msgctxt ",8738B95245E3A4C3EBFE789CB296F4FD"
 msgid "Well what are you waiting for? Come on in!"
-msgstr ""
+msgstr "¿Bueno, qué estás esperando? ¡Venga!"
 
 #. Key:	876C0AAA40651DB0D464218A41FDE0CB
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleDragonMatriarch.Default__KybeleDragonMatriarch_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Kybele/Default/KybeleDragonMatriarch.Default__KybeleDragonMatriarch_C.SessionData.Lines(1).Lines
 msgctxt ",876C0AAA40651DB0D464218A41FDE0CB"
 msgid "A centaur never backs down from her duty. I have sworn an oath and nothing will sway me!"
-msgstr ""
+msgstr "Un centauro nunca se echa atrás en su deber. ¡He hecho un juramento y nada me influirá!"
 
 #. Key:	8778E21C45BEF3475418C79BD3B95062
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeGreeting01.Default__MegaSlimeGreeting01_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeGreeting01.Default__MegaSlimeGreeting01_C.SessionData.Lines(2).Lines
 msgctxt ",8778E21C45BEF3475418C79BD3B95062"
 msgid "Amazing! I never thought I would see a real living human."
-msgstr ""
+msgstr "¡Increíble! Nunca pensé que vería a un ser humano vivo real."
 
 #. Key:	8797C4C64E06B6CA137B77BA4824489F
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadFlowers.Default__DryadFlowers_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Autumn/Default/DryadFlowers.Default__DryadFlowers_C.SessionData.Lines(4).Lines
 msgctxt ",8797C4C64E06B6CA137B77BA4824489F"
 msgid "How sad... they haven't grown in hundreds of years. Those poor bees!"
-msgstr ""
+msgstr "Qué triste... no han crecido en cientos de años. ¡Esas pobres abejas!"
 
 #. Key:	87AE8529473D2DEE9E580591D88F1EE5
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadFlowers.Default__DryadFlowers_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Autumn/Default/DryadFlowers.Default__DryadFlowers_C.SessionData.Lines(5).Lines
 msgctxt ",87AE8529473D2DEE9E580591D88F1EE5"
 msgid "As you might have guessed from the name, ejaculum-phallis are famous for producing tons of nectar."
-msgstr ""
+msgstr "Como habrás adivinado por el nombre, los ejaculum-phallis son famosos por producir toneladas de néctar."
 
 #. Key:	87F01F0B48F45D7E461449960ED82A56
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaGreeting01.Default__LeylannaGreeting01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Leylanna/Default/LeylannaGreeting01.Default__LeylannaGreeting01_C.SessionData.Lines(1).Lines
 msgctxt ",87F01F0B48F45D7E461449960ED82A56"
 msgid "I am high priestess Leylanna, enlightened servant of the Goddess most high."
-msgstr "Soy la suma sacerdotisa Leylanna, sirvienta iluminada de la más alta Diosa."
+msgstr "Soy la suma sacerdotisa Leylanna, sirvienta iluminada de la altísima Diosa."
 
 #. Key:	88006BFC4372D17451C7D19A862A2574
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeHaveKeystone.Default__BeeHaveKeystone_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/QueenBee/Default/BeeHaveKeystone.Default__BeeHaveKeystone_C.SessionData.Lines(5).Lines
 msgctxt ",88006BFC4372D17451C7D19A862A2574"
 msgid "When we had access to that nectar, the honey I made lured even the angels of Sensual Heavens to worship my nipples."
-msgstr ""
+msgstr "Cuando tuvimos acceso a ese néctar, la miel que hice atrajo incluso a los ángeles de los Cielos Sensuales a adorar mis pezones."
 
 #. Key:	8800985D4901B4EF2FE2FD9B6D818E41
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_Pregnancy.Default__FaleneDefault01_Pregnancy_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_Pregnancy.Default__FaleneDefault01_Pregnancy_C.SessionData.Lines(1).Lines
 msgctxt ",8800985D4901B4EF2FE2FD9B6D818E41"
 msgid "There is no birthing, no embryo, and no pain involved whatsoever."
-msgstr "No hay parto, ni embrión, y no hay dolor en absoluto."
+msgstr "No hay parto, ni embrión, y ningún dolor involucrado en absoluto."
 
 #. Key:	8839893A45BD5AC8569BAD8798ACEE15
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowDefault01.Default__WidowDefault01_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Widow/Default/WidowDefault01.Default__WidowDefault01_C.SessionData.Lines(2).Lines
 msgctxt ",8839893A45BD5AC8569BAD8798ACEE15"
 msgid "..."
-msgstr ""
+msgstr "..."
 
 #. Key:	887E11C1414E35B9B9420BA80FD5A411
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R01.Default__FaleneDefault01_R01_C.SessionData.Lines(13).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R01.Default__FaleneDefault01_R01_C.SessionData.Lines(13).Lines
 msgctxt ",887E11C1414E35B9B9420BA80FD5A411"
 msgid "@MONSTER_RACE@ are half human, we know this for a fact. To be honest we've never had a human here to... experiment with... until now."
-msgstr "Los @MONSTER_RACE@ son mitad humanos, lo sabemos a ciencia cierta. Para ser sincera, nunca hemos tenido una humana aquí para... experimentar... hasta ahora."
+msgstr "Los @MONSTER_RACE@ son mitad humanos, lo sabemos a ciencia cierta. Para ser sincera, nunca hemos tenido un humano aquí para... experimentar... hasta ahora."
 
 #. Key:	889821A14F372C605AB0A58DD716FB9E
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleAnyMeans_RL.Default__KybeleAnyMeans_RL_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/Kybele/Default/KybeleAnyMeans_RL.Default__KybeleAnyMeans_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",889821A14F372C605AB0A58DD716FB9E"
 msgid "Pfff I can handle a titty pony."
-msgstr ""
+msgstr "Pfff, puedo manejar una pony tetudita."
 
 #. Key:	889D5D974E2DA932F5EAC7B50EC85E50
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(5).Lines
@@ -7319,7 +7363,7 @@ msgstr "¿Qué hago con la leshe que compro?"
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R04.Default__FaleneDefault01_R04_C.SessionData.Lines(1).Lines
 msgctxt ",88B965E0435F9EAD252E91913254E01A"
 msgid "To call us horny is an understatement!"
-msgstr "¡Llamarnos cachondos es un eufemismo!"
+msgstr "¡Llamarnos cachondos es quedarse corto!"
 
 #. Key:	88C30C5C411F049B09320995A20AE25B
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R01.Default__FaleneDefault01_R01_C.SessionData.Lines(0).Lines
@@ -7333,56 +7377,56 @@ msgstr "Ese es un tema que merece todo un volumen."
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_FloatRhyme.Default__ParvatiDefault01_FloatRhyme_C.SessionData.Lines(9).Lines
 msgctxt ",88C6CA66419DF0FF12D0A4B560B847DA"
 msgid "Thus, you should stay and hear my rhymes."
-msgstr "Así que deberías quedarte y escuchar mis rimas a diario."
+msgstr "Por tanto, deberías quedarte y escuchar mis rimas."
 
 #. Key:	88C799D944DFFE73BC3FD485C3770EEE
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchShySexF_RL.Default__MonarchShySexF_RL_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/Monarch/Default/MonarchShySexF_RL.Default__MonarchShySexF_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",88C799D944DFFE73BC3FD485C3770EEE"
 msgid "No!"
-msgstr ""
+msgstr "¡No!"
 
 #. Key:	88DA748247D4C0C5CE3BEC9851A55E05
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadAboutDryads.Default__DryadAboutDryads_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Autumn/Default/DryadAboutDryads.Default__DryadAboutDryads_C.SessionData.Lines(3).Lines
 msgctxt ",88DA748247D4C0C5CE3BEC9851A55E05"
 msgid "Our nature inclines us to plant roots and help life flourish. In my case, I saw so many cows wandering aimlessly here."
-msgstr ""
+msgstr "Nuestra naturaleza nos inclina a plantar raíces y ayudar a que la vida florezca. En mi caso, vi tantas vacas vagando sin rumbo fijo aquí."
 
 #. Key:	88E908134B3B56C2274F33974CFB4AE5
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(0).LinesToMale
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(0).LinesToMale
 msgctxt ",88E908134B3B56C2274F33974CFB4AE5"
 msgid "Wow! It can't be!"
-msgstr "Guauu! No puede ser!"
+msgstr "¡Guau! ¡No puede ser!"
 
 #. Key:	8914763C4965D6C23C2F2FA37534FDA8
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R01.Default__CamillaDefault01_R01_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R01.Default__CamillaDefault01_R01_C.SessionData.Lines(5).Lines
 msgctxt ",8914763C4965D6C23C2F2FA37534FDA8"
 msgid "However if you're a lame human who hates fun, you can give them their favorite body fluid instead."
-msgstr "Sin embargo, si eres un humano cojo que odia la diversión, puedes darles su líquido corporal favorito en su lugar."
+msgstr "Sin embargo, si eres un humano aburrido que odia la diversión, puedes darles su fluido corporal favorito en su lugar."
 
 #. Key:	896A556649DF30C2C9A122A0DA91A3C0
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_YourMusic.Default__RomyDefault01_YourMusic_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/Romy/Default/RomyDefault01_YourMusic.Default__RomyDefault01_YourMusic_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",896A556649DF30C2C9A122A0DA91A3C0"
 msgid "You do wish to feel my music, I knew it."
-msgstr "Tu sí deseas sentir mi música, lo sabía."
+msgstr "Deseas sentir mi música, lo sabía."
 
 #. Key:	89AD310E47680E241C7AEEB5C24A9E59
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToFemale(2).LinesToFemale
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",89AD310E47680E241C7AEEB5C24A9E59"
 msgid "A chance to mate with a human is making my hearts pound, and my tentacles slick..."
-msgstr "Una oportunidad de aparearme con una humana está haciendo que mi corazón palpite y mis tentáculos resbalen..."
+msgstr "Una oportunidad de aparearme con una humana está haciendo que mi corazón se acelere y que mis tentáculos resbalen..."
 
 #. Key:	89B96FEA426FD3ECBA90259F724E6DF2
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadCherryHelp.Default__DryadCherryHelp_C.SessionData.LinesToFemale(2).LinesToFemale
 #: /Game/Dialogue/Autumn/Default/DryadCherryHelp.Default__DryadCherryHelp_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",89B96FEA426FD3ECBA90259F724E6DF2"
 msgid "I'm getting wet just thinking about us rubbing our labia together."
-msgstr ""
+msgstr "Me estoy mojando solo de pensar en nosotras frotándonos los labios."
 
 #. Key:	89C2CF4D4CB264FC19F1259B533341FD
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_HowToSpiritForm.Default__LeylannaDefault01_HowToSpiritForm_C.SessionData.LinesToFemale(1).LinesToFemale
@@ -7396,63 +7440,64 @@ msgstr "Por lo tanto, solo puedes transformarte en variantes que hayas capturado
 #: /Game/Dialogue/Emissary/SexScenes/EmissaryAngelGroinLove.Default__EmissaryAngelGroinLove_C.SessionData.LinesToFuta(1).LinesToFuta
 msgctxt ",8A20FAFA493E277B6F0278A65210863E"
 msgid "My labia are holy and magical. May your tongue be graced by their presence."
-msgstr "Mis labios son santos y mágicos. Que tu lengua sea agraciada por su presencia."
+msgstr "Mis labios son sagrados y mágicos. Que tu lengua sea agraciada con su presencia."
 
 #. Key:	8A2E92A74C7DDAAAFC792FA98B65DD60
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_TheVoid.Default__NeelaDefault01_TheVoid_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_TheVoid.Default__NeelaDefault01_TheVoid_C.SessionData.Lines(0).Lines
 msgctxt ",8A2E92A74C7DDAAAFC792FA98B65DD60"
 msgid "The Void is an infinite expanse that exists all around you, but it is unseen."
-msgstr "El vacío es una extensión infinita que existe a su alrededor, pero no se ve."
+msgstr "El Vacío es una extensión infinita que existe a tu alrededor, pero es invisible."
 
 #. Key:	8A5F2FCA4C02275D682FC2A405506B34
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(11).LinesToFemale
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(11).LinesToFemale
 msgctxt ",8A5F2FCA4C02275D682FC2A405506B34"
 msgid "We love humans because you're special!"
-msgstr "¡Amamos a las humanas porque sois especiales!"
+msgstr "¡Amamos a los humanos porque sois especiales!"
 
 #. Key:	8A73A23E40F07266FC6191AAAC25476C
 #. SourceLocation:	/Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToFemale(4).LinesToFemale
 #: /Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToFemale(4).LinesToFemale
 msgctxt ",8A73A23E40F07266FC6191AAAC25476C"
 msgid "Do my soft elven lips feel good? Enjoy their delicate caress as they kiss your groin."
-msgstr "¿Se sienten bien mis suaves labios élficos? Disfruta de su delicada caricia mientras besan tu ingle."
+msgstr "¿Mis suaves labios élficos se sienten bien? Disfruta de sus delicadas caricias mientras besan tu ingle."
 
 #. Key:	8A77725E4111005E08D6A08330057BBF
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcDefault03_RL.Default__OrcDefault03_RL_C.ResponseData(5).ResponseData.BreederPrompt
 #: /Game/Dialogue/OrcChief/Default/OrcDefault03_RL.Default__OrcDefault03_RL_C.ResponseData(5).ResponseData.BreederPrompt
 msgctxt ",8A77725E4111005E08D6A08330057BBF"
 msgid "How is that Akabeko treating you?"
-msgstr ""
+msgstr "¿Cómo te trata esa akabeko?"
 
 #. Key:	8A7AA1664D50A6AD3F66CE8B9B57C01F
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_Daze.Default__EmissaryDefault01_Daze_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_Daze.Default__EmissaryDefault01_Daze_C.SessionData.Lines(3).Lines
 msgctxt ",8A7AA1664D50A6AD3F66CE8B9B57C01F"
 msgid "But beware, a toll will she require."
-msgstr ""
+msgstr "Pero cuidado, necesitarás un peaje."
 
 #. Key:	8AF6FC6641A12C2B4A5B90B25313D5E2
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03.Default__FernDefault03_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03.Default__FernDefault03_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",8AF6FC6641A12C2B4A5B90B25313D5E2"
 msgid "I am a full grown Alraune now!"
-msgstr "¡Soy una Mandrágora adulta ahora!"
+msgstr "¡Ahora soy una alraune completamente desarrollada!"
 
 #. Key:	8B1379924334951ADC6F618BF40ECB55
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_Daze.Default__EmissaryDefault01_Daze_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_Daze.Default__EmissaryDefault01_Daze_C.SessionData.Lines(1).Lines
 msgctxt ",8B1379924334951ADC6F618BF40ECB55"
 msgid "Once the body is pushed beyond capacity, it will lose conciousness and for an undetermined time, thou shall not perceive the world."
-msgstr ""
+msgstr "Una vez que el cuerpo es empujado más allá de su capacidad, perderás el conocimiento y por un tiempo indeterminado, no percibirás el mundo."
 
 #. Key:	8B26942A46ED0C778AE5E1BC7C39336A
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(11 - Value).TraitIcons.HelpText
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(11 - Value).TraitIcons.HelpText
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(11 -
+#: Value).TraitIcons.HelpText
 msgctxt ",8B26942A46ED0C778AE5E1BC7C39336A"
 msgid "Fertile: Fertility doubles pregnancy chance from repeated breeding."
-msgstr "Fértil: Fertilidad duplica la posibilidad de embarazo por la reproducción repetida."
+msgstr "Fértil: la fertilidad duplica la posibilidad de embarazo debido a la reproducción repetida."
 
 #. Key:	8B4E1ACB4F89392773B344A3BE6A4E57
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_Princess.Default__MirruDefault01_Princess_C.SessionData.Lines(5).Lines
@@ -7463,7 +7508,8 @@ msgstr "Se quedan en casa para servir y complacer a madre... oh, cómo extraño 
 
 #. Key:	8B77D0FA4239D5EB678BAE8CDE396838
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(13 - Value).TraitIcons.DisplayName
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(13 - Value).TraitIcons.DisplayName
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(13 -
+#: Value).TraitIcons.DisplayName
 msgctxt ",8B77D0FA4239D5EB678BAE8CDE396838"
 msgid "Hedonist"
 msgstr "Hedonista"
@@ -7473,28 +7519,28 @@ msgstr "Hedonista"
 #: /Game/Dialogue/Fern/DefaultP3/FernGreeting03.Default__FernGreeting03_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",8B8E6E7E442F870ECD9423A21D60D95B"
 msgid "Your fluids have nourished me so well Master..."
-msgstr "Tus fluidos me han alimentado tan bien Maestra..."
+msgstr "Tus fluidos me han nutrido tan bien Master..."
 
 #. Key:	8B99E6244548DDC5BAF8798C9395ED84
 #. SourceLocation:	/Game/Ranch/Upgrades/ThriaeHive.Default__ThriaeHive_C.Upgrade.TypeDisplay
 #: /Game/Ranch/Upgrades/ThriaeHive.Default__ThriaeHive_C.Upgrade.TypeDisplay
 msgctxt ",8B99E6244548DDC5BAF8798C9395ED84"
 msgid "Nephelym Barn"
-msgstr "Granero de Nephelyms"
+msgstr "Granero de Nephelym"
 
 #. Key:	8BADB4BC4F48C251A1FDE2BA89B03B22
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcBrashDumb.Default__OrcBrashDumb_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcBrashDumb.Default__OrcBrashDumb_C.SessionData.Lines(4).Lines
 msgctxt ",8BADB4BC4F48C251A1FDE2BA89B03B22"
 msgid "Wrestling usually turns into sex. Weak outsiders can't tell if we are mating or fighting!"
-msgstr ""
+msgstr "La lucha libre generalmente se convierte en sexo. ¡Los forasteros débiles no pueden saber si nos estamos apareando o peleando!"
 
 #. Key:	8BF8D9C84BBFA034861E1CA3B675AE2F
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R04.Default__CamillaDefault01_R04_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R04.Default__CamillaDefault01_R04_C.SessionData.Lines(2).Lines
 msgctxt ",8BF8D9C84BBFA034861E1CA3B675AE2F"
 msgid "But I think she likes having easier access to my crotch..."
-msgstr "Pero creo que a ella le gusta tener un acceso más fácil a mi entrepierna..."
+msgstr "Pero creo que le gusta tener un acceso más fácil a mi entrepierna..."
 
 #. Key:	8C159EEF4934350128EF61B587714DE0
 #. SourceLocation:	/Game/Dialogue/Cassie/SexScenes/CassieButterButtF.Default__CassieButterButtF_C.SessionData.Lines(3).Lines
@@ -7515,56 +7561,56 @@ msgstr "Pero, la mitad @MONSTER_RACE@ dominante asegura que la descendencia sea 
 #: /Game/World/Overworld.Overworld:PersistentLevel.CBGate_Breaks.BlockMessage
 msgctxt ",8C5FB38741A249FFD19CB3AB1EDFCC3D"
 msgid "Kybele guards this Cockblock Gate."
-msgstr ""
+msgstr "Kybele protege este Portón Bloque-polla."
 
 #. Key:	8C93DBB64045A67B0309ACB46E0AD026
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimePlay1.Default__MegaSlimePlay1_C.SessionData.LinesToFemale(3).LinesToFemale
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePlay1.Default__MegaSlimePlay1_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",8C93DBB64045A67B0309ACB46E0AD026"
 msgid "You will feel so good as I flood your womb with my slime..."
-msgstr ""
+msgstr "Te sentirás tan bien mientras inundo tu útero con mi limo..."
 
 #. Key:	8C95D2A04A969135BDEC06A780BBC656
 #. SourceLocation:	/Game/Characters/Procedural/Variants/Hybrid/Harvest/HybridHarvest.Default__HybridHarvest_C.Harvest.Description
 #: /Game/Characters/Procedural/Variants/Hybrid/Harvest/HybridHarvest.Default__HybridHarvest_C.Harvest.Description
 msgctxt ",8C95D2A04A969135BDEC06A780BBC656"
 msgid "Hybrid body fluids."
-msgstr "Fluidos corporales de Híbrida."
+msgstr "Fluidos corporales de Híbrido."
 
 #. Key:	8C9B5804468F5F400DC62BBD043B050E
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchHaveKeystone2.Default__MonarchHaveKeystone2_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Monarch/Default/MonarchHaveKeystone2.Default__MonarchHaveKeystone2_C.SessionData.Lines(0).Lines
 msgctxt ",8C9B5804468F5F400DC62BBD043B050E"
 msgid "Please take it... maybe we will cross paths again."
-msgstr ""
+msgstr "Por favor, tómalo... tal vez nos volvamos a cruzar de nuevo."
 
 #. Key:	8CA4D43149A0F1DAAAC64681E65FE7BE
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiDefault03_RL_T.Default__FesssiDefault03_RL_T_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/Fesssi/Default/FesssiDefault03_RL_T.Default__FesssiDefault03_RL_T_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",8CA4D43149A0F1DAAAC64681E65FE7BE"
 msgid "Wow... this world is full of idiots."
-msgstr ""
+msgstr "Guau... este mundo está lleno de idiotas."
 
 #. Key:	8CB5ACBF46F02BEA48B084A15F2AD8C2
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(3).Lines
 msgctxt ",8CB5ACBF46F02BEA48B084A15F2AD8C2"
 msgid "Once the Seraphim had started propagating, the Goddess ordered them to spread their light across the empty expanse."
-msgstr "Una vez que las Serafines comenzaron a propagarse, la Diosa les ordenó que extendieran su luz a través de la extensión vacía."
+msgstr "Una vez que las serafines comenzaron a propagarse, la Diosa les ordenó que extendieran su luz a través de la extensión vacía."
 
 #. Key:	8CD67FB74B2E43F406AB5B932B717B19
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToMale(2).LinesToMale
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToMale(2).LinesToMale
 msgctxt ",8CD67FB74B2E43F406AB5B932B717B19"
 msgid "A chance to mate with a human is making my hearts pound, and my tentacles slick..."
-msgstr "Una oportunidad de aparearme con un humano está haciendo que mi corazón palpite y mis tentáculos resbalen..."
+msgstr "Una oportunidad de aparearme con un humano está haciendo que mi corazón se acelere y que mis tentáculos resbalen..."
 
 #. Key:	8CDBFE6141B0505672CA5BAAD842B1B4
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeAboutBees.Default__BeeAboutBees_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/QueenBee/Default/BeeAboutBees.Default__BeeAboutBees_C.SessionData.Lines(4).Lines
 msgctxt ",8CDBFE6141B0505672CA5BAAD842B1B4"
 msgid "Ahhh... the milking process is... quite pleasurable trust me human."
-msgstr ""
+msgstr "Ahhh... el proceso de ordeño es... bastante placentero confía en mí humano."
 
 #. Key:	8D055D5140B28DADFD055EA100CF2F32
 #. SourceLocation:	/Game/Characters/Procedural/Variants/Vulwarg/Harvest/VulwargHarvest.Default__VulwargHarvest_C.Harvest.Description
@@ -7578,49 +7624,49 @@ msgstr "Fluidos corporales de Vulwarg."
 #: /Game/Dialogue/Neela/Default/NeelaHadSex01.Default__NeelaHadSex01_C.SessionData.Lines(1).Lines
 msgctxt ",8D12D3854864E7395B64589A2754A1A5"
 msgid "I waited so long to experience the pleasure only a human could offer..."
-msgstr ""
+msgstr "Esperé tanto tiempo para experimentar el placer que solo un humano podía ofrecer..."
 
 #. Key:	8D19606C4C2EC6C25E3CF1A4F53B952A
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_HowToSpiritForm.Default__LeylannaDefault01_HowToSpiritForm_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/Leylanna/Default/LeylannaDefault01_HowToSpiritForm.Default__LeylannaDefault01_HowToSpiritForm_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",8D19606C4C2EC6C25E3CF1A4F53B952A"
 msgid "One cannot take on a @MONSTER_RACE@ form without first becoming intimately familiar with it."
-msgstr "Una no puede adoptar una forma @MONSTER_RACE@ sin primero familiarizarse íntimamente con él."
+msgstr "No se puede adoptar una forma @MONSTER_RACE@ sin antes familiarizarse íntimamente con ella."
 
 #. Key:	8D1DC11348D4FCEB4B6BC6A7DE4D5D75
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiHowLong.Default__FesssiHowLong_C.SessionData.Lines(7).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiHowLong.Default__FesssiHowLong_C.SessionData.Lines(7).Lines
 msgctxt ",8D1DC11348D4FCEB4B6BC6A7DE4D5D75"
 msgid "Yessss, before the gate closed, random cavern dwellers would sneak up behind me and have their way with my body."
-msgstr ""
+msgstr "Ssssí, antes de que se cerrara el portón, habitantes de las cavernas aleatorios se acercaban furtivamente detrás de mí y se salían con la suya con mi cuerpo."
 
 #. Key:	8D3533C24DF82A263421E5AD13FC2CE1
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_MultipleHearts.Default__MirruDefault01_MultipleHearts_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_MultipleHearts.Default__MirruDefault01_MultipleHearts_C.SessionData.Lines(0).Lines
 msgctxt ",8D3533C24DF82A263421E5AD13FC2CE1"
 msgid "What? Yes... hearts... Krakens require two."
-msgstr "¿Qué? Sí... corazones... Krakens necesitan dos."
+msgstr "¿Qué? Sí... corazones... los krakens necesitan dos."
 
 #. Key:	8D3E28104D0EAE4C533EE39A8D65B6DB
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_R01.Default__FernDefault02_R01_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02_R01.Default__FernDefault02_R01_C.SessionData.Lines(3).Lines
 msgctxt ",8D3E28104D0EAE4C533EE39A8D65B6DB"
 msgid "It's going to be sad to lose the ability to move, but at least I have you Master!"
-msgstr "Va a ser triste perder la capacidad de moverme, ¡pero al menos te tengo Maestra!"
+msgstr "Va a ser triste perder la capacidad de moverme, ¡pero al menos te tengo a ti, Master!"
 
 #. Key:	8D4C9C144C33EE6A19B08696ABFFB5DA
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_FloatRhyme.Default__ParvatiDefault01_FloatRhyme_C.SessionData.Lines(7).Lines
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_FloatRhyme.Default__ParvatiDefault01_FloatRhyme_C.SessionData.Lines(7).Lines
 msgctxt ",8D4C9C144C33EE6A19B08696ABFFB5DA"
 msgid "I will make you feel so good, if it is pleasure that you seek."
-msgstr "Te haré sentir tan bien, si de placer buscas deleitarte."
+msgstr "Te haré sentir tan bien, si es placer lo que buscas."
 
 #. Key:	8D8E77CB4454DA71E9231DA6647955ED
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowHadSex01.Default__WidowHadSex01_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Widow/Default/WidowHadSex01.Default__WidowHadSex01_C.SessionData.Lines(2).Lines
 msgctxt ",8D8E77CB4454DA71E9231DA6647955ED"
 msgid "My hunger is satiated, but not for long... be assured when it returns I will again suck you dry."
-msgstr ""
+msgstr "Mi hambre está saciada, pero no por mucho tiempo... ten por seguro que cuando vuelva, te volveré a chupar hasta dejarte seco."
 
 #. Key:	8DA42A584992D1AF833DDA8EA615FB7B
 #. SourceLocation:	/Game/Dialogue/Fern/SexScenes/FernCum_01.Default__FernCum_01_C.SessionData.Lines(3).Lines
@@ -7634,21 +7680,21 @@ msgstr "*Sorbe* *Lame*"
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R01.Default__FaleneDefault01_R01_C.SessionData.Lines(5).Lines
 msgctxt ",8DDD55F24FF9E587CD5770861537FEC2"
 msgid "When humans reproduce, the process is slow and subject to all sorts of tragic complications."
-msgstr "Cuando los humanos se reproducen, el proceso es lento y está sujeto a todo tipo de complicaciones trágicas."
+msgstr "Cuando los humanos se reproducen, el proceso es lento y está sujeto a todo tipo de trágicas complicaciones."
 
 #. Key:	8E241E394ECAACAC71637784506ACEA1
 #. SourceLocation:	/Game/Characters/Procedural/Variants/Foxen/Harvest/FoxenHarvest.Default__FoxenHarvest_C.Harvest.Description
 #: /Game/Characters/Procedural/Variants/Foxen/Harvest/FoxenHarvest.Default__FoxenHarvest_C.Harvest.Description
 msgctxt ",8E241E394ECAACAC71637784506ACEA1"
 msgid "Foxen body fluids."
-msgstr "Fluidos corporales de Zorro/a."
+msgstr "Fluidos corporales de Foxen."
 
 #. Key:	8E34225A44160F2F0BD6DD9EFC546B2E
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadHadSex01.Default__DryadHadSex01_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Autumn/Default/DryadHadSex01.Default__DryadHadSex01_C.SessionData.Lines(3).Lines
 msgctxt ",8E34225A44160F2F0BD6DD9EFC546B2E"
 msgid "Ohhhh... we should do it again."
-msgstr ""
+msgstr "Ohhhh... deberíamos hacerlo de nuevo."
 
 #. Key:	8E5478244452BC05131C69AB8D675563
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeSuckJugs_RL.Default__AmberMaeSuckJugs_RL_C.ResponseData(1).ResponseData.BreederPrompt
@@ -7662,14 +7708,14 @@ msgstr "Pensándolo bien, no tengo sed."
 #: /Game/Dialogue/Kybele/Default/KybeleAnyMeans.Default__KybeleAnyMeans_C.SessionData.LinesToFemale(5).LinesToFemale
 msgctxt ",8E670FBC49A79D7C192CB5916E7E2B4B"
 msgid "If you do not leave this place, your little human pussy will become aquainted with it!"
-msgstr ""
+msgstr "Si no abandonas este lugar, ¡tu pequeño coño humano se familiarizará con él!"
 
 #. Key:	8E6A9EEC45D5EC9F679747AFFA8DA855
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchHaveKeystone.Default__MonarchHaveKeystone_C.SessionData.Lines(6).Lines
 #: /Game/Dialogue/Monarch/Default/MonarchHaveKeystone.Default__MonarchHaveKeystone_C.SessionData.Lines(6).Lines
 msgctxt ",8E6A9EEC45D5EC9F679747AFFA8DA855"
 msgid "M-m-maybe one of those adorable Foxen!"
-msgstr ""
+msgstr "¡T-t-tal vez uno de esos adorables foxen!"
 
 #. Key:	8F007620423E7F8C613814916858A58C
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_BlueSmoke2.Default__LeylannaDefault01_BlueSmoke2_C.SessionData.Lines(0).Lines
@@ -7704,7 +7750,7 @@ msgstr "Gestiona tus Serafines"
 #: /Game/Dialogue/Petra/Default/PetraGreeting01.Default__PetraGreeting01_C.SessionData.Lines(3).Lines
 msgctxt ",8F881FCB45236FE8DB057EBCF2939A73"
 msgid "I recently finished a session with her... ahhh. My mind is so clear and open."
-msgstr ""
+msgstr "Recientemente terminé una sesión con ella... ahhh. Mi mente está tan clara y abierta."
 
 #. Key:	8FD6281749815A4E5D3B62A257075F76
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R02.Default__FaleneDefault01_R02_C.SessionData.Lines(9).Lines
@@ -7718,11 +7764,12 @@ msgstr "La mayoría son como yo, ¡queremos tu amor! Es a la vez una bendición 
 #: /Game/Dialogue/Leylanna/Default/LeylannaDefault01_SpiritForm.Default__LeylannaDefault01_SpiritForm_C.SessionData.Lines(1).Lines
 msgctxt ",8FF3797442838C0E95D3409B6C613E43"
 msgid "Even from the Void, they adore you breeder. You have made it your goal to bring them into this world so that they might experience pleasure and love."
-msgstr "Incluso desde el vacío, te adoran criadora. Tu objetivo ha sido traerlos a este mundo para que puedan experimentar placer y amor."
+msgstr "Incluso desde el Vacío, te adoran, criador. Te has propuesto traerlos a este mundo para que puedan experimentar placer y amor."
 
 #. Key:	8FFFE80A49114390AEF4A190D3F0A48F
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(11 - Value).TraitIcons.DisplayName
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(11 - Value).TraitIcons.DisplayName
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(11 -
+#: Value).TraitIcons.DisplayName
 msgctxt ",8FFFE80A49114390AEF4A190D3F0A48F"
 msgid "Fertile"
 msgstr "Fértil"
@@ -7732,14 +7779,14 @@ msgstr "Fértil"
 #: /Game/Dialogue/QueenBee/Default/BeeHaveKeystone1.Default__BeeHaveKeystone1_C.SessionData.Lines(0).Lines
 msgctxt ",9006FF4140E2EBD3C3E40ABD8F0E2D40"
 msgid "Hmm... perhaps."
-msgstr ""
+msgstr "Hmm... quizás."
 
 #. Key:	900A82D44250A3392806469644B7B93B
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryGreeting01.Default__EmissaryGreeting01_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryGreeting01.Default__EmissaryGreeting01_C.SessionData.Lines(3).Lines
 msgctxt ",900A82D44250A3392806469644B7B93B"
 msgid "However, roaming this land are lesser @MONSTER_RACE@, to which many brand as \"wild\"."
-msgstr "Sin embargo, vagando por esta tierra hay @MONSTER_RACE@ menores, a lo que muchos califican como \"salvajes\"."
+msgstr "Sin embargo, vagando por esta tierra hay @MONSTER_RACE@ menores, a lo que muchos califican como \"silvestres\"."
 
 #. Key:	902A41DB403EFA60B99E8CB596EFE0BF
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02.Default__FernDefault02_C.SessionData.LinesToFemale(3).LinesToFemale
@@ -7753,14 +7800,14 @@ msgstr "Mi cuerpo anhela tu deliciosa leche materna."
 #: /Game/UI/TaskDescriptions.TaskDescriptions.TextEntries(5).TextEntries
 msgctxt ",906D8350484725AED7108C8EB418C5AF"
 msgid "This one isn't for me, but the beautiful golden angel Emissary. She doesn't seem interested when I try to please her... and oh have I tried. I want to get her something really special, bring me the most lusty Nephelym you can breed. When you do, I will let it make love with Emissary until she cums. If she doesn't, I definitely will while watching.  -Leylanna"
-msgstr ""
+msgstr "Este no es para mí, sino la hermosa ángel dorada Emisaria. No parece interesada cuando trato de complacerla... y oh, lo he intentado. Quiero conseguirle algo realmente especial, tráeme el Nephelym más lujurioso que puedas criar. Cuando lo hagas, dejaré que haga el amor con Emisaria hasta que se corra. Si ella no lo hace, definitivamente lo haré yo mientras observo. -Leylanna"
 
 #. Key:	907E7C35462D4EC3BC72C5B05C7ABDB9
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyGreeting01.Default__RomyGreeting01_C.SessionData.LinesGrungy(2).LinesGrungy
 #: /Game/Dialogue/Romy/Default/RomyGreeting01.Default__RomyGreeting01_C.SessionData.LinesGrungy(2).LinesGrungy
 msgctxt ",907E7C35462D4EC3BC72C5B05C7ABDB9"
 msgid "I hear your eyes working your way down my voluptuous form, your heart beats faster, but... oh... no."
-msgstr "Escucho tus ojos trabajando en mi voluptuosa forma, tu corazón late más rápido, pero... oh... no."
+msgstr "Escucho a tus ojos recorrer su camino bajando por mi voluptuosa forma, tu corazón late más rápido, pero... oh... no."
 
 #. Key:	90AAD27D43E39D45DAC8A492F1373436
 #. SourceLocation:	/Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToMale(9).LinesToMale
@@ -7771,17 +7818,18 @@ msgstr "*Chupa* *Chupa*"
 
 #. Key:	90BF47A74AF19E981D455BAB280C9D02
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(13 - Value).TraitIcons.HelpText
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(13 - Value).TraitIcons.HelpText
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(13 -
+#: Value).TraitIcons.HelpText
 msgctxt ",90BF47A74AF19E981D455BAB280C9D02"
 msgid "Hedonist: Gains the XP that would have been granted to the other mate."
-msgstr "Hedonista: Obtiene el EXP que le habría sido otorgado a el/la otro/a compañero/a."
+msgstr "Hedonista: gana la EXP que se le hubiera otorgado al otro compañero."
 
 #. Key:	90CF176E415EE7CEA27716868800482A
 #. SourceLocation:	/Game/Dialogue/Blossom/Default/BlossomGreeting01.Default__BlossomGreeting01_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Blossom/Default/BlossomGreeting01.Default__BlossomGreeting01_C.SessionData.Lines(4).Lines
 msgctxt ",90CF176E415EE7CEA27716868800482A"
 msgid "Timeeee for the fluidsssss?"
-msgstr "¿Horrrra de los fluidossss?"
+msgstr "¿Hoooora de los fluidosssss?"
 
 #. Key:	90DA01BE4F6814F010ECF99D4730B696
 #. SourceLocation:	/Game/Characters/Procedural/Variants/Dragon/Harvest/DragonHarvest.Default__DragonHarvest_C.Harvest.RaceName
@@ -7795,91 +7843,92 @@ msgstr "Dragón"
 #: /Game/Dialogue/Leylanna/Default/LeylannaHadSex01.Default__LeylannaHadSex01_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",911090974165315ED68A81A7F5257175"
 msgid "You felt so good... we can spend hours together."
-msgstr ""
+msgstr "Te sentiste tan bien... podemos pasar horas juntos."
 
 #. Key:	912A5F994D44D6C64F6E35AE76B06D09
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchHaveKeystone.Default__MonarchHaveKeystone_C.SessionData.Lines(7).Lines
 #: /Game/Dialogue/Monarch/Default/MonarchHaveKeystone.Default__MonarchHaveKeystone_C.SessionData.Lines(7).Lines
 msgctxt ",912A5F994D44D6C64F6E35AE76B06D09"
 msgid "*Blush*"
-msgstr ""
+msgstr "*Sonrojo*"
 
 #. Key:	91512E3C41CA91E3C203E3BFD899DA24
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToFuta(7).LinesToFuta
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToFuta(7).LinesToFuta
 msgctxt ",91512E3C41CA91E3C203E3BFD899DA24"
 msgid "Human cum is something I have always wanted."
-msgstr ""
+msgstr "El semen humano es algo que siempre he querido."
 
 #. Key:	918C772C4F35E159A184638CC564271F
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowScary.Default__WidowScary_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Widow/Default/WidowScary.Default__WidowScary_C.SessionData.Lines(1).Lines
 msgctxt ",918C772C4F35E159A184638CC564271F"
 msgid "Did you not experience immense pleasure as I sucked your genitals for all they had to offer?"
-msgstr ""
+msgstr "¿No experimentaste un inmenso placer mientras chupaba tus genitales por todo lo que tenían para ofrecer?"
 
 #. Key:	91922DC94FEA86B72D24D097B1B9B169
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.EM_Keystone_Dryad.FailMessage
 #: /Game/World/Overworld.Overworld:PersistentLevel.EM_Keystone_Dryad.FailMessage
 msgctxt ",91922DC94FEA86B72D24D097B1B9B169"
 msgid "Tree roots hold it in place."
-msgstr ""
+msgstr "Las raíces de los árboles lo mantienen en su lugar."
 
 #. Key:	91BFB5AF42AF2A7DA5B8219CB5296CAC
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault02.Default__FaleneDefault02_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault02.Default__FaleneDefault02_C.SessionData.Lines(2).Lines
 msgctxt ",91BFB5AF42AF2A7DA5B8219CB5296CAC"
 msgid "..."
-msgstr ""
+msgstr "..."
 
 #. Key:	91C04C0641057656CC61A48472D8954C
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_R03.Default__FernDefault02_R03_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02_R03.Default__FernDefault02_R03_C.SessionData.Lines(1).Lines
 msgctxt ",91C04C0641057656CC61A48472D8954C"
 msgid "I need human cum to grow into my final form. Your dick will slide all the way down my throat as I suck every drop."
-msgstr "Necesito semen humano para crecer en mi forma final. Tu polla se deslizará hasta mi garganta mientras succiono cada gota."
+msgstr "Necesito semen humano para crecer hasta mi forma final. Tu pene se deslizará todo el camino bajando por mi garganta mientras chupo cada gota."
 
 #. Key:	91EBB0754C1505A5258A0CB3E6CE0D71
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraGetKeystone.Default__PetraGetKeystone_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Petra/Default/PetraGetKeystone.Default__PetraGetKeystone_C.SessionData.Lines(0).Lines
 msgctxt ",91EBB0754C1505A5258A0CB3E6CE0D71"
 msgid "Sure can! I'm a bunny, so hopping up there wouldn't be a problem."
-msgstr ""
+msgstr "¡Claro que sí! Soy una conejita, así que saltar allí no sería un problema."
 
 #. Key:	926325814BBC6464CA76E097764B7F27
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(0 - Value).TraitIcons.HelpText
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(0 - Value).TraitIcons.HelpText
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(0 -
+#: Value).TraitIcons.HelpText
 msgctxt ",926325814BBC6464CA76E097764B7F27"
 msgid "Hominal: Inherited more human traits."
-msgstr "Humanoide: Heredó más rasgos humanos."
+msgstr "Humanoide: heredó más rasgos humanos."
 
 #. Key:	926950C44065493241D67FA1816D2447
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleTittyPony_T.Default__KybeleTittyPony_T_C.SessionData.LinesToFuta(1).LinesToFuta
 #: /Game/Dialogue/Kybele/Default/KybeleTittyPony_T.Default__KybeleTittyPony_T_C.SessionData.LinesToFuta(1).LinesToFuta
 msgctxt ",926950C44065493241D67FA1816D2447"
 msgid "It's been sometime since I have been mouted, so I might get rough!"
-msgstr ""
+msgstr "Ha pasado algún tiempo desde que me montaron, ¡así que podría ponerme dura!"
 
 #. Key:	92840010469055DB3A7EADA0FB5C99E1
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcTribeSucks.Default__OrcTribeSucks_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcTribeSucks.Default__OrcTribeSucks_C.SessionData.Lines(1).Lines
 msgctxt ",92840010469055DB3A7EADA0FB5C99E1"
 msgid "Human is right... tribe is weak."
-msgstr ""
+msgstr "El humano tiene razón... la tribu es débil."
 
 #. Key:	929A4EF9420407BC85391A864F8E955D
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToFuta(2).LinesToFuta
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",929A4EF9420407BC85391A864F8E955D"
 msgid "Our preference is always for semen from the source, if you are interested... it will feel amazing!"
-msgstr ""
+msgstr "Nuestra preferencia es siempre por el semen de origen, si estás interesado... ¡se sentirá increíble!"
 
 #. Key:	92CD80ED43FA1902AD31098F05B9E924
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDungeon.Default__CassieDungeon_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Cassie/Default/CassieDungeon.Default__CassieDungeon_C.SessionData.Lines(0).Lines
 msgctxt ",92CD80ED43FA1902AD31098F05B9E924"
 msgid "Oh the old temple?"
-msgstr ""
+msgstr "Oh, ¿el viejo templo?"
 
 #. Key:	92E3821949A8C289A4AAFCA4103F1915
 #. SourceLocation:	/Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToMale(3).LinesToMale
@@ -7900,14 +7949,14 @@ msgstr "Mis manos vellosas arreglarán esto, pero un poco de amor humano tambié
 #: /Game/Dialogue/Autumn/Default/DryadBossomCherries.Default__DryadBossomCherries_C.SessionData.Lines(5).Lines
 msgctxt ",9309BD074F9B0FFE924A35B157A44C07"
 msgid "The thunderous clash of their fall sometimes even shakes the fruit loose."
-msgstr ""
+msgstr "El estruendoso choque de su caída a veces incluso hace que la fruta se suelte."
 
 #. Key:	931A324E4A49D084F8210CA54C479750
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryHadSex01.Default__EmissaryHadSex01_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/Emissary/Default/EmissaryHadSex01.Default__EmissaryHadSex01_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",931A324E4A49D084F8210CA54C479750"
 msgid "Well your tongue certainly found it's way around @BREEDER_NAME@."
-msgstr ""
+msgstr "Bueno, tu lengua ciertamente encontró su camino alrededor, @BREEDER_NAME@."
 
 #. Key:	93200BC643D32038D21FA9A6972CB59F
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryBlessedInquiry01_RL.Default__EmissaryBlessedInquiry01_RL_C.ResponseData(1).ResponseData.BreederPrompt
@@ -7921,28 +7970,28 @@ msgstr "¡Asombroso!"
 #: /Game/Dialogue/Autumn/Default/DryadGreeting01.Default__DryadGreeting01_C.SessionData.Lines(0).Lines
 msgctxt ",934029E9456E811CFA0084839F9BABE4"
 msgid "Sweet and juicy, but just a little squishy."
-msgstr ""
+msgstr "Dulce y jugosa, pero solo un poco blanda."
 
 #. Key:	93692542487EDBAE8A18A699EC9053E1
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeHadSex01.Default__MegaSlimeHadSex01_C.SessionData.LinesToFemale(4).LinesToFemale
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeHadSex01.Default__MegaSlimeHadSex01_C.SessionData.LinesToFemale(4).LinesToFemale
 msgctxt ",93692542487EDBAE8A18A699EC9053E1"
 msgid "So much excitement for one day, getting sleepy."
-msgstr ""
+msgstr "Tanta emoción por un día, me está dando sueño."
 
 #. Key:	936951A3415054668ED149B82FBDB343
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchPrettyButterfly.Default__MonarchPrettyButterfly_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Monarch/Default/MonarchPrettyButterfly.Default__MonarchPrettyButterfly_C.SessionData.Lines(1).Lines
 msgctxt ",936951A3415054668ED149B82FBDB343"
 msgid "Butterflies are a rare Thriae variant, but not a strong one."
-msgstr ""
+msgstr "Las mariposas son una variante rara de thriae, pero no fuerte."
 
 #. Key:	9376B5AE48D48B7CA5084B81F2F5181E
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraGreeting01.Default__PetraGreeting01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Petra/Default/PetraGreeting01.Default__PetraGreeting01_C.SessionData.Lines(0).Lines
 msgctxt ",9376B5AE48D48B7CA5084B81F2F5181E"
 msgid "A human? How neat!"
-msgstr ""
+msgstr "¿Un humano? ¡Qué bien!"
 
 #. Key:	9386C1184C3F241BDF4D33BB1297FF2B
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_Forgot.Default__ParvatiDefault01_Forgot_C.SessionData.Lines(3).Lines
@@ -7956,14 +8005,14 @@ msgstr "Quítate la ropa y ríndete al placer."
 #: /Game/Ranch/Upgrades/DemonPool.Default__DemonPool_C.Upgrade.TypeDisplay
 msgctxt ",93965A5D468FD50976A359A6DC4ABD45"
 msgid "Nephelym Barn"
-msgstr "Granero de Nephelyms"
+msgstr "Granero de Nephelym"
 
 #. Key:	939FC3974789211249F6CB84A4A9FCB8
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeDefault02_RL.Default__BeeDefault02_RL_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/QueenBee/Default/BeeDefault02_RL.Default__BeeDefault02_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",939FC3974789211249F6CB84A4A9FCB8"
 msgid "Can I have that keystone?"
-msgstr ""
+msgstr "¿Puedo tener esa piedra-llave?"
 
 #. Key:	93ACD44B44EFF7C20AF15E9D718C3166
 #. SourceLocation:	/Game/Breeding/Positions/Missionary.Default__Missionary_C.SessionData.PositionName
@@ -7984,21 +8033,21 @@ msgstr "Uh... ¡miau!"
 #: /Game/Ranch/Upgrades/DragonHoard.Default__DragonHoard_C.Upgrade.Description
 msgctxt ",93BFA77B4203C927F888AA9756403DB1"
 msgid "This allows you to catch and store all variants of Dragon."
-msgstr "Esto te permite capturar y almacenar todas las variantes de Dragón."
+msgstr "Esto te permite capturar y almacenar todas las variantes de Dragones."
 
 #. Key:	93DE33A2469E1BAFBEC17DAF59AF4070
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDungeon.Default__CamillaDungeon_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaDungeon.Default__CamillaDungeon_C.SessionData.Lines(1).Lines
 msgctxt ",93DE33A2469E1BAFBEC17DAF59AF4070"
 msgid "Go talk to bulge kitty, she pretends to be exactly that."
-msgstr ""
+msgstr "Ve a hablar con la gatita con bulto, ella finge ser exactamente eso."
 
 #. Key:	941010544E6432D137832FA1B37E0C10
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_Teach.Default__ParvatiDefault01_Teach_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_Teach.Default__ParvatiDefault01_Teach_C.SessionData.Lines(3).Lines
 msgctxt ",941010544E6432D137832FA1B37E0C10"
 msgid "So we can do any position that might arise."
-msgstr "Para que podamos hacer cualquier posición si la ocasión se halla."
+msgstr "Entonces podemos hacer cualquier posición que pueda surgir."
 
 #. Key:	943C15EB4C419656532B6A8A133CD0F3
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01_RL_M.Default__FernDefault01_RL_M_C.ResponseData(3).ResponseData.BreederPrompt
@@ -8009,24 +8058,25 @@ msgstr "¡Puedes tener mi semen!"
 
 #. Key:	94451EBE42500C5CEC2E988DDD887046
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(19 - Value).TraitIcons.HelpText
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(19 - Value).TraitIcons.HelpText
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(19 -
+#: Value).TraitIcons.HelpText
 msgctxt ",94451EBE42500C5CEC2E988DDD887046"
 msgid "Nymphomaniac: Loyalty is increased twice as fast from having sex."
-msgstr "Ninfómana/o: La lealtad aumenta dos veces más rápido por tener sexo."
+msgstr "Ninfómano: la lealtad aumenta dos veces más rápido al tener sexo."
 
 #. Key:	9458CFDE4690A312D5CC8F94BF4AE00A
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03_RL_F.Default__FernDefault03_RL_F_C.ResponseData(3).ResponseData.BreederPrompt
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03_RL_F.Default__FernDefault03_RL_F_C.ResponseData(3).ResponseData.BreederPrompt
 msgctxt ",9458CFDE4690A312D5CC8F94BF4AE00A"
 msgid "Who is the pink Alraune?"
-msgstr "¿Quién es la Mandrágora rosa?"
+msgstr "¿Quién es la alraune rosa?"
 
 #. Key:	945B516446601CCDF45E92B6DC0D6175
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryHadSex01.Default__EmissaryHadSex01_C.SessionData.LinesToFemale(2).LinesToFemale
 #: /Game/Dialogue/Emissary/Default/EmissaryHadSex01.Default__EmissaryHadSex01_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",945B516446601CCDF45E92B6DC0D6175"
 msgid "Is that a comforting feeling?"
-msgstr ""
+msgstr "¿Es un sentimiento reconfortante?"
 
 #. Key:	945CB3304860CBDF1DCD348F2BE3E32B
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R03.Default__FaleneDefault01_R03_C.SessionData.Lines(1).Lines
@@ -8040,53 +8090,54 @@ msgstr "Son más comunes que los bendecidos y actúan por instinto."
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02_R02.Default__FernDefault02_R02_C.SessionData.Lines(0).Lines
 msgctxt ",9471D48E445DF08463FDFC8291100E4E"
 msgid "Indeed! Your delicious fluid has done wonders."
-msgstr "¡En efecto! Tu delicioso líquido ha hecho maravillas."
+msgstr "¡En efecto! Tu delicioso fluido ha hecho maravillas."
 
 #. Key:	94861BA24AA560F31BB02F9A4AC431F9
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_Princess.Default__MirruDefault01_Princess_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_Princess.Default__MirruDefault01_Princess_C.SessionData.Lines(2).Lines
 msgctxt ",94861BA24AA560F31BB02F9A4AC431F9"
 msgid "Unlike most Krakens, she is pure female and not futa. She is very rare."
-msgstr "A diferencia de la mayoría de los Krakens, ella es puramente hembra y no futa. Ella es muy rara."
+msgstr "A diferencia de la mayoría de los krakens, ella es puramente hembra y no futa. Ella es muy rara."
 
 #. Key:	94DDBB0049FCED99D5C08FB803C12B7D
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleHadSex01.Default__KybeleHadSex01_C.SessionData.LinesToFuta(1).LinesToFuta
 #: /Game/Dialogue/Kybele/Default/KybeleHadSex01.Default__KybeleHadSex01_C.SessionData.LinesToFuta(1).LinesToFuta
 msgctxt ",94DDBB0049FCED99D5C08FB803C12B7D"
 msgid "You paid the price, now your little human ejaculation is all mine."
-msgstr ""
+msgstr "Pagaste el precio, ahora tu pequeña eyaculación humana es toda mía."
 
 #. Key:	94FAC38648F37068EA98D4BEB220AA61
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_AboutLamias.Default__NeelaDefault01_AboutLamias_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_AboutLamias.Default__NeelaDefault01_AboutLamias_C.SessionData.Lines(4).Lines
 msgctxt ",94FAC38648F37068EA98D4BEB220AA61"
 msgid "Apparently, the males and futas had two dicks."
-msgstr "Aparentemente, las machos y las futas tenían dos pollas."
+msgstr "Al parecer, los machos y las futas tenían dos vergas."
 
 #. Key:	954CCB0A40A176E6B34A32A8E4590B0A
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchStartShySexT.Default__MonarchStartShySexT_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Monarch/Default/MonarchStartShySexT.Default__MonarchStartShySexT_C.SessionData.Lines(0).Lines
 msgctxt ",954CCB0A40A176E6B34A32A8E4590B0A"
 msgid "*Blush*"
-msgstr ""
+msgstr "*Sonrojo*"
 
 #. Key:	9562407547DB97CDA2482285D47741B5
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchShySex_RL.Default__MonarchShySex_RL_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/Monarch/Default/MonarchShySex_RL.Default__MonarchShySex_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",9562407547DB97CDA2482285D47741B5"
 msgid "You can have sex with me!"
-msgstr ""
+msgstr "¡Puedes tener sexo conmigo!"
 
 #. Key:	9575F3C94F07BC8A511E8D85F3737E68
 #. SourceLocation:	/Game/Characters/Procedural/Variants/Harpy/Harvest/HarpyHarvest.Default__HarpyHarvest_C.Harvest.Description
 #: /Game/Characters/Procedural/Variants/Harpy/Harvest/HarpyHarvest.Default__HarpyHarvest_C.Harvest.Description
 msgctxt ",9575F3C94F07BC8A511E8D85F3737E68"
 msgid "Harpy body fluids."
-msgstr "Fluídos corporales de Arpía."
+msgstr "Fluidos corporales de Arpía."
 
 #. Key:	95781B414AAF336B071430A39FC2F698
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TravelShrines(5 - Value).TravelShrines.ShrineName
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TravelShrines(5 - Value).TravelShrines.ShrineName
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TravelShrines(5 -
+#: Value).TravelShrines.ShrineName
 msgctxt ",95781B414AAF336B071430A39FC2F698"
 msgid "Esoteric Glade"
 msgstr "Claro Esotérico"
@@ -8096,14 +8147,14 @@ msgstr "Claro Esotérico"
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03.Default__FernDefault03_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",9589965546B48748E41BA7942844189B"
 msgid "I am a growing Alraune, perhaps you have fluids to spare?"
-msgstr "Soy una Mandrágora en crecimiento, ¿quizás tengas líquidos de sobra?"
+msgstr "Soy una alraune en crecimiento, ¿tal vez te sobran fluidos?"
 
 #. Key:	960E85EF4CA91DAAA4DCFF93B84D183E
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToFuta(4).LinesToFuta
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToFuta(4).LinesToFuta
 msgctxt ",960E85EF4CA91DAAA4DCFF93B84D183E"
 msgid "Imagine all of the places you could slide your dick in human... and I promise I would make them all feel so good..."
-msgstr "Imagina todos los lugares en los que podrías deslizar tu polla dentro, humana... y prometo que hare todos sentir tan bien..."
+msgstr "Imagina todos los lugares en los que podrías deslizar tu pene dentro, humana... y te prometo que te harán sentir tan bien..."
 
 #. Key:	96151D60454DB0FB521DD6A507DA6C07
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_Forgot_RL.Default__ParvatiDefault01_Forgot_RL_C.ResponseData(2).ResponseData.BreederPrompt
@@ -8117,35 +8168,35 @@ msgstr "¡Vaquera!"
 #: /Game/Dialogue/Kybele/Default/KybeleTittyPony.Default__KybeleTittyPony_C.SessionData.LinesToMale(2).LinesToMale
 msgctxt ",96224E4C41C21D56ABD895A4ACFB4843"
 msgid "That should teach you to cross this titty po--I mean mighty centaur warmaiden, again!"
-msgstr ""
+msgstr "Eso debería enseñarte a cruzar esta poni tet-: ¡otra vez, me refiero a la poderosa doncella-guerrera centauro!"
 
 #. Key:	9656DDC24323054BCA6436A90C28AD1C
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleDragonMatriarch.Default__KybeleDragonMatriarch_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Kybele/Default/KybeleDragonMatriarch.Default__KybeleDragonMatriarch_C.SessionData.Lines(2).Lines
 msgctxt ",9656DDC24323054BCA6436A90C28AD1C"
 msgid "Even if it means... ugh... no leaving to find sexual encounters."
-msgstr ""
+msgstr "Incluso si eso significa... uf... no salir a buscar encuentros sexuales."
 
 #. Key:	9668736F4FE45C7CD14E0C9DE8400813
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFemale(10).LinesToFemale
 #: /Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFemale(10).LinesToFemale
 msgctxt ",9668736F4FE45C7CD14E0C9DE8400813"
 msgid "Unlike nephnip, blue smoke destroys your mind... just look how dumb that kitsune priestess is."
-msgstr ""
+msgstr "A diferencia de la nephnip, el humo azul destruye tu mente... solo mira lo tonta que es esa sacerdotisa kitsune."
 
 #. Key:	96824C894B9B4241DBDFEEB68C760057
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(30).LinesToMale
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(30).LinesToMale
 msgctxt ",96824C894B9B4241DBDFEEB68C760057"
 msgid "If you want to learn about how to catch @MONSTER_RACE@, head to the town located up the plateau ahead and speak to my assistant Camilla. You can't miss her... actually wait you might, she's so tiny and cute hehehe."
-msgstr "Si quieres aprender cómo atrapar @MONSTER_RACE@, dirígete a la ciudad ubicada en la meseta y habla con mi asistente Camilla. No puedes perdértela... en realidad puede que lo hagas, es tan pequeña y linda jejeje."
+msgstr "Si quieres aprender cómo atrapar @MONSTER_RACE@, dirígete a la ciudad ubicada en la meseta más adelante y habla con mi asistente Camilla. No puedes perderla... en realidad, espera, es posible, es tan pequeña y linda jejeje."
 
 #. Key:	9697386D4E5433DC67FA228576AC58B4
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernBeeFlowers3.Default__FernBeeFlowers3_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Fern/DefaultP3/FernBeeFlowers3.Default__FernBeeFlowers3_C.SessionData.Lines(0).Lines
 msgctxt ",9697386D4E5433DC67FA228576AC58B4"
 msgid "Even in my current form, I am not powerful enough to control the plants in other lands."
-msgstr ""
+msgstr "Incluso en mi forma actual, no soy lo suficientemente poderosa para controlar las plantas en otras tierras."
 
 #. Key:	96BF4241443E0334BA81569BD0CAB916
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01.Default__LeylannaDefault01_C.SessionData.Lines(1).Lines
@@ -8159,49 +8210,50 @@ msgstr "La llegada de la Emisaria es un presagio, debemos unir nuestras almas en
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_StartSnatchF.Default__MirruDefault01_StartSnatchF_C.SessionData.Lines(0).Lines
 msgctxt ",96CB06FD409452A1B37913AA11EB845B"
 msgid "Ahhh... come here human!"
-msgstr "Ahhh... ¡ven aquí humana!"
+msgstr "Ahhh… ¡ven aquí humana!"
 
 #. Key:	96D35D8C41748461CFD8F9A9404E42B5
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToFemale(2).LinesToFemale
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",96D35D8C41748461CFD8F9A9404E42B5"
 msgid "I have experienced @MONSTER_RACE@ dick and vagina beyond comprehension."
-msgstr "He experimentado polla y vagina @MONSTER_RACE@ más allá de la comprensión."
+msgstr "He experimentado el pene y la vagina @MONSTER_RACE@ más allá de la comprensión."
 
 #. Key:	96FA042F4830A4781D9FA0874F4705D7
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryCockblockGates.Default__EmissaryCockblockGates_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryCockblockGates.Default__EmissaryCockblockGates_C.SessionData.Lines(1).Lines
 msgctxt ",96FA042F4830A4781D9FA0874F4705D7"
 msgid "The Goddess wisely placed them there to test your ability."
-msgstr ""
+msgstr "La Diosa los colocó sabiamente allí para poner a prueba tu habilidad."
 
 #. Key:	97086CA946BFA31C6199599097E76015
 #. SourceLocation:	/Game/Dialogue/Cassie/SexScenes/CassieButterButtF.Default__CassieButterButtF_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Cassie/SexScenes/CassieButterButtF.Default__CassieButterButtF_C.SessionData.Lines(4).Lines
 msgctxt ",97086CA946BFA31C6199599097E76015"
 msgid "*Purr*"
-msgstr "*Ronroneo*"
+msgstr "*Ronronea*"
 
 #. Key:	9717FEC243A7CD17EDAAD89765F8E2A8
 #. SourceLocation:	/Game/Ranch/Upgrades/FoxenHouse.Default__FoxenHouse_C.Upgrade.Description
 #: /Game/Ranch/Upgrades/FoxenHouse.Default__FoxenHouse_C.Upgrade.Description
 msgctxt ",9717FEC243A7CD17EDAAD89765F8E2A8"
 msgid "This allows you to catch and store all variants of Foxen."
-msgstr "Esto te permite capturar y almacenar todas las variantes de Zorros."
+msgstr "Esto te permite capturar y almacenar todas las variantes de foxens."
 
 #. Key:	97244FB84D6D7CC0273CD3BB89B847D9
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(22 - Value).TraitIcons.DisplayName
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(22 - Value).TraitIcons.DisplayName
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(22 -
+#: Value).TraitIcons.DisplayName
 msgctxt ",97244FB84D6D7CC0273CD3BB89B847D9"
 msgid "Swift"
-msgstr "Rápida/o"
+msgstr "Rápido"
 
 #. Key:	975E8DE7431AB39F97281DB7BD7DE314
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_Teach.Default__ParvatiDefault01_Teach_C.SessionData.LinesToMale(0).LinesToMale
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_Teach.Default__ParvatiDefault01_Teach_C.SessionData.LinesToMale(0).LinesToMale
 msgctxt ",975E8DE7431AB39F97281DB7BD7DE314"
 msgid "Remove your garments, for you must be nude."
-msgstr "Quítate la ropa, debes estar de polla desnuda."
+msgstr "Quítate tus prendas, debes estar desnudo."
 
 #. Key:	97819B7A480CF2968256F1AD74021DAD
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_AboutMusic.Default__RomyDefault01_AboutMusic_C.SessionData.Lines(4).Lines
@@ -8215,14 +8267,14 @@ msgstr "Entonces... bueno, puedes imaginar lo que hacemos."
 #: /Game/Dialogue/QueenBee/Default/BeeDefault01.Default__BeeDefault01_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",9787E49C47227601EF65578F30C5CCA2"
 msgid "Is t-t-there something... you want human?"
-msgstr ""
+msgstr "¿Hay a-a-algo... que quieras humana?"
 
 #. Key:	97A580FD4F8820DD9E8FA09B6B69797A
 #. SourceLocation:	/Game/Ranch/Upgrades/SeraphimLoft.Default__SeraphimLoft_C.Upgrade.DisplayName
 #: /Game/Ranch/Upgrades/SeraphimLoft.Default__SeraphimLoft_C.Upgrade.DisplayName
 msgctxt ",97A580FD4F8820DD9E8FA09B6B69797A"
 msgid "Seraphim Loft"
-msgstr "Ático de Serafines"
+msgstr "Desván de Serafines"
 
 #. Key:	97B6C8DB42BBC06231748889E00AC3AE
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03_R02.Default__FernDefault03_R02_C.SessionData.Lines(3).Lines
@@ -8236,49 +8288,49 @@ msgstr "Húndete dentro de mi cuerpo sedoso y te haré sentir bien durante horas
 #: /Game/Dialogue/DragonMatriarch/Default/DMWantHuman.Default__DMWantHuman_C.SessionData.Lines(4).Lines
 msgctxt ",97B7D1BE4E385C8A6215AC8465CF6026"
 msgid "Your little body will be overwhelmed, and the next thing you know will be the sweet embrace of the Reaper."
-msgstr ""
+msgstr "Tu pequeño cuerpo se sentirá abrumado y lo siguiente que reconocerás será el dulce abrazo de la Segadora."
 
 #. Key:	97B89613437939D3F62A4F9364D46263
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchPrettyButterfly.Default__MonarchPrettyButterfly_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Monarch/Default/MonarchPrettyButterfly.Default__MonarchPrettyButterfly_C.SessionData.Lines(5).Lines
 msgctxt ",97B89613437939D3F62A4F9364D46263"
 msgid "*Blush*"
-msgstr ""
+msgstr "*Sonrojo*"
 
 #. Key:	97C48C5D4FCF938DF123EA94C35A3858
 #. SourceLocation:	/Game/Dialogue/Mirru/SexScenes/MirruSnatchT.Default__MirruSnatchT_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Mirru/SexScenes/MirruSnatchT.Default__MirruSnatchT_C.SessionData.Lines(3).Lines
 msgctxt ",97C48C5D4FCF938DF123EA94C35A3858"
 msgid "Feel my soft girthy tentacles embrace you... oh... yes."
-msgstr "Siente mis suaves tentáculos circunferenciales que te abrazan... oh... sí."
+msgstr "Siente mis suaves y gruesos tentáculos abrazándote... oh... sí."
 
 #. Key:	97DE1E2D44F75CDC8B07A3ACE527EFC4
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03_R03.Default__FernDefault03_R03_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03_R03.Default__FernDefault03_R03_C.SessionData.Lines(1).Lines
 msgctxt ",97DE1E2D44F75CDC8B07A3ACE527EFC4"
 msgid "I need human cum to grow into my final form. Your dick will slide all the way down my throat as I suck every drop."
-msgstr "Necesito semen humano para crecer en mi forma final. Tu polla se deslizará hasta mi garganta mientras succiono cada gota."
+msgstr "Necesito semen humano para crecer hasta mi forma final. Tu pene se deslizará todo el camino bajando por mi garganta mientras chupo cada gota."
 
 #. Key:	97E28C894118E126ABF5B3B0124EB241
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeDefault02_RL.Default__BeeDefault02_RL_C.ResponseData(3).ResponseData.BreederPrompt
 #: /Game/Dialogue/QueenBee/Default/BeeDefault02_RL.Default__BeeDefault02_RL_C.ResponseData(3).ResponseData.BreederPrompt
 msgctxt ",97E28C894118E126ABF5B3B0124EB241"
 msgid "More honey!"
-msgstr ""
+msgstr "¡Más miel!"
 
 #. Key:	97E4D09B44D082B3154FEE94A88EE112
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFemale(8).LinesToFemale
 #: /Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFemale(8).LinesToFemale
 msgctxt ",97E4D09B44D082B3154FEE94A88EE112"
 msgid "That must have been you, perhaps you should go and talk to her."
-msgstr ""
+msgstr "Debes haber sido tú, quizás deberías ir a hablar con ella."
 
 #. Key:	9823997B4369C9710C0858A44B670A9D
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_RL.Default__CamillaDefault01_RL_C.ResponseData(4).ResponseData.BreederPrompt
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_RL.Default__CamillaDefault01_RL_C.ResponseData(4).ResponseData.BreederPrompt
 msgctxt ",9823997B4369C9710C0858A44B670A9D"
 msgid "Why don't futas have balls?"
-msgstr "¿Por qué las futas no tienen bolas?"
+msgstr "¿Por qué las futas no tienen pelotas?"
 
 #. Key:	9826413940251A15497827A9930F74C3
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(24).LinesToFemale
@@ -8292,14 +8344,14 @@ msgstr "Sin duda te encontraras con bendecidos en este mundo que simplemente qui
 #: /Game/Dialogue/Blossom/Default/BlossomDefault01.Default__BlossomDefault01_C.SessionData.Lines(2).Lines
 msgctxt ",9828516944EAF3071BF52881396D2B01"
 msgid "Timeeee for harvest fluidsssss?"
-msgstr "¿Horrrra de cosechar fluidossss?"
+msgstr "¿Hoooora de cosechar fluidosssss?"
 
 #. Key:	982CC755420F84E3E4F0E5A5452A5A48
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiHadSex01.Default__ParvatiHadSex01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Parvati/Default/ParvatiHadSex01.Default__ParvatiHadSex01_C.SessionData.Lines(1).Lines
 msgctxt ",982CC755420F84E3E4F0E5A5452A5A48"
 msgid "I want to make love with you, I will not lie."
-msgstr ""
+msgstr "Quiero hacer el amor contigo, no mentiré."
 
 #. Key:	985E4BA14797DC7FF94FF4974E66471A
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R06.Default__FaleneDefault01_R06_C.SessionData.Lines(6).Lines
@@ -8313,35 +8365,35 @@ msgstr "Estos nuevos descendientes, tanto criaturas naturales como divinas, se c
 #: /Game/World/Overworld.Overworld:PersistentLevel.FoxenHouse.ManageActionMessage
 msgctxt ",9884BCFB41767F163392F78AC097E388"
 msgid "Manage your Foxen"
-msgstr "Gestiona tus Zorro"
+msgstr "Gestiona tus Foxens"
 
 #. Key:	9894566A4CC22E8EE536A59E367BF98A
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMClimaxPeak.Default__DMClimaxPeak_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMClimaxPeak.Default__DMClimaxPeak_C.SessionData.Lines(2).Lines
 msgctxt ",9894566A4CC22E8EE536A59E367BF98A"
 msgid "*Yawn*"
-msgstr ""
+msgstr "*Bosteza*"
 
 #. Key:	9906C87647695E1D9105C3867D704EB0
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMAboutDragons.Default__DMAboutDragons_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMAboutDragons.Default__DMAboutDragons_C.SessionData.Lines(3).Lines
 msgctxt ",9906C87647695E1D9105C3867D704EB0"
 msgid "I have taken the... heavy burden... upon myself of growing the dragon population."
-msgstr ""
+msgstr "He asumido la... pesada carga... de aumentar la población de dragones."
 
 #. Key:	992B062D49B06DDE4398A58352D2F7DF
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchStartShySexF.Default__MonarchStartShySexF_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Monarch/Default/MonarchStartShySexF.Default__MonarchStartShySexF_C.SessionData.Lines(0).Lines
 msgctxt ",992B062D49B06DDE4398A58352D2F7DF"
 msgid "*Blush*"
-msgstr ""
+msgstr "*Sonrojo*"
 
 #. Key:	9935EBCD498F8B600AAED699613B52E9
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01_R02_R01.Default__FernDefault01_R02_R01_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Fern/Default/FernDefault01_R02_R01.Default__FernDefault01_R02_R01_C.SessionData.Lines(3).Lines
 msgctxt ",9935EBCD498F8B600AAED699613B52E9"
 msgid "Many shiny does Fern find in soil. Fern try to eat shiny, too hard."
-msgstr "Mucho brillante Helecho encuentra en el suelo. Helecho intenta comer brillante, demasiado duro."
+msgstr "Mucho brillante Fern encuentra en el suelo. Fern intenta comer brillante, demasiado duro."
 
 #. Key:	9948725645B6492AE76EDB8B38DB1C7F
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.HarpyAviary.ManageActionMessage
@@ -8355,84 +8407,84 @@ msgstr "Gestiona tus Arpías"
 #: /Game/Dialogue/Yasmine/Default/YasmineHadSex01.Default__YasmineHadSex01_C.SessionData.LinesGrungy(1).LinesGrungy
 msgctxt ",996ED4764E0D1E469F8958853E2AABAD"
 msgid "You need a bath. Come now, place your body between my breasts and let's get you clean."
-msgstr ""
+msgstr "Necesitas un baño. Ven ahora, coloca tu cuerpo entre mis pechos y vamos a limpiarte."
 
 #. Key:	99AAA6394A3838FD6FEF1EAA31AD6102
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaGreeting01.Default__LeylannaGreeting01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Leylanna/Default/LeylannaGreeting01.Default__LeylannaGreeting01_C.SessionData.Lines(0).Lines
 msgctxt ",99AAA6394A3838FD6FEF1EAA31AD6102"
 msgid "The human comes at last to seek my wisdom."
-msgstr "La humana viene por fin a buscar mi sabiduría."
+msgstr "El humano viene por fin a buscar mi sabiduría."
 
 #. Key:	99D4A5E745FE69C8C652C6AC80533D2D
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowDefault01_RL.Default__WidowDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
 #: /Game/Dialogue/Widow/Default/WidowDefault01_RL.Default__WidowDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
 msgctxt ",99D4A5E745FE69C8C652C6AC80533D2D"
 msgid "Can I have that keystone?"
-msgstr ""
+msgstr "¿Puedo tener esa piedra-llave?"
 
 #. Key:	99E0E26846BB80B4206E7DB11488DCC4
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernBeeFlowers.Default__FernBeeFlowers_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Fern/Default/FernBeeFlowers.Default__FernBeeFlowers_C.SessionData.Lines(2).Lines
 msgctxt ",99E0E26846BB80B4206E7DB11488DCC4"
 msgid "Fern don't know... not powerful enough."
-msgstr ""
+msgstr "Fern no sabe... no lo suficientemente poderosa."
 
 #. Key:	99F080324D7FD127AB659FB7CC382C5A
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraGetKeystone.Default__PetraGetKeystone_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Petra/Default/PetraGetKeystone.Default__PetraGetKeystone_C.SessionData.Lines(4).Lines
 msgctxt ",99F080324D7FD127AB659FB7CC382C5A"
 msgid "Perhaps Pawsmaati is testing me... maybe her riddle is a metaphore for my own lust..."
-msgstr ""
+msgstr "Quizás Pawsmaati me esté poniendo a prueba... quizás su acertijo es una metáfora de mi propia lujuria..."
 
 #. Key:	9A0EF6A841D0C76A871BD39DB09AEFD4
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01_R03.Default__FernDefault01_R03_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Fern/Default/FernDefault01_R03.Default__FernDefault01_R03_C.SessionData.Lines(0).Lines
 msgctxt ",9A0EF6A841D0C76A871BD39DB09AEFD4"
 msgid "Ohhhh mastah! Finally Fern can have fluids?!"
-msgstr "¡Ohhh maeztra! ¡¿Finalmente Helecho puede tener líquidos?!"
+msgstr "¡Ohhh, Mastah! ¡¿Finalmente Fern puede tener fluidos?!"
 
 #. Key:	9A173A0445AB01F578033CA42A8E9C8F
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_Forgot.Default__ParvatiDefault01_Forgot_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_Forgot.Default__ParvatiDefault01_Forgot_C.SessionData.Lines(0).Lines
 msgctxt ",9A173A0445AB01F578033CA42A8E9C8F"
 msgid "Oh! Ahem..."
-msgstr "Oh! Ejem..."
+msgstr "¡Oh! Ejem..."
 
 #. Key:	9A872CD1493BC95421F01C946AF0F7E4
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaHadSex01.Default__CamillaHadSex01_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/Camilla/Default/CamillaHadSex01.Default__CamillaHadSex01_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",9A872CD1493BC95421F01C946AF0F7E4"
 msgid "Wow human, you must have been desperate to give this nugget your love."
-msgstr ""
+msgstr "Guau, humana, debes haber estado desesperada por darle a esta pepita tu amor."
 
 #. Key:	9A9EDF3448107C0855BB35BBD9D849F5
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(23).LinesToFemale
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(23).LinesToFemale
 msgctxt ",9A9EDF3448107C0855BB35BBD9D849F5"
 msgid "Blessed @MONSTER_RACE@ like me have human-level intelligence. Sometimes even greater!"
-msgstr "Bendecidos @MONSTER_RACE@ como yo tiene inteligencia a nivel humano. ¡A veces incluso mayor!"
+msgstr "@MONSTER_RACE@ bendecidos como yo tienen una inteligencia a nivel humano. ¡A veces incluso mayor!"
 
 #. Key:	9AF5988A4B6D8F174F3241B67F4033C8
 #. SourceLocation:	/Game/Dialogue/Blossom/Default/BlossomDefault01_R02.Default__BlossomDefault01_R02_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Blossom/Default/BlossomDefault01_R02.Default__BlossomDefault01_R02_C.SessionData.Lines(0).Lines
 msgctxt ",9AF5988A4B6D8F174F3241B67F4033C8"
 msgid "Blossom!"
-msgstr "¡Flor!"
+msgstr "¡Blossom!"
 
 #. Key:	9B115CE5485736847F748591F0C8FB2A
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToMale(3).LinesToMale
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToMale(3).LinesToMale
 msgctxt ",9B115CE5485736847F748591F0C8FB2A"
 msgid "All have been pleasurable and delicious... but oh have I wanted something more..."
-msgstr "Todos han sido placenteros y deliciosos... pero he querido algo más..."
+msgstr "Todos han sido placenteros y deliciosos... pero oh, he querido algo más..."
 
 #. Key:	9B2F56474FA9D82EE9F76EBEB5723F74
 #. SourceLocation:	/Game/Dialogue/Fern/SexScenes/FernCum_01.Default__FernCum_01_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Fern/SexScenes/FernCum_01.Default__FernCum_01_C.SessionData.Lines(4).Lines
 msgctxt ",9B2F56474FA9D82EE9F76EBEB5723F74"
 msgid "Hiss... Fern like this... much pleasure, taste is good."
-msgstr "Ssss... Helecho gustar esto... mucho placer, sabor es bueno."
+msgstr "Sss... Fern gustar esto... mucho placer, sabor es bueno."
 
 #. Key:	9B3D729A40A0E93316F524B863B2BAED
 #. SourceLocation:	/Game/Characters/Procedural/Variants/Neko/Harvest/NekoHarvest.Default__NekoHarvest_C.Harvest.RaceName
@@ -8453,28 +8505,28 @@ msgstr "Serafín"
 #: /Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToMale(0).LinesToMale
 msgctxt ",9B8AE2F943E1AF24641C2BB8C4C41176"
 msgid "Ohhhh your dick! Finally!"
-msgstr "¡Ohhhh tu polla! ¡Finalmente!"
+msgstr "¡Ohhhh, tu pene! ¡Por fin!"
 
 #. Key:	9BCB9BF649F84B0314EFF688539A52A5
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeGreeting01.Default__BeeGreeting01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/QueenBee/Default/BeeGreeting01.Default__BeeGreeting01_C.SessionData.Lines(0).Lines
 msgctxt ",9BCB9BF649F84B0314EFF688539A52A5"
 msgid "Kneel before your queen... ahhh.... ohhh..."
-msgstr ""
+msgstr "Arrodíllate ante tu reina... ahhh... ohhh..."
 
 #. Key:	9BD2015749AE3D2CD457DDB2CBC112F4
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleGreeting01.Default__KybeleGreeting01_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Kybele/Default/KybeleGreeting01.Default__KybeleGreeting01_C.SessionData.Lines(2).Lines
 msgctxt ",9BD2015749AE3D2CD457DDB2CBC112F4"
 msgid "The offspring of the Dragon Matriarch will be protected by any means necessary."
-msgstr ""
+msgstr "La descendencia de la Matriarca Dragón estará protegida por todos los medios necesarios."
 
 #. Key:	9BDBC0EB4511337E7515C89A6620BBA0
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeHadSex01.Default__AmberMaeHadSex01_C.SessionData.LinesToFemale(3).LinesToFemale
 #: /Game/Dialogue/AmberMae/Default/AmberMaeHadSex01.Default__AmberMaeHadSex01_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",9BDBC0EB4511337E7515C89A6620BBA0"
 msgid "Come back and drink up anytime."
-msgstr ""
+msgstr "Vuelve y bebe en cualquier momento."
 
 #. Key:	9BF2AD09410781A66302329DB25BA0EC
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_Forgot.Default__ParvatiDefault01_Forgot_C.SessionData.Lines(5).Lines
@@ -8488,77 +8540,77 @@ msgstr "Mientras medito, todo lo que quiero es hacer el amor contigo."
 #: /Game/Dialogue/DragonMatriarch/Default/DMYourChildren.Default__DMYourChildren_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",9C0628944A08387197D344B7CBC502FB"
 msgid "The dragon race will reign supreme over all of @WORLD_NAME@!"
-msgstr ""
+msgstr "¡La raza dragón reinará sobre todo @WORLD_NAME@!"
 
 #. Key:	9C25CF834B78D0D105D4C98D2D869441
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiHadSex01.Default__FesssiHadSex01_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/Fesssi/Default/FesssiHadSex01.Default__FesssiHadSex01_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",9C25CF834B78D0D105D4C98D2D869441"
 msgid "Sssso tasty. Hiss!"
-msgstr ""
+msgstr "Tan ssssabroso. ¡Sss!"
 
 #. Key:	9C2CBDE44BB47D22C9F6A5AFB2316748
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcDefault01.Default__OrcDefault01_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcDefault01.Default__OrcDefault01_C.SessionData.Lines(3).Lines
 msgctxt ",9C2CBDE44BB47D22C9F6A5AFB2316748"
 msgid "Grrr! Do it or you will breed with me now."
-msgstr ""
+msgstr "¡Grrr! Hazlo o te reproducirás conmigo ahora."
 
 #. Key:	9C3FDDD5490B3180DDD3329C692C0B4D
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R01.Default__CamillaDefault01_R01_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R01.Default__CamillaDefault01_R01_C.SessionData.Lines(3).Lines
 msgctxt ",9C3FDDD5490B3180DDD3329C692C0B4D"
 msgid "The fastest way is to sex them into submission, just use what's between your legs human!"
-msgstr "La forma más rápida es tener sexo con ellos para someterlos, ¡solo usa lo que está entre tus piernas humana!"
+msgstr "La forma más rápida es tener sexo con ellos hasta someterlos, ¡solo usa lo que está entre tus piernas humano!"
 
 #. Key:	9C7CF64D42692442A687709D5C22BB3D
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeLikesPresent.Default__MegaSlimeLikesPresent_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeLikesPresent.Default__MegaSlimeLikesPresent_C.SessionData.Lines(0).Lines
 msgctxt ",9C7CF64D42692442A687709D5C22BB3D"
 msgid "The pearl you gave me is wonderful, I love it."
-msgstr ""
+msgstr "La perla que me diste es maravillosa, me encanta."
 
 #. Key:	9CA55551425FE9DE83AB5B9535E62AFC
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadDefault01_RL.Default__DryadDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/Autumn/Default/DryadDefault01_RL.Default__DryadDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",9CA55551425FE9DE83AB5B9535E62AFC"
 msgid "Tell me about dryads!"
-msgstr ""
+msgstr "¡Háblame de las dríadas!"
 
 #. Key:	9CB6C5E14DD6C412AD7898B8D2120925
 #. SourceLocation:	/Game/UI/TaskDescriptions.TaskDescriptions.TextEntries(8).TextEntries
 #: /Game/UI/TaskDescriptions.TaskDescriptions.TextEntries(8).TextEntries
 msgctxt ",9CB6C5E14DD6C412AD7898B8D2120925"
 msgid "Having fins makes moving on dry land challenging. Would you breed me a loveable Nephelym that can fetch things around town? I suppose it doesn't HAVE to be attractive... though if you could... just in case.  -Romy"
-msgstr ""
+msgstr "Tener aletas hace que moverse en tierra firme sea un desafío. ¿Me criarías un adorable Nephelym que pueda ir a buscar cosas por la ciudad? Supongo que no TIENE que ser atractivo... aunque si pudieras... por si acaso. -Romy"
 
 #. Key:	9D593DC94FAA9CCF2CB35CBA7EA06A73
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToMale(2).LinesToMale
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToMale(2).LinesToMale
 msgctxt ",9D593DC94FAA9CCF2CB35CBA7EA06A73"
 msgid "I have experienced @MONSTER_RACE@ dick and vagina beyond comprehension."
-msgstr "He experimentado polla y vagina @MONSTER_RACE@ más allá de la comprensión."
+msgstr "He experimentado el pene y la vagina @MONSTER_RACE@ más allá de la comprensión."
 
 #. Key:	9D875449461B56179F1FE9A457741C3B
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiDefault03_RL_T.Default__FesssiDefault03_RL_T_C.ResponseData(2).ResponseData.BreederPrompt
 #: /Game/Dialogue/Fesssi/Default/FesssiDefault03_RL_T.Default__FesssiDefault03_RL_T_C.ResponseData(2).ResponseData.BreederPrompt
 msgctxt ",9D875449461B56179F1FE9A457741C3B"
 msgid "Where does that cave lead?"
-msgstr ""
+msgstr "¿A dónde lleva esa cueva?"
 
 #. Key:	9DCE82F542FEDB443D7432A9C8EE7AF6
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleDefault01_RL.Default__KybeleDefault01_RL_C.ResponseData(3).ResponseData.BreederPrompt
 #: /Game/Dialogue/Kybele/Default/KybeleDefault01_RL.Default__KybeleDefault01_RL_C.ResponseData(3).ResponseData.BreederPrompt
 msgctxt ",9DCE82F542FEDB443D7432A9C8EE7AF6"
 msgid "By any means necessary..."
-msgstr ""
+msgstr "Por cualquier medio necesario..."
 
 #. Key:	9E0F2A7F4F6510D820FB12BE4580D421
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_EnlightenedOne.Default__NeelaDefault01_EnlightenedOne_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_EnlightenedOne.Default__NeelaDefault01_EnlightenedOne_C.SessionData.Lines(3).Lines
 msgctxt ",9E0F2A7F4F6510D820FB12BE4580D421"
 msgid "She is kind and loving, you will experience untold pleasures... trust me."
-msgstr ""
+msgstr "Ella es amable y cariñosa, experimentarás placeres incalculables... confía en mí."
 
 #. Key:	9E15F19C4964C11243C2BE906C8DB6C9
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_RL.Default__EmissaryDefault01_RL_C.ResponseData(3).ResponseData.BreederPrompt
@@ -8579,119 +8631,123 @@ msgstr "Muéstrame tus productos lácteos."
 #: /Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToFuta(0).LinesToFuta
 msgctxt ",9E5B0BA14AE1E009AC9A5BA4D423863D"
 msgid "Ohhh how I have waited to wrap my soft lips around a human dick! Ahhh..."
-msgstr "¡Oh, cómo he esperado para envolver mis suaves labios alrededor de una polla humana! Ahhh..."
+msgstr "¡Ohhh, cómo he esperado para envolver mis suaves labios alrededor de un pene humano! Ahhh..."
 
 #. Key:	9E8424C246BEBF834649DAABF8B5CD18
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_RL.Default__EmissaryDefault01_RL_C.ResponseData(7).ResponseData.BreederPrompt
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_RL.Default__EmissaryDefault01_RL_C.ResponseData(7).ResponseData.BreederPrompt
 msgctxt ",9E8424C246BEBF834649DAABF8B5CD18"
 msgid "How do I open the stone gates?"
-msgstr ""
+msgstr "¿Cómo abro los portones de piedra?"
 
 #. Key:	9E8C52C446FF788D61D6B98D9189D88D
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFuta(3).LinesToFuta
 #: /Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFuta(3).LinesToFuta
 msgctxt ",9E8C52C446FF788D61D6B98D9189D88D"
 msgid "Maybe between my fat ass cheeks?"
-msgstr ""
+msgstr "¿Quizás entre mis gordas mejillas del culo?"
 
 #. Key:	9EB1E11442BB00388C518B8B9CDC9A62
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiDefault01.Default__FesssiDefault01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiDefault01.Default__FesssiDefault01_C.SessionData.Lines(1).Lines
 msgctxt ",9EB1E11442BB00388C518B8B9CDC9A62"
 msgid "But it's time for a change... time to once again roam the surface in search of pleasure."
-msgstr ""
+msgstr "Pero es hora de un cambio... hora de vagar una vez más por la superficie en busca de placer."
 
 #. Key:	9ECA418E4EC2E9617CD48B82C43CB5FA
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(2 - Value).TraitIcons.HelpText
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(2 - Value).TraitIcons.HelpText
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(2 -
+#: Value).TraitIcons.HelpText
 msgctxt ",9ECA418E4EC2E9617CD48B82C43CB5FA"
 msgid "Huge: Roughly 10ft in height."
-msgstr "Enorme: Aproximadamente 3m de altura."
+msgstr "Enorme: aproximadamente 10 pies (3 m) de altura."
 
 #. Key:	9ECDE7F64C28F7F9624081B927CA3030
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadAboutDryads.Default__DryadAboutDryads_C.SessionData.Lines(8).Lines
 #: /Game/Dialogue/Autumn/Default/DryadAboutDryads.Default__DryadAboutDryads_C.SessionData.Lines(8).Lines
 msgctxt ",9ECDE7F64C28F7F9624081B927CA3030"
 msgid "Compared to other Alraunes, dryads are wise and mobile. We use our pleasure to help others."
-msgstr ""
+msgstr "En comparación con otras alraunes, las dríadas son sabias y móviles. Usamos nuestro placer para ayudar a los demás."
 
 #. Key:	9EEBDB0446F2AAFA8F605E8A3DE83534
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_YourMusic.Default__RomyDefault01_YourMusic_C.SessionData.LinesToFuta(2).LinesToFuta
 #: /Game/Dialogue/Romy/Default/RomyDefault01_YourMusic.Default__RomyDefault01_YourMusic_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",9EEBDB0446F2AAFA8F605E8A3DE83534"
 msgid "Your face will know the sweet melody of my soft large breasts."
-msgstr "Tu cara sabrá la dulce melodía de mis senos grandes y suaves."
+msgstr "Tu rostro conocerá la dulce melodía de mis suaves y grandes pechos."
 
 #. Key:	9EEFE8B54303A99BB5053CA7F7960A23
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.FormurianPond.ManageActionMessage
 #: /Game/World/Overworld.Overworld:PersistentLevel.FormurianPond.ManageActionMessage
 msgctxt ",9EEFE8B54303A99BB5053CA7F7960A23"
 msgid "Manage your Formurians"
-msgstr "Gestiona tus Formurianas"
+msgstr "Gestiona tus Formurians"
 
 #. Key:	9F2120194C14A491202338AEB2C05883
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieHadSex01.Default__CassieHadSex01_C.SessionData.LinesToFuta(5).LinesToFuta
 #: /Game/Dialogue/Cassie/Default/CassieHadSex01.Default__CassieHadSex01_C.SessionData.LinesToFuta(5).LinesToFuta
 msgctxt ",9F2120194C14A491202338AEB2C05883"
 msgid "I want to release again already... you humans have it so easy."
-msgstr ""
+msgstr "Quiero descargar de nuevo ya... vosotros, los humanos, lo tieneis muy fácil."
 
 #. Key:	9F25BEB847378BA942933C8A503B4F1A
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(22 - Value).TraitIcons.HelpText
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(22 - Value).TraitIcons.HelpText
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(22 -
+#: Value).TraitIcons.HelpText
 msgctxt ",9F25BEB847378BA942933C8A503B4F1A"
 msgid "Swift: Dexterity reduces lust cost of actions as a percentage."
-msgstr "Rápida/o: La destreza reduce el costo de las acciones como porcentaje."
+msgstr "Rápido: la Destreza reduce el coste de lujuria de las acciones como un porcentaje."
 
 #. Key:	9F7E04704B60E2F2EC07E9B3308B36FE
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(36 - Value).TraitIcons.HelpText
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(36 - Value).TraitIcons.HelpText
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(36 -
+#: Value).TraitIcons.HelpText
 msgctxt ",9F7E04704B60E2F2EC07E9B3308B36FE"
 msgid "Surprise: This one was the product of surprise sex."
-msgstr ""
+msgstr "Sorpresa: este fue el producto del sexo sorpresa."
 
 #. Key:	9F82F5BC4976131C6A3861A1CAF32EFA
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMGrasslandsTrees.Default__DMGrasslandsTrees_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMGrasslandsTrees.Default__DMGrasslandsTrees_C.SessionData.Lines(1).Lines
 msgctxt ",9F82F5BC4976131C6A3861A1CAF32EFA"
 msgid "Yeah... I suppose you're right though."
-msgstr ""
+msgstr "Sí... supongo que tienes razón."
 
 #. Key:	9F83DE504D98E2D4C149568C1F8DE768
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(4 - Value).TraitIcons.HelpText
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(4 - Value).TraitIcons.HelpText
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(4 -
+#: Value).TraitIcons.HelpText
 msgctxt ",9F83DE504D98E2D4C149568C1F8DE768"
 msgid "Massive: Roughly 15ft in height."
-msgstr "Gigante: Aproximadamente 4,5m de altura."
+msgstr "Inmenso: aproximadamente 15 pies (4,5 m) de altura."
 
 #. Key:	9F883FFA4CA5D4B34A5726989E26C6C5
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleTittyPony_T.Default__KybeleTittyPony_T_C.SessionData.LinesToFuta(0).LinesToFuta
 #: /Game/Dialogue/Kybele/Default/KybeleTittyPony_T.Default__KybeleTittyPony_T_C.SessionData.LinesToFuta(0).LinesToFuta
 msgctxt ",9F883FFA4CA5D4B34A5726989E26C6C5"
 msgid "That's it human, you have annoyed me long enough. Get against that rock and prepare to be smashed."
-msgstr ""
+msgstr "Eso es humano, me has molestado lo suficiente. Ponte contra esa roca y prepárate para ser aplastado."
 
 #. Key:	9F8F75924886323A16353D90FDCB1B1C
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernBeeFlowers.Default__FernBeeFlowers_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Fern/Default/FernBeeFlowers.Default__FernBeeFlowers_C.SessionData.Lines(0).Lines
 msgctxt ",9F8F75924886323A16353D90FDCB1B1C"
 msgid "Queen Bee?"
-msgstr ""
+msgstr "¿Abeja Reina?"
 
 #. Key:	9F98C71B4D9DFE442CACEAAB6F21EB92
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeGreeting01.Default__MegaSlimeGreeting01_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeGreeting01.Default__MegaSlimeGreeting01_C.SessionData.Lines(5).Lines
 msgctxt ",9F98C71B4D9DFE442CACEAAB6F21EB92"
 msgid "We can be friends too! Why don't you stay and play in my slime?"
-msgstr ""
+msgstr "¡Nosotros también podemos ser amigos! ¿Por qué no te quedas y juegas en mi limo?"
 
 #. Key:	9F9D5BEE4F26E405A81EB09066622552
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_FloatRhyme.Default__ParvatiDefault01_FloatRhyme_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_FloatRhyme.Default__ParvatiDefault01_FloatRhyme_C.SessionData.Lines(4).Lines
 msgctxt ",9F9D5BEE4F26E405A81EB09066622552"
 msgid "Eons in Her embrace have taught me bodily forms."
-msgstr "Eones en su abrazo me han enseñado corporales formas."
+msgstr "Eones en Su abrazo me han enseñado formas corporales."
 
 #. Key:	9FAD5CA34B7A4B192E688C9C72A825B3
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R06.Default__FaleneDefault01_R06_C.SessionData.Lines(1).Lines
@@ -8705,56 +8761,56 @@ msgstr "Según la suma sacerdotisa Leylana en el templo, la Diosa y sus ángeles
 #: /Game/Dialogue/OrcChief/Default/OrcWantWrestle.Default__OrcWantWrestle_C.SessionData.Lines(1).Lines
 msgctxt ",9FE3B8C04B35B846B4CFB99902294CDE"
 msgid "I knew human liked feeling this mighty body."
-msgstr ""
+msgstr "Sabía que a los humanos les gustaba sentir este poderoso cuerpo."
 
 #. Key:	9FE7AADC4372F0B32E971C838E6554EA
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(20).LinesToFemale
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(20).LinesToFemale
 msgctxt ",9FE7AADC4372F0B32E971C838E6554EA"
 msgid "Since you're a breeder, it's your job to catch and mate as many @MONSTER_RACE@ as possible!"
-msgstr "¡Ya que eres una criadora, es tu trabajo atrapar y aparear tantos @MONSTER_RACE@ como sea posible!"
+msgstr "Ya que eres un criador, ¡es tu trabajo atrapar y aparearte con tantos @MONSTER_RACE@ como sea posible!"
 
 #. Key:	9FF8B7CE43E6A9321DDB60919962BBB7
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(17).LinesToMale
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(17).LinesToMale
 msgctxt ",9FF8B7CE43E6A9321DDB60919962BBB7"
 msgid "Grrrr... hehehe... must control myself!"
-msgstr "Grrrr... jejeje... ¡debo controlarme!"
+msgstr "Grrrr… jejeje... ¡debo controlarme!"
 
 #. Key:	A01964EC4E78EA32585A688D940B9FCC
 #. SourceLocation:	/Game/Characters/Procedural/Variants/Formurian/Harvest/FormurianHarvest.Default__FormurianHarvest_C.Harvest.Description
 #: /Game/Characters/Procedural/Variants/Formurian/Harvest/FormurianHarvest.Default__FormurianHarvest_C.Harvest.Description
 msgctxt ",A01964EC4E78EA32585A688D940B9FCC"
 msgid "Formurian body fluids."
-msgstr "Fluidos corporales de Formuriana."
+msgstr "Fluidos corporales de Formurian."
 
 #. Key:	A028577648369DBF41FFC6B04A76C3FA
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(5).LinesToFemale
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(5).LinesToFemale
 msgctxt ",A028577648369DBF41FFC6B04A76C3FA"
 msgid "Oh silly me, I never introduced myself."
-msgstr "Oh tonta yo, nunca me presenté."
+msgstr "Oh, tonta de mí, nunca me presenté."
 
 #. Key:	A084B03140D9C320BD31DCA76ED4873F
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaOldTempleDungeon.Default__LeylannaOldTempleDungeon_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Leylanna/Default/LeylannaOldTempleDungeon.Default__LeylannaOldTempleDungeon_C.SessionData.Lines(3).Lines
 msgctxt ",A084B03140D9C320BD31DCA76ED4873F"
 msgid "There's something under this temple?"
-msgstr ""
+msgstr "¿Hay algo debajo de este templo?"
 
 #. Key:	A0B0E60C4AD4856B54C5298236CC5BC3
 #. SourceLocation:	/Game/Ranch/Upgrades/MuttHut.Default__MuttHut_C.Upgrade.DisplayName
 #: /Game/Ranch/Upgrades/MuttHut.Default__MuttHut_C.Upgrade.DisplayName
 msgctxt ",A0B0E60C4AD4856B54C5298236CC5BC3"
 msgid "Mutt Hut"
-msgstr "Cabaña de Híbridas"
+msgstr "Choza de Híbridos"
 
 #. Key:	A0B57F5941F9CAEBBB30CF828C3E26AC
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R01.Default__FaleneDefault01_R01_C.SessionData.Lines(12).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R01.Default__FaleneDefault01_R01_C.SessionData.Lines(12).Lines
 msgctxt ",A0B57F5941F9CAEBBB30CF828C3E26AC"
 msgid "This begs the question though, can we reproduce with you humans? All my research says yes!"
-msgstr "Sin embargo, esto plantea la pregunta: ¿podemos reproducirnos con vosotros humanos? ¡Toda mi investigación dice que sí!"
+msgstr "Sin embargo, esto plantea la pregunta, ¿podemos reproducirnos con vosotros, humanos? ¡Toda mi investigación dice que sí!"
 
 #. Key:	A0DC38DD454D19C4375D3CAADA8796AA
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_RL_T.Default__FernDefault02_RL_T_C.ResponseData(2).ResponseData.BreederPrompt
@@ -8768,28 +8824,28 @@ msgstr "¿Qué puedes hacer?"
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePlay1.Default__MegaSlimePlay1_C.SessionData.LinesToFuta(1).LinesToFuta
 msgctxt ",A1243ACB4057D3CAD0A25787BA4DF627"
 msgid "I think... you might be my best friend of all time."
-msgstr ""
+msgstr "Creo que... podrías ser mi mejor amigo de todos los tiempos."
 
 #. Key:	A12A50F34FE88A004CB5458C982B3915
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(16).LinesToFemale
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(16).LinesToFemale
 msgctxt ",A12A50F34FE88A004CB5458C982B3915"
 msgid "I want to feel your soft breasts... on top of mine... ahhh."
-msgstr "Quiero sentir tus senos suaves... encima de los míos... ahhh."
+msgstr "Quiero sentir tus suaves pechos... encima de los míos... ahhh."
 
 #. Key:	A208709240369AEC212F70B1CEFE7BE8
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaGreeting01.Default__LeylannaGreeting01_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Leylanna/Default/LeylannaGreeting01.Default__LeylannaGreeting01_C.SessionData.Lines(3).Lines
 msgctxt ",A208709240369AEC212F70B1CEFE7BE8"
 msgid "Let us make love to form a covenant in Her holy temple, and you can meet your spirit form."
-msgstr "Hagamos el amor para formar un pacto en su templo sagrado, y podrás encontrar tu forma espiritual."
+msgstr "Hagamos el amor para formar un convenio en Su santo templo, y podrás encontrar tu forma espiritual."
 
 #. Key:	A21511DE4632808A0555608E6F6880C6
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowScary.Default__WidowScary_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Widow/Default/WidowScary.Default__WidowScary_C.SessionData.Lines(2).Lines
 msgctxt ",A21511DE4632808A0555608E6F6880C6"
 msgid "Oh how I did... for nothing pleases a lonely spider more."
-msgstr ""
+msgstr "Oh, cómo lo hice... porque nada agrada más a una araña solitaria."
 
 #. Key:	A257204E40613ED62BA7D982059BC6E7
 #. SourceLocation:	/Game/Ranch/Upgrades/SeraphimLoft.Default__SeraphimLoft_C.Upgrade.TypeDisplay
@@ -8803,14 +8859,14 @@ msgstr "Granero de Nephelym"
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(28).LinesToFemale
 msgctxt ",A2DA50B44D0A24E096AF488F787D4928"
 msgid "Well I must be off, good luck breeder!"
-msgstr "Bueno, debo irme, ¡buena suerte criadora!"
+msgstr "Bueno, debo irme, ¡buena suerte criador!"
 
 #. Key:	A2EE900942F55DC4C6AA92BC44E482E4
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R03.Default__CamillaDefault01_R03_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R03.Default__CamillaDefault01_R03_C.SessionData.Lines(2).Lines
 msgctxt ",A2EE900942F55DC4C6AA92BC44E482E4"
 msgid "Most dicks in this world are larger than me! As someone who collects and studies cum, you can't imagine how miserable it is stroking dick after dick and never being able to feel them penetrate me."
-msgstr "¡La mayoría de las pollas en este mundo son más grandes que yo! Como alguien que recolecta y estudia semen, no te puedes imaginar lo miserable que es acariciar polla tras polla y nunca ser capaz de sentirlas penetrándome."
+msgstr "¡La mayoría de las pollas de este mundo son más grandes que yo! Como alguien que recolecta y estudia semen, no te imaginas lo miserable que es acariciar un pene tras otro y nunca pudiendo sentirlos penetrarme."
 
 #. Key:	A350122B4286C7BCFA490982F8390CB1
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieGreeting01.Default__CassieGreeting01_C.SessionData.Lines(2).Lines
@@ -8824,133 +8880,134 @@ msgstr "¿Rancho? ¡Ah claro, y tu rancho también!"
 #: /Game/Dialogue/OrcChief/Default/OrcGoneWorse.Default__OrcGoneWorse_C.SessionData.Lines(1).Lines
 msgctxt ",A3546DAB440D5D09BE7F809541FB90C3"
 msgid "Chieftain very horny, you will regret this. Come here!"
-msgstr ""
+msgstr "Cacique muy cachonda, te arrepentirás de esto. ¡Ven aquí!"
 
 #. Key:	A3A36F6A453B245F5CA58C97B791509D
 #. SourceLocation:	/Game/Dialogue/Cassie/SexScenes/CassieButterButtF.Default__CassieButterButtF_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Cassie/SexScenes/CassieButterButtF.Default__CassieButterButtF_C.SessionData.Lines(0).Lines
 msgctxt ",A3A36F6A453B245F5CA58C97B791509D"
 msgid "Ohhh... soft human pussy feels amazing!"
-msgstr "Ohhh… ¡suave coño humano se siente increíble!"
+msgstr "Ohhh... ¡el suave coño humano se siente increíble!"
 
 #. Key:	A3D34227454452C74EC9BEBE9D5B4A17
 #. SourceLocation:	/Game/Dialogue/Fern/SexScenes/FernMilk_01.Default__FernMilk_01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Fern/SexScenes/FernMilk_01.Default__FernMilk_01_C.SessionData.Lines(0).Lines
 msgctxt ",A3D34227454452C74EC9BEBE9D5B4A17"
 msgid "Mastah's breast so soft! Fern like it."
-msgstr "¡El pecho de Maeztra es tan suave! A Helecho gustarle."
+msgstr "¡El pecho de Mastah tan suave! A Fern gustarle."
 
 #. Key:	A40264BD4BB3E658212ECE987CC24B4A
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_Teach.Default__ParvatiDefault01_Teach_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_Teach.Default__ParvatiDefault01_Teach_C.SessionData.Lines(2).Lines
 msgctxt ",A40264BD4BB3E658212ECE987CC24B4A"
 msgid "Don't worry, for I can change my size."
-msgstr "No te preocupes, porque puedo cambiar mi talla."
+msgstr "No te preocupes, porque puedo cambiar mi tamaño."
 
 #. Key:	A41D55094C37585E241DB98D76B52F65
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToFemale(6).LinesToFemale
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToFemale(6).LinesToFemale
 msgctxt ",A41D55094C37585E241DB98D76B52F65"
 msgid "If that doesn't suit you, I could put my slime in other places..."
-msgstr ""
+msgstr "Si eso no te conviene, podría poner mi limo en otros lugares..."
 
 #. Key:	A4367C3445DA16F7A5FC4584F73685FA
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01.Default__NeelaDefault01_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Neela/Default/NeelaDefault01.Default__NeelaDefault01_C.SessionData.Lines(2).Lines
 msgctxt ",A4367C3445DA16F7A5FC4584F73685FA"
 msgid "Perhaps, you care to experience what's in front of you now?"
-msgstr "¿Tal vez te importe experimentar lo que está frente a ti ahora?"
+msgstr "Quizás, ¿te gustaría experimentar lo que tienes frente a ti ahora?"
 
 #. Key:	A49D87C0482481404A2CD39993C62A1F
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieGreeting01.Default__CassieGreeting01_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Cassie/Default/CassieGreeting01.Default__CassieGreeting01_C.SessionData.Lines(4).Lines
 msgctxt ",A49D87C0482481404A2CD39993C62A1F"
 msgid "Don' matter now, that ranch's been like that for ages."
-msgstr "Da igual ahora, ese rancho ha sido así desde hace tiempo."
+msgstr "Ahora no importa, ese rancho ha sido así desde hace tiempo."
 
 #. Key:	A4A671C24CE09EFBA18364BA3C0F94EB
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraAboutPawsmaati.Default__PetraAboutPawsmaati_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Petra/Default/PetraAboutPawsmaati.Default__PetraAboutPawsmaati_C.SessionData.Lines(1).Lines
 msgctxt ",A4A671C24CE09EFBA18364BA3C0F94EB"
 msgid "Pawsmaati is ancient, much older than me or anyone else I've met."
-msgstr ""
+msgstr "Pawsmaati es anciana, mucho mayor que yo o cualquier otra persona que haya conocido."
 
 #. Key:	A4B99F3C407E9C094C137DAF9E60A51F
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowHadSex01.Default__WidowHadSex01_C.SessionData.LinesGrungy(0).LinesGrungy
 #: /Game/Dialogue/Widow/Default/WidowHadSex01.Default__WidowHadSex01_C.SessionData.LinesGrungy(0).LinesGrungy
 msgctxt ",A4B99F3C407E9C094C137DAF9E60A51F"
 msgid "Oh you dirty dirty human... what have you done to yourself?"
-msgstr ""
+msgstr "Oh, sucio, sucio humano... ¿Qué te has hecho a ti mismo?"
 
 #. Key:	A4C22B3045E8159B66E47CB636E23172
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(18 - Value).TraitIcons.DisplayName
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(18 - Value).TraitIcons.DisplayName
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(18 -
+#: Value).TraitIcons.DisplayName
 msgctxt ",A4C22B3045E8159B66E47CB636E23172"
 msgid "Nurturing"
-msgstr "Acogedor/a"
+msgstr "Crianza"
 
 #. Key:	A4D2B8DD4CBF1E0294D5918B75F17CB7
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchDefault01.Default__MonarchDefault01_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/Monarch/Default/MonarchDefault01.Default__MonarchDefault01_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",A4D2B8DD4CBF1E0294D5918B75F17CB7"
 msgid "This corner is n-n-nice and safe!"
-msgstr ""
+msgstr "¡Este rincón es a-a-agradable y seguro!"
 
 #. Key:	A4E670824F11C45EC16FA29BAF6EB6E1
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R02.Default__CamillaDefault01_R02_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R02.Default__CamillaDefault01_R02_C.SessionData.Lines(3).Lines
 msgctxt ",A4E670824F11C45EC16FA29BAF6EB6E1"
 msgid "Bovaur can be found sleeping in the soft grass of Pleasure Pastures."
-msgstr "Bovaur se puede encontrar durmiendo en la suave hierba de los Pastos del Placer."
+msgstr "Se puede encontrar a bovaur durmiendo en la suave hierba de los Pastos del Placer."
 
 #. Key:	A4F79CC74333E2131FC34EBBF3796A56
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchDefault01.Default__MonarchDefault01_C.SessionData.LinesToFemale(2).LinesToFemale
 #: /Game/Dialogue/Monarch/Default/MonarchDefault01.Default__MonarchDefault01_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",A4F79CC74333E2131FC34EBBF3796A56"
 msgid "Good thing I have my toy!"
-msgstr ""
+msgstr "¡Menos mal que tengo mi juguete!"
 
 #. Key:	A5496AE246B786D1E975C6A2F4004B43
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMGreeting01.Default__DMGreeting01_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMGreeting01.Default__DMGreeting01_C.SessionData.Lines(3).Lines
 msgctxt ",A5496AE246B786D1E975C6A2F4004B43"
 msgid "That useless titty pony failed again I see. She will feel my wrath."
-msgstr ""
+msgstr "Veo que esa pony tetudita inútil falló de nuevo. Ella sentirá mi ira."
 
 #. Key:	A56B0F264A329DF192CE53B3DBA118EB
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiWantAss.Default__FesssiWantAss_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiWantAss.Default__FesssiWantAss_C.SessionData.Lines(2).Lines
 msgctxt ",A56B0F264A329DF192CE53B3DBA118EB"
 msgid "You are really going to enjoy thissss!"
-msgstr ""
+msgstr "¡Realmente vass a disfrutar de essssto!"
 
 #. Key:	A58134D54AF7A503EDA75C88BD1471C1
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraDefault01.Default__PetraDefault01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Petra/Default/PetraDefault01.Default__PetraDefault01_C.SessionData.Lines(1).Lines
 msgctxt ",A58134D54AF7A503EDA75C88BD1471C1"
 msgid "I can't wait until my next lesson with Pawsmaati!"
-msgstr ""
+msgstr "¡No puedo esperar hasta mi próxima lección con Pawsmaati!"
 
 #. Key:	A59547D94C2E8733CA14998734EBC002
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMWantHuman.Default__DMWantHuman_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMWantHuman.Default__DMWantHuman_C.SessionData.Lines(0).Lines
 msgctxt ",A59547D94C2E8733CA14998734EBC002"
 msgid "Haha! You joke human, my genitals are too big for you."
-msgstr ""
+msgstr "¡Jaja! Bromeas humano, mis genitales son demasiado grandes para ti."
 
 #. Key:	A5B9250C4C49694C624437927A399459
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeHaveKeystone1.Default__BeeHaveKeystone1_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/QueenBee/Default/BeeHaveKeystone1.Default__BeeHaveKeystone1_C.SessionData.Lines(2).Lines
 msgctxt ",A5B9250C4C49694C624437927A399459"
 msgid "Ohhh! Ahhh... that was a good one."
-msgstr ""
+msgstr "¡Ohhh! Ahhh... esa fue una buena."
 
 #. Key:	A5C9D438443FEDCB4CF41985385B02E1
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiStuck.Default__FesssiStuck_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiStuck.Default__FesssiStuck_C.SessionData.Lines(4).Lines
 msgctxt ",A5C9D438443FEDCB4CF41985385B02E1"
 msgid "Such is how I learned of my buxom genetics, few blessed ones possess the trait and it is highly coveted."
-msgstr ""
+msgstr "Así es como me enteré de mi genética exuberante, pocos benditos poseen el rasgo y es muy codiciado."
 
 #. Key:	A6D19C3141AF406B6318CA8CB0A72613
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R02.Default__FaleneDefault01_R02_C.SessionData.Lines(0).Lines
@@ -8964,7 +9021,7 @@ msgstr "¡Eso es lo que soy!"
 #: /Game/Dialogue/Mirru/Default/MirruGreeting01.Default__MirruGreeting01_C.SessionData.Lines(1).Lines
 msgctxt ",A6DD5AA2419F165755885E8ED44BB09B"
 msgid "You are lucky, for today you have crossed paths with the Kraken princess of Formuria."
-msgstr "Tienes suerte, porque hoy te has cruzado con la princesa Kraken de Formuria."
+msgstr "Tienes suerte, porque hoy te has cruzado con la princesa kraken de Formuria."
 
 #. Key:	A6EE239344DA6CC08AFE6E8689A1996F
 #. SourceLocation:	/Game/Dialogue/Neela/SexScenes/NeelaSnakeCuddleF.Default__NeelaSnakeCuddleF_C.SessionData.Lines(1).Lines
@@ -8992,21 +9049,21 @@ msgstr "Oh no, no otra vez..."
 #: /Game/Dialogue/Romy/Default/RomyDefault01_RL.Default__RomyDefault01_RL_C.ResponseData(3).ResponseData.BreederPrompt
 msgctxt ",A7310E5A43F60121BD9352B96FBB8369"
 msgid "How did you get up here?"
-msgstr "¿Cómo llegaste aquí arriba?"
+msgstr "¿Cómo subiste hasta aquí?"
 
 #. Key:	A77C67204806B8B31933BD9C7A4C5C54
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeUhNo.Default__BeeUhNo_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/QueenBee/Default/BeeUhNo.Default__BeeUhNo_C.SessionData.Lines(0).Lines
 msgctxt ",A77C67204806B8B31933BD9C7A4C5C54"
 msgid "Such... ahhh... deviance..."
-msgstr ""
+msgstr "Tal... ahhh... desviación..."
 
 #. Key:	A794490B471FFA8A958C3BA3B3BFDB9C
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchDefault01_RL.Default__MonarchDefault01_RL_C.ResponseData(3).ResponseData.BreederPrompt
 #: /Game/Dialogue/Monarch/Default/MonarchDefault01_RL.Default__MonarchDefault01_RL_C.ResponseData(3).ResponseData.BreederPrompt
 msgctxt ",A794490B471FFA8A958C3BA3B3BFDB9C"
 msgid "How adorable, may I have the keystone now?"
-msgstr ""
+msgstr "Qué adorable, ¿puedo tener la piedra-llave ahora?"
 
 #. Key:	A7C8404E4B6C68006478148076380602
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R01.Default__FaleneDefault01_R01_C.SessionData.Lines(14).Lines
@@ -9020,28 +9077,28 @@ msgstr "Supongo que cuando uno de los compañeros es humano, la mitad @MONSTER_R
 #: /Game/Dialogue/Monarch/Default/MonarchTaskFulfilled.Default__MonarchTaskFulfilled_C.SessionData.Lines(1).Lines
 msgctxt ",A7E400D84D8F2911F46A3BA5FBA020A8"
 msgid "My nectar collection has grown considerably, and the wild ones around here can't keep up."
-msgstr ""
+msgstr "Mi colección de néctar ha crecido considerablemente, y los silvestres por aquí no pueden seguir el ritmo."
 
 #. Key:	A7F13B9A43B11BD74FA2CB95A0F30AC2
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleTittyPony.Default__KybeleTittyPony_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/Kybele/Default/KybeleTittyPony.Default__KybeleTittyPony_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",A7F13B9A43B11BD74FA2CB95A0F30AC2"
 msgid "It's been sometime since I have released, so this is going to get messy."
-msgstr ""
+msgstr "Ha pasado algún tiempo desde que he descargado, así que esto se va a complicar."
 
 #. Key:	A7F62643438C0E70840CB3BDB7695B68
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleHaveKeystone2.Default__KybeleHaveKeystone2_C.SessionData.Message
 #: /Game/Dialogue/Kybele/Default/KybeleHaveKeystone2.Default__KybeleHaveKeystone2_C.SessionData.Message
 msgctxt ",A7F62643438C0E70840CB3BDB7695B68"
 msgid "Kybele is satisfied."
-msgstr ""
+msgstr "Kybele está satisfecha."
 
 #. Key:	A8125055480BB34E28E96EB2CD3017F0
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiHowLong.Default__FesssiHowLong_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiHowLong.Default__FesssiHowLong_C.SessionData.Lines(3).Lines
 msgctxt ",A8125055480BB34E28E96EB2CD3017F0"
 msgid "They liked it and kept coming back for more. I gave many blow jobs and tasted cum from all over the world, it was great. Hiss!"
-msgstr ""
+msgstr "Les gustó y siguieron volviendo por más. Di muchas mamadas y probé semen de todo el mundo, fue genial. ¡Ssss!"
 
 #. Key:	A83161F4465E00C6CE9D718D3E76EDC6
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_RL.Default__FaleneDefault01_RL_C.ResponseData(6).ResponseData.BreederPrompt
@@ -9055,7 +9112,7 @@ msgstr "¿Cuál es el origen del nombre \"@MONSTER_RACE@\"?"
 #: /Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToFuta(4).LinesToFuta
 msgctxt ",A87432C446A6D9C7528A67B94431B712"
 msgid "Mmmm... so hard! Ohhh... ahhh!"
-msgstr "Mmmm... ¡tan duro! Ohhh... ahhh!"
+msgstr "Mmmm... ¡tan duro! ¡Ohhh... ahhh!"
 
 #. Key:	A897C9924C36C6F2E58C379611A2B01C
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R05.Default__FaleneDefault01_R05_C.SessionData.Lines(0).Lines
@@ -9069,28 +9126,28 @@ msgstr "¡Sí, soy una elfa pintada!"
 #: /Game/Dialogue/OrcChief/Default/OrcGreeting01.Default__OrcGreeting01_C.SessionData.Lines(1).Lines
 msgctxt ",A8F87DE746E7EF4E3350AA9C662E1BF0"
 msgid "You come to fix gate yes? Stupid elves broke it from their side."
-msgstr ""
+msgstr "¿Vienes a arreglar el portón, sí? Los estúpidos elfos lo rompieron de su lado."
 
 #. Key:	A90E87E3497D9E41C08BE1AB25DF9AEE
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_SexPositions.Default__EmissaryDefault01_SexPositions_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_SexPositions.Default__EmissaryDefault01_SexPositions_C.SessionData.Lines(0).Lines
 msgctxt ",A90E87E3497D9E41C08BE1AB25DF9AEE"
 msgid "If thou must indulge your desires, seek the Enlightened One in Sultry Plateau."
-msgstr "Si debes satisfacer tus deseos, busca a la Iluminada en la Meseta Bochornosa."
+msgstr "Si debes complacer tus deseos, busca a la Iluminada en la Meseta Bochornosa."
 
 #. Key:	A913B249494A32A6AF263BAE0962E781
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeDefault01.Default__MegaSlimeDefault01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeDefault01.Default__MegaSlimeDefault01_C.SessionData.Lines(0).Lines
 msgctxt ",A913B249494A32A6AF263BAE0962E781"
 msgid "Slime slime slime... I can play with my slime all day!"
-msgstr ""
+msgstr "Limo, limo, limo... ¡Puedo jugar con mi limo todo el día!"
 
 #. Key:	A91571364DFC6A4FA3772D9FCBDB52AA
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMYourChildren.Default__DMYourChildren_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/DragonMatriarch/Default/DMYourChildren.Default__DMYourChildren_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",A91571364DFC6A4FA3772D9FCBDB52AA"
 msgid "Who knows which of them are mine, and I don't care. This matriarch will continue reproducing until the end of time."
-msgstr ""
+msgstr "Quién sabe cuáles son míos, y no me importa. Esta matriarca seguirá reproduciéndose hasta el fin de los tiempos."
 
 #. Key:	A91A80914B126F3C3F262D93E88AEA71
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_Forgot_RL.Default__ParvatiDefault01_Forgot_RL_C.ResponseData(5).ResponseData.BreederPrompt
@@ -9104,84 +9161,84 @@ msgstr "¡Misionero!"
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_RL.Default__CamillaDefault01_RL_C.ResponseData(7).ResponseData.BreederPrompt
 msgctxt ",A926E381450A057D1E6C1598ABA5B917"
 msgid "About that dungeon over there..."
-msgstr ""
+msgstr "Sobre esa mazmorra de allí..."
 
 #. Key:	A931FB674A22AA9E31C00B9F0762AF5C
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleDefault01_RL.Default__KybeleDefault01_RL_C.ResponseData(5).ResponseData.BreederPrompt
 #: /Game/Dialogue/Kybele/Default/KybeleDefault01_RL.Default__KybeleDefault01_RL_C.ResponseData(5).ResponseData.BreederPrompt
 msgctxt ",A931FB674A22AA9E31C00B9F0762AF5C"
 msgid "Too much information... now, the keystone."
-msgstr ""
+msgstr "Demasiada información... ahora, la piedra-llave."
 
 #. Key:	A95B76C9415993E5F52ECDA4492EBE73
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiDefault03_RL_T.Default__FesssiDefault03_RL_T_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/Fesssi/Default/FesssiDefault03_RL_T.Default__FesssiDefault03_RL_T_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",A95B76C9415993E5F52ECDA4492EBE73"
 msgid "How long have you been stuck?"
-msgstr ""
+msgstr "¿Cuánto tiempo has estado atascada?"
 
 #. Key:	A97AEF8E47499B2AEB627CAE711C36BC
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDefault01_Meow_StartSplinters.Default__CassieDefault01_Meow_StartSplinters_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Cassie/Default/CassieDefault01_Meow_StartSplinters.Default__CassieDefault01_Meow_StartSplinters_C.SessionData.Lines(0).Lines
 msgctxt ",A97AEF8E47499B2AEB627CAE711C36BC"
 msgid "MEOW!!! Penetrate me human!"
-msgstr "¡¡¡MIAU!!! Penétrame humana!"
+msgstr "¡¡¡MIAU!!! ¡Penétrame humano!"
 
 #. Key:	A9AE4A3A494201CBF1191DA42CD01CA8
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",A9AE4A3A494201CBF1191DA42CD01CA8"
 msgid "Wow! It can't be!"
-msgstr "¡Guau! ¡No puede ser!!"
+msgstr "¡Guau! ¡No puede ser!"
 
 #. Key:	A9B242A6410BF5830F30419F32801AC2
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02.Default__FernDefault02_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02.Default__FernDefault02_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",A9B242A6410BF5830F30419F32801AC2"
 msgid "Look at my beautiful flower, it bloomed! Oh my did it feel weird..."
-msgstr "Mira mi hermosa flor, ¡floreció! Oh, se sintió raro..."
+msgstr "Mira mi hermosa flor, ¡floreció! Oh cielos, se sintió raro..."
 
 #. Key:	A9DC970946A02BBA89824685FB14ED6A
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeDefault01.Default__BeeDefault01_C.SessionData.LinesToFemale(3).LinesToFemale
 #: /Game/Dialogue/QueenBee/Default/BeeDefault01.Default__BeeDefault01_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",A9DC970946A02BBA89824685FB14ED6A"
 msgid "If I wiggle it the right way, it w-w-will distract any potential... mates."
-msgstr ""
+msgstr "Si lo muevo de la manera correcta, d-d-distraerá a cualquier potencial... pareja."
 
 #. Key:	AA08081E4A0AF7A81D4B99B1527E6970
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(14).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(14).Lines
 msgctxt ",AA08081E4A0AF7A81D4B99B1527E6970"
 msgid "The demons took advantage of this and started using them as breeding toys."
-msgstr "Los demonios se aprovecharon de esto y comenzaron a usarlos como juguetes de cría."
+msgstr "Los demonios se aprovecharon de esto y comenzaron a usarlos como juguetes de reproducción."
 
 #. Key:	AA14311148FE8C6A89D0DE953790D7E7
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcGreeting01.Default__OrcGreeting01_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcGreeting01.Default__OrcGreeting01_C.SessionData.Lines(4).Lines
 msgctxt ",AA14311148FE8C6A89D0DE953790D7E7"
 msgid "Human fix gate now!"
-msgstr ""
+msgstr "¡Ahora humano repara el portón!"
 
 #. Key:	AA16BE3B4732F407329ED6B450557C71
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyGreeting01.Default__RomyGreeting01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Romy/Default/RomyGreeting01.Default__RomyGreeting01_C.SessionData.Lines(0).Lines
 msgctxt ",AA16BE3B4732F407329ED6B450557C71"
 msgid "A strange song approaches me, a tune not heard in this land."
-msgstr "Se me acerca una canción extraña, una melodía que no se escucha en esta tierra."
+msgstr "Una extraña canción se me acerca, una melodía que no se escucha en esta tierra."
 
 #. Key:	AA18E8094B0BEABB8C6A948FC36B6552
 #. SourceLocation:	/Game/Dialogue/Yasmine/Default/YasmineHadSex01.Default__YasmineHadSex01_C.SessionData.LinesGrungy(0).LinesGrungy
 #: /Game/Dialogue/Yasmine/Default/YasmineHadSex01.Default__YasmineHadSex01_C.SessionData.LinesGrungy(0).LinesGrungy
 msgctxt ",AA18E8094B0BEABB8C6A948FC36B6552"
 msgid "Oh you dirty dirty human... what have you done to yourself?"
-msgstr ""
+msgstr "Oh, sucio, sucio humano... ¿Qué te has hecho a ti mismo?"
 
 #. Key:	AA19D8F246FE5FAD5F7E9D8BEEDF10E3
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeHadSex01.Default__MegaSlimeHadSex01_C.SessionData.LinesToFemale(3).LinesToFemale
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeHadSex01.Default__MegaSlimeHadSex01_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",AA19D8F246FE5FAD5F7E9D8BEEDF10E3"
 msgid "You should stay down here and play with me all day, we can be friends forever!"
-msgstr ""
+msgstr "Deberías quedarte aquí abajo y jugar conmigo todo el día, ¡podemos ser amigos para siempre!"
 
 #. Key:	AA3F14D64D5670190F05DD83A37D1AC9
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_RL_F.Default__FernDefault02_RL_F_C.ResponseData(1).ResponseData.BreederPrompt
@@ -9195,7 +9252,7 @@ msgstr "¡Has cambiado!"
 #: /Game/Dialogue/Autumn/Default/DryadHaveKeystone.Default__DryadHaveKeystone_C.SessionData.Lines(6).Lines
 msgctxt ",AA4B233A44217B671C811FA495E456B5"
 msgid "She can pollinate me all day, and together we will make amazing fruit."
-msgstr ""
+msgstr "Ella puede polinizarme todo el día y juntos haremos una fruta increíble."
 
 #. Key:	AAD8CEA34AE6DE13A8683089046598D3
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R02.Default__FaleneDefault01_R02_C.SessionData.Lines(6).Lines
@@ -9209,28 +9266,28 @@ msgstr "No es que pudieras de todos modos, ¡solo nos quitaremos el collar si in
 #: /Game/World/Overworld.Overworld:PersistentLevel.EM_HedonDungeonSwitch.ActivateMessage
 msgctxt ",AB0597744358BD82828774A65E812AEE"
 msgid "Pull Lever"
-msgstr ""
+msgstr "Palanca de Tiro"
 
 #. Key:	AB0F23814A695DE61DBE5DB8FFDFC3EA
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcFixOwnGate.Default__OrcFixOwnGate_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/OrcChief/Default/OrcFixOwnGate.Default__OrcFixOwnGate_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",AB0F23814A695DE61DBE5DB8FFDFC3EA"
 msgid "No one says no to chieftain!"
-msgstr ""
+msgstr "¡Nadie dice que no a cacique!"
 
 #. Key:	AB33AE4E444B3C498B0DFF9C8B60192F
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.CBGate_Crag.PlaceMessage
 #: /Game/World/Overworld.Overworld:PersistentLevel.CBGate_Crag.PlaceMessage
 msgctxt ",AB33AE4E444B3C498B0DFF9C8B60192F"
 msgid "Moaning Crag is now accessible."
-msgstr ""
+msgstr "El Risco Gimiente ahora es accesible."
 
 #. Key:	AB9D2C374B19A9E1B3E16E8EF742C9C8
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01.Default__EmissaryDefault01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01.Default__EmissaryDefault01_C.SessionData.Lines(1).Lines
 msgctxt ",AB9D2C374B19A9E1B3E16E8EF742C9C8"
 msgid "Cometh thy to offer @MONSTER_RACE@?"
-msgstr "¿Vienes a ofrecer @MONSTER_RACE@?"
+msgstr "¿Vienes para ofrecer @MONSTER_RACE@?"
 
 #. Key:	ABAD7A244F5B11BC403296A9DDE29AFE
 #. SourceLocation:	/Game/Characters/Procedural/Variants/Bovaur/Harvest/BovaurHarvest.Default__BovaurHarvest_C.Harvest.RaceName
@@ -9244,7 +9301,7 @@ msgstr "Bovaur"
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_Princess.Default__MirruDefault01_Princess_C.SessionData.Lines(0).Lines
 msgctxt ",ABE8783F45F5B2BBC550D384AB07C325"
 msgid "Indeed, and soon queen of all Formuria."
-msgstr "En efecto, y pronto reina de todo Formuria."
+msgstr "En efecto, y pronto reina de toda Formuria."
 
 #. Key:	ABE9EC6846B58FCFACC56D9EEF9C2B8B
 #. SourceLocation:	/Game/Characters/Procedural/Variants/Titan/Harvest/TitanHarvest.Default__TitanHarvest_C.Harvest.RaceName
@@ -9265,21 +9322,21 @@ msgstr "*Chupa* *Besa*"
 #: /Game/Dialogue/OrcChief/Default/OrcTribeSucks.Default__OrcTribeSucks_C.SessionData.Lines(3).Lines
 msgctxt ",AC0651B441F4DE497F64ABAC64E703E2"
 msgid "Elves are soft and easy, they like making offspring with us."
-msgstr ""
+msgstr "Los elfos son suaves y fáciles, les gusta tener descendencia con nosotros."
 
 #. Key:	AC30709F43155DB485B91FA519412629
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleTittyPony_T.Default__KybeleTittyPony_T_C.SessionData.LinesToMale(0).LinesToMale
 #: /Game/Dialogue/Kybele/Default/KybeleTittyPony_T.Default__KybeleTittyPony_T_C.SessionData.LinesToMale(0).LinesToMale
 msgctxt ",AC30709F43155DB485B91FA519412629"
 msgid "That's it human, you have annoyed me long enough. Get against that rock and prepare to be smashed."
-msgstr ""
+msgstr "Eso es humano, me has molestado lo suficiente. Ponte contra esa roca y prepárate para ser aplastado."
 
 #. Key:	AC4DD54E4585ECFF9E20A9806DEDCEE4
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadGreeting01.Default__DryadGreeting01_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Autumn/Default/DryadGreeting01.Default__DryadGreeting01_C.SessionData.Lines(5).Lines
 msgctxt ",AC4DD54E4585ECFF9E20A9806DEDCEE4"
 msgid "My apologies human, I was lost in thought. I'm always busy making fruit for the cows."
-msgstr ""
+msgstr "Mis disculpas, humano, estaba perdida en mis pensamientos. Siempre estoy ocupada haciendo fruta para las vacas."
 
 #. Key:	ACB6D0AB4FEF709BE8976DAF20A467D6
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaGreeting01.Default__CamillaGreeting01_C.SessionData.Lines(0).Lines
@@ -9300,70 +9357,70 @@ msgstr "Sin embargo, nuestro semen y óvulos son donde ocurre la \"magia\"."
 #: /Game/Dialogue/Cassie/Default/CassieGreeting01.Default__CassieGreeting01_C.SessionData.Lines(1).Lines
 msgctxt ",AD1829A4465DB79DEB4829B81F4E7A03"
 msgid "Meow! That's a fine piece o' property ya got down there..."
-msgstr "¡Miau! Esa es una buena herramienta la que tienes ahí abajo..."
+msgstr "¡Miau! Esa es un buen pedazo de propiedad lo que tienes ahí abajo..."
 
 #. Key:	AD224A514AC35938B00457BC8B2C7422
 #. SourceLocation:	/Game/Dialogue/Blossom/Default/BlossomDefault01_R02.Default__BlossomDefault01_R02_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Blossom/Default/BlossomDefault01_R02.Default__BlossomDefault01_R02_C.SessionData.Lines(2).Lines
 msgctxt ",AD224A514AC35938B00457BC8B2C7422"
 msgid "Blossom needsss fluidsss!"
-msgstr "¡Flor necessssita fluidossss!"
+msgstr "¡Blossom necesssita fluidosss!"
 
 #. Key:	AD478B234D74F4166BEDE6A5C70593F6
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleCentaur.Default__KybeleCentaur_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Kybele/Default/KybeleCentaur.Default__KybeleCentaur_C.SessionData.Lines(3).Lines
 msgctxt ",AD478B234D74F4166BEDE6A5C70593F6"
 msgid "And believe me human... it has been awhile."
-msgstr ""
+msgstr "Y créeme humana... ha pasado un tiempo."
 
 #. Key:	AD4B293B4D8F1432446C92924F59456E
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(22).LinesToFemale
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(22).LinesToFemale
 msgctxt ",AD4B293B4D8F1432446C92924F59456E"
 msgid "You will only catch wild @MONSTER_RACE@, which have roughly the intelligence of animals."
-msgstr "Solo atraparás @MONSTER_RACE@ salvajes, que tienen aproximadamente la inteligencia de animales."
+msgstr "Solo atraparás @MONSTER_RACE@ silvestres, que tienen aproximadamente la inteligencia de animales."
 
 #. Key:	AD729AD145061E3B808691AE861F3641
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcBrashDumb.Default__OrcBrashDumb_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcBrashDumb.Default__OrcBrashDumb_C.SessionData.Lines(2).Lines
 msgctxt ",AD729AD145061E3B808691AE861F3641"
 msgid "We fight and wrestle for the hell of it!"
-msgstr ""
+msgstr "¡Peleamos y luchamos por el gusto de hacerlo!"
 
 #. Key:	AD8370D449B2058385D511BCC7D8B193
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadDefault01_RL.Default__DryadDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/Autumn/Default/DryadDefault01_RL.Default__DryadDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",AD8370D449B2058385D511BCC7D8B193"
 msgid "Bosom cherries?"
-msgstr ""
+msgstr "¿Cerezas de seno?"
 
 #. Key:	ADE570A545B3D82C930945ACF5A2C3CE
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowTaskFulfilled.Default__WidowTaskFulfilled_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Widow/Default/WidowTaskFulfilled.Default__WidowTaskFulfilled_C.SessionData.Lines(1).Lines
 msgctxt ",ADE570A545B3D82C930945ACF5A2C3CE"
 msgid "Human, you have exceeded my expectations and pleased me greatly."
-msgstr ""
+msgstr "Humano, has superado mis expectativas y me has complacido enormemente."
 
 #. Key:	ADECACEF405669C45FAC77AB2A48E637
 #. SourceLocation:	/Game/Dialogue/Emissary/SexScenes/EmissaryAngelGroinLove.Default__EmissaryAngelGroinLove_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/Emissary/SexScenes/EmissaryAngelGroinLove.Default__EmissaryAngelGroinLove_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",ADECACEF405669C45FAC77AB2A48E637"
 msgid "My labia are holy and magical. May your tongue be graced by their presence."
-msgstr "Mis labios son santos y mágicos. Que tu lengua sea agraciada por su presencia."
+msgstr "Mis labios son sagrados y mágicos. Que tu lengua sea agraciada con su presencia."
 
 #. Key:	ADECFCE04009A18A9FCD358FEAD730A5
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiGreeting01.Default__FesssiGreeting01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiGreeting01.Default__FesssiGreeting01_C.SessionData.Lines(0).Lines
 msgctxt ",ADECFCE04009A18A9FCD358FEAD730A5"
 msgid "Hiss! Oh sexy human, come closer... I promise I won't bite."
-msgstr ""
+msgstr "¡Sss! Oh sexy humano, acércate... te prometo que no morderé."
 
 #. Key:	ADF357A1447CC164A3CF54A274E1EECF
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02.Default__FernDefault02_C.SessionData.LinesToFemale(2).LinesToFemale
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02.Default__FernDefault02_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",ADF357A1447CC164A3CF54A274E1EECF"
 msgid "I am a growing Alraune, perhaps you have fluids to spare?"
-msgstr "Soy una Mandrágora en crecimiento, ¿quizás tengas líquidos de sobra?"
+msgstr "Soy una alraune en crecimiento, ¿tal vez te sobran fluidos?"
 
 #. Key:	AE10903F4F5306C2AF3432A0D40AD89F
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R02.Default__FaleneDefault01_R02_C.SessionData.Lines(14).Lines
@@ -9384,7 +9441,7 @@ msgstr "¡Un mundo de sexo y aventuras te espera!"
 #: /Game/Dialogue/DragonMatriarch/Default/DMYourChildren.Default__DMYourChildren_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",AE940C0E4203F3605E98088D0827EA0B"
 msgid "Believe me human, I have sired many offspring."
-msgstr ""
+msgstr "Créeme, humana, he dado a luz a muchos descendientes."
 
 #. Key:	AE9DC6E246625CE553B669ADBD1EB570
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDefault01_Meow_RL_F.Default__CassieDefault01_Meow_RL_F_C.ResponseData(0).ResponseData.BreederPrompt
@@ -9405,67 +9462,69 @@ msgstr "Esto te permite capturar y almacenar todas las variantes de Titanes."
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R01.Default__CamillaDefault01_R01_C.SessionData.Lines(8).Lines
 msgctxt ",AF4962AA4EF7962370DC5D869BFFA992"
 msgid "Don't give me that look!!"
-msgstr "¡No me mires así!"
+msgstr "¡¡No me mires así!!"
 
 #. Key:	AF56D3A1427EFDD2D086F09E5534EC68
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03_R01.Default__FernDefault03_R01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03_R01.Default__FernDefault03_R01_C.SessionData.Lines(0).Lines
 msgctxt ",AF56D3A1427EFDD2D086F09E5534EC68"
 msgid "You are the lord of this soil--or owner of Homestead in the common tongue."
-msgstr "Eres señora de este suelo, o dueña del Caserío en la lengua común."
+msgstr "Eres el señor de este suelo: o más bien el dueño de la Granja en la lengua común."
 
 #. Key:	AF5E23FC4ED6AD9A92E6E98CE8F2080F
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeSad_RL.Default__MegaSlimeSad_RL_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeSad_RL.Default__MegaSlimeSad_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",AF5E23FC4ED6AD9A92E6E98CE8F2080F"
 msgid "Uh... are you alright?"
-msgstr ""
+msgstr "Uh... ¿estás bien?"
 
 #. Key:	AF6126694453EEB0A7AA7787649EC605
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFuta(2).LinesToFuta
 #: /Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",AF6126694453EEB0A7AA7787649EC605"
 msgid "Perhaps you would like to stick that dick in my sparkly elf pussy? Ahhh I would love that..."
-msgstr ""
+msgstr "¿Quizás te gustaría meter ese pene en mi brillante coño de elfa? Ahhh me encantaría eso..."
 
 #. Key:	AFBF754C422E5E00DF8BB7A37B956DFB
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(10 - Value).TraitIcons.HelpText
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(10 - Value).TraitIcons.HelpText
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(10 -
+#: Value).TraitIcons.HelpText
 msgctxt ",AFBF754C422E5E00DF8BB7A37B956DFB"
 msgid "Divergent: Offspring have a chance to generate a random trait upon being summoned."
-msgstr "Divergente: Las/os descendientes tienen la posibilidad de generar un rasgo aleatorio al ser convocadas/os."
+msgstr "Divergente: los descendientes tienen la posibilidad de generar un rasgo aleatorio al ser convocados."
 
 #. Key:	AFF40FDB49E0435621047691DD80B3DC
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMYourChildren.Default__DMYourChildren_C.SessionData.LinesToMale(1).LinesToMale
 #: /Game/Dialogue/DragonMatriarch/Default/DMYourChildren.Default__DMYourChildren_C.SessionData.LinesToMale(1).LinesToMale
 msgctxt ",AFF40FDB49E0435621047691DD80B3DC"
 msgid "Who knows which of them are mine, and I don't care. This matriarch will continue reproducing until the end of time."
-msgstr ""
+msgstr "Quién sabe cuáles son míos, y no me importa. Esta matriarca seguirá reproduciéndose hasta el fin de los tiempos."
 
 #. Key:	B00960644B62BA0C4CBBCD83C25D5855
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcHadSex01.Default__OrcHadSex01_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/OrcChief/Default/OrcHadSex01.Default__OrcHadSex01_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",B00960644B62BA0C4CBBCD83C25D5855"
 msgid "Ahhh! *snarl*"
-msgstr ""
+msgstr "¡Ahhh! *gruñe*"
 
 #. Key:	B0133AC44E841D002819DB9289664369
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMAboutDragons.Default__DMAboutDragons_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMAboutDragons.Default__DMAboutDragons_C.SessionData.Lines(2).Lines
 msgctxt ",B0133AC44E841D002819DB9289664369"
 msgid "However, they are mere simpletons that serve as my breeding stock!"
-msgstr ""
+msgstr "Sin embargo, ¡son meros simplones que sirven como mi ganado reproductor!"
 
 #. Key:	B071E1E04B9EA4D9C227C2935955161A
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R03.Default__FaleneDefault01_R03_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R03.Default__FaleneDefault01_R03_C.SessionData.Lines(0).Lines
 msgctxt ",B071E1E04B9EA4D9C227C2935955161A"
 msgid "Wild @MONSTER_RACE@ are what you will be catching and breeding."
-msgstr "@MONSTER_RACE@ salvajes son los que atraparás y con quienes te reproducirás."
+msgstr "@MONSTER_RACE@ silvestres son los que atraparás y te reproducirás."
 
 #. Key:	B088E0624E17857FAE8AE4B893251DA2
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(0 - Value).TraitIcons.DisplayName
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(0 - Value).TraitIcons.DisplayName
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(0 -
+#: Value).TraitIcons.DisplayName
 msgctxt ",B088E0624E17857FAE8AE4B893251DA2"
 msgid "Hominal"
 msgstr "Humanoide"
@@ -9475,28 +9534,28 @@ msgstr "Humanoide"
 #: /Game/Dialogue/QueenBee/Default/BeeHaveKeystone1.Default__BeeHaveKeystone1_C.SessionData.Lines(1).Lines
 msgctxt ",B0D63ADB45CCFD884D1581A5725EA8BF"
 msgid "Should you manage to do it, the keystone will be granted to you and I shall instruct my workers to remove the honey blocking Sultry Plateau."
-msgstr ""
+msgstr "Si logras hacerlo, se te otorgará la piedra-llave y daré instrucciones a mis trabajadoras para que retiren la miel que bloquea la Meseta Bochornosa."
 
 #. Key:	B0F5CCC741FEDFC39587579F638D56DC
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeMasturbate.Default__BeeMasturbate_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/QueenBee/Default/BeeMasturbate.Default__BeeMasturbate_C.SessionData.Lines(3).Lines
 msgctxt ",B0F5CCC741FEDFC39587579F638D56DC"
 msgid "Asking one of the @MONSTER_RACE@ if they masturbate all day is the most redundant question I've heard."
-msgstr ""
+msgstr "Preguntarle a uno de los @MONSTER_RACE@ si se masturban todo el día es la pregunta más redundante que he escuchado."
 
 #. Key:	B100F65E4495A60CD1761FA5FA43CBEE
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaHadSex02.Default__CamillaHadSex02_C.SessionData.LinesToMale(2).LinesToMale
 #: /Game/Dialogue/Camilla/Default/CamillaHadSex02.Default__CamillaHadSex02_C.SessionData.LinesToMale(2).LinesToMale
 msgctxt ",B100F65E4495A60CD1761FA5FA43CBEE"
 msgid "Ohhh but I did!"
-msgstr ""
+msgstr "¡Ohhh, pero lo hice!"
 
 #. Key:	B11026CD462D3D9C5256F4A490A45911
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R07.Default__FaleneDefault01_R07_C.SessionData.LinesToFuta(1).LinesToFuta
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R07.Default__FaleneDefault01_R07_C.SessionData.LinesToFuta(1).LinesToFuta
 msgctxt ",B11026CD462D3D9C5256F4A490A45911"
 msgid "Errrr, I can't stand it anymore, I'm going to milk you dry! I have never tasted human cum before!"
-msgstr "Errrr, no puedo soportarlo más, ¡voy a ordeñarte seca! ¡Nunca antes había probado semen humano!"
+msgstr "Errrr, no puedo soportarlo más, ¡voy a ordeñarte hasta secarte! ¡Nunca antes había probado semen humano!"
 
 #. Key:	B12A342547F0295A52457D814E45C485
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_AreYouBlessed.Default__EmissaryDefault01_AreYouBlessed_C.SessionData.Lines(0).Lines
@@ -9510,112 +9569,113 @@ msgstr "Sí @BREEDER_NAME@."
 #: /Game/Dialogue/DragonMatriarch/Default/DMDefault_RL2.Default__DMDefault_RL2_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",B1435DF7419D2F4948DD9B9EFF8E628E"
 msgid "Are all of these wild dragons your children?"
-msgstr ""
+msgstr "¿Son todos estos dragones silvestres tus hijos?"
 
 #. Key:	B146211A43E4F159EC3A0C85790314DD
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimePlay1.Default__MegaSlimePlay1_C.SessionData.LinesToFuta(5).LinesToFuta
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePlay1.Default__MegaSlimePlay1_C.SessionData.LinesToFuta(5).LinesToFuta
 msgctxt ",B146211A43E4F159EC3A0C85790314DD"
 msgid "Well what are you waiting for? Come on in!"
-msgstr ""
+msgstr "¿Bueno, qué estás esperando? ¡Venga!"
 
 #. Key:	B16A16AD4DAD11735CC38DBC5E9237B1
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleTittyPony.Default__KybeleTittyPony_C.SessionData.LinesToFuta(1).LinesToFuta
 #: /Game/Dialogue/Kybele/Default/KybeleTittyPony.Default__KybeleTittyPony_C.SessionData.LinesToFuta(1).LinesToFuta
 msgctxt ",B16A16AD4DAD11735CC38DBC5E9237B1"
 msgid "It's been sometime since I have been mounted, so I might get rough!"
-msgstr ""
+msgstr "Ha pasado algún tiempo desde que me montaron, ¡así que podría ponerme dura!"
 
 #. Key:	B17C429C4AE53B8CA98F5E8166D598D2
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadCherryHelp.Default__DryadCherryHelp_C.SessionData.LinesToFemale(3).LinesToFemale
 #: /Game/Dialogue/Autumn/Default/DryadCherryHelp.Default__DryadCherryHelp_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",B17C429C4AE53B8CA98F5E8166D598D2"
 msgid "Come closer human..."
-msgstr ""
+msgstr "Acércate humana..."
 
 #. Key:	B18F6EA040A16FCFD95EB3894A067B79
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeAboutOrb.Default__MegaSlimeAboutOrb_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeAboutOrb.Default__MegaSlimeAboutOrb_C.SessionData.Lines(5).Lines
 msgctxt ",B18F6EA040A16FCFD95EB3894A067B79"
 msgid "She speaks to me! Such wonderful stories about her adventures rolling around the world."
-msgstr ""
+msgstr "¡Ella me habla! Historias tan maravillosas sobre sus aventuras rodando por todo el mundo."
 
 #. Key:	B1A4C4984540058620CA09A3FC603DBE
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeDefault01_Accent.Default__AmberMaeDefault01_Accent_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeDefault01_Accent.Default__AmberMaeDefault01_Accent_C.SessionData.Lines(1).Lines
 msgctxt ",B1A4C4984540058620CA09A3FC603DBE"
 msgid "Hail from the Northern Isles I do! Aye what a beauty 'mai homeland is..."
-msgstr "¡Sarve de lah islah der norte que soy! Sí, qué bellesa eh mi tierra natah..."
+msgstr "¡Sarve dehde lah Irlah der Norte! Seh, qué bellesa eh mi tierra natah..."
 
 #. Key:	B1BCFA034FBA8483F5D2578BABDDE685
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(27).LinesToMale
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(27).LinesToMale
 msgctxt ",B1BCFA034FBA8483F5D2578BABDDE685"
 msgid "We just love you too much, and sometimes our desires spiral out of control!"
-msgstr "¡Te amamos demasiado y, a veces, nuestros deseos se descontrolan!"
+msgstr "Te amamos demasiado y, a veces, ¡nuestros deseos se descontrolan!"
 
 #. Key:	B1BEC3C54841F5611ED8E1A3547AD05F
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(1).Lines
 msgctxt ",B1BEC3C54841F5611ED8E1A3547AD05F"
 msgid "Awww! I could just squeeze ye between 'mai jugs 'til ye climax!"
-msgstr "¡Awww! ¡Podría exprimirloh entre mih jarrah hahta que alcasarah el clímax!"
+msgstr "¡Ammm! ¡Podría zimplemente ehtrujarte entre mih cántaroh de leshe hahta que llegueh al clímah!"
 
 #. Key:	B1E706104468BBBC8C481498B5352B8D
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaHadSex01.Default__LeylannaHadSex01_C.SessionData.LinesToFemale(2).LinesToFemale
 #: /Game/Dialogue/Leylanna/Default/LeylannaHadSex01.Default__LeylannaHadSex01_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",B1E706104468BBBC8C481498B5352B8D"
 msgid "When we please each other, the Goddess shares in that pleasure."
-msgstr ""
+msgstr "Cuando nos complacemos mutuamente, la Diosa comparte ese placer."
 
 #. Key:	B20F5D9040267E77436A9B94B5F68150
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(30 - Value).TraitIcons.DisplayName
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(30 - Value).TraitIcons.DisplayName
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(30 -
+#: Value).TraitIcons.DisplayName
 msgctxt ",B20F5D9040267E77436A9B94B5F68150"
 msgid "Gaudy"
-msgstr "Llamativa/o"
+msgstr "Llamativo"
 
 #. Key:	B22A0E0B459BF554FEEAB7920A478BAF
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraDefault01.Default__PetraDefault01_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Petra/Default/PetraDefault01.Default__PetraDefault01_C.SessionData.Lines(2).Lines
 msgctxt ",B22A0E0B459BF554FEEAB7920A478BAF"
 msgid "In the meantime... I've been a very naughty bunny. Perhaps you'd like to give me a spanking??"
-msgstr ""
+msgstr "Mientras tanto... he sido una conejita muy traviesa. ¿Tal vez te gustaría darme unos azotes en las nalgas?"
 
 #. Key:	B22CBCF74EE8D6771B1E7987993911F6
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiCave.Default__FesssiCave_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiCave.Default__FesssiCave_C.SessionData.Lines(0).Lines
 msgctxt ",B22CBCF74EE8D6771B1E7987993911F6"
 msgid "The cave leads to Amorous Hallows. Hiss!"
-msgstr ""
+msgstr "La cueva conduce a Reliquias Amorosas. ¡Sss!"
 
 #. Key:	B2323665415F7EE8A74204A9FD52D914
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(7).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(7).Lines
 msgctxt ",B2323665415F7EE8A74204A9FD52D914"
 msgid "Ye can consider me a connoisseur of @MONSTER_RACE@ milk. Each race's milk has a distinct and delicious flavor, so it is."
-msgstr "Puedeh considerahme una conosedora de leshe @MONSTER_RACE@. La leshe de cada rasa tiene un saboh distinto y delisioso, por lo que eh."
+msgstr "Puedeh considerahme una conosedora de la leshe @MONSTER_RACE@. La leshe de cada rasa tiene un saboh distinto y delisioso, asín eh."
 
 #. Key:	B235542C44D65B1D62C721A3C4CD289F
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_StartForgotten.Default__ParvatiDefault01_StartForgotten_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_StartForgotten.Default__ParvatiDefault01_StartForgotten_C.SessionData.Lines(2).Lines
 msgctxt ",B235542C44D65B1D62C721A3C4CD289F"
 msgid "Pay close attention to my form, and learn you should."
-msgstr "Presta mucha atención a mi forma y aprenderás como ningún quien."
+msgstr "Presta mucha atención a mi forma, y aprende lo que debas."
 
 #. Key:	B27218744AEBAD507E1037B620EC16DA
 #. SourceLocation:	/Game/Dialogue/Blossom/Default/BlossomDefault01_R03_R01.Default__BlossomDefault01_R03_R01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Blossom/Default/BlossomDefault01_R03_R01.Default__BlossomDefault01_R03_R01_C.SessionData.Lines(0).Lines
 msgctxt ",B27218744AEBAD507E1037B620EC16DA"
 msgid "Hiss! Blossom love you mastah!"
-msgstr "¡Sssss! ¡Flor te ama maeztra!"
+msgstr "¡Sss! ¡Blossom te ama Mastah!"
 
 #. Key:	B27FC78147626E1ED81B86A06FCF68F9
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiWantAss.Default__FesssiWantAss_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiWantAss.Default__FesssiWantAss_C.SessionData.Lines(1).Lines
 msgctxt ",B27FC78147626E1ED81B86A06FCF68F9"
 msgid "My ass is the product of years of \"hard\" work."
-msgstr ""
+msgstr "Mi culo es producto de años de trabajo \"duro\"."
 
 #. Key:	B2DF6AC642DDC3C552F43290DCBE4EA7
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFuta(1).LinesToFuta
@@ -9636,7 +9696,7 @@ msgstr "Aviario de Arpías"
 #: /Game/Dialogue/QueenBee/Default/BeeHadSex01.Default__BeeHadSex01_C.SessionData.Lines(0).Lines
 msgctxt ",B31209614A74AB1A0C2C14AD375B0165"
 msgid "I trust my honey was exquisite. Consider yourself honored to have tasted the thick sweet product of my teats."
-msgstr ""
+msgstr "Confío en que mi miel fue exquisita. Considérate honrado de haber probado el espeso y dulce producto de mis pezones."
 
 #. Key:	B34ADF5D4AB31A7DC61000950C44B54F
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(1).LinesToMale
@@ -9650,49 +9710,50 @@ msgstr "¡Un humano! Un humano super lindo... este es mi día de suerte. He esta
 #: /Game/Dialogue/Fern/Default/FernDefault01_R03.Default__FernDefault01_R03_C.SessionData.Lines(1).Lines
 msgctxt ",B36EC36B46E4D040A92BF09236F605F9"
 msgid "Fern need human cum to grow into big Alraune! Hissss, Fern suck dick now!"
-msgstr "¡Helecho necesita semen humano para convertirse en gran Mandrágora! ¡Sssss, Helecho chupa polla ahora!"
+msgstr "¡Fern necesita semen humano para convertirse en una gran alraune! ¡Sssss, Fern chupa pene ahora!"
 
 #. Key:	B3953BA1451F630DE2CF019EB4CB6A69
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(23 - Value).TraitIcons.DisplayName
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(23 - Value).TraitIcons.DisplayName
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(23 -
+#: Value).TraitIcons.DisplayName
 msgctxt ",B3953BA1451F630DE2CF019EB4CB6A69"
 msgid "Valuable"
-msgstr "Valiosa/o"
+msgstr "Valioso"
 
 #. Key:	B3B231554333647A7518C9A44578C0B1
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyGreeting01.Default__RomyGreeting01_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Romy/Default/RomyGreeting01.Default__RomyGreeting01_C.SessionData.Lines(2).Lines
 msgctxt ",B3B231554333647A7518C9A44578C0B1"
 msgid "I hear your eyes working your way down my voluptuous form, your heart beats faster."
-msgstr "Escucho tus ojos trabajando en mi voluptuosa forma, tu corazón late más rápido."
+msgstr "Escucho a tus ojos recorrer su camino bajando por mi voluptuosa forma, tu corazón late más rápido."
 
 #. Key:	B3B7244F401573EDDD24A0BB5011F55C
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_HowToSpiritForm_RL_T.Default__LeylannaDefault01_HowToSpiritForm_RL_T_C.ResponseData(2).ResponseData.BreederPrompt
 #: /Game/Dialogue/Leylanna/Default/LeylannaDefault01_HowToSpiritForm_RL_T.Default__LeylannaDefault01_HowToSpiritForm_RL_T_C.ResponseData(2).ResponseData.BreederPrompt
 msgctxt ",B3B7244F401573EDDD24A0BB5011F55C"
 msgid "This is getting weird..."
-msgstr "Esto se está poniendo raro..."
+msgstr "Esto se está volviendo raro..."
 
 #. Key:	B3B9D4DE46AC98F7EC5432A2F06C92D6
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R03.Default__FaleneDefault01_R03_C.SessionData.Lines(7).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R03.Default__FaleneDefault01_R03_C.SessionData.Lines(7).Lines
 msgctxt ",B3B9D4DE46AC98F7EC5432A2F06C92D6"
 msgid "Also, you will be making more cute little @MONSTER_RACE@ for me to \"play\" with!"
-msgstr "Además, ¡estarás haciendo un poco más lindos @MONSTER_RACE@ para que yo \"juegue\" con éllos!"
+msgstr "Además, ¡harás pequeños @MONSTER_RACE@ más lindos para que yo \"juegue\" con ellos!"
 
 #. Key:	B40DA93F4D87A08B36AB2198B2D523AF
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiHadSex01.Default__ParvatiHadSex01_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Parvati/Default/ParvatiHadSex01.Default__ParvatiHadSex01_C.SessionData.Lines(2).Lines
 msgctxt ",B40DA93F4D87A08B36AB2198B2D523AF"
 msgid "We can learn the origins of the universe."
-msgstr ""
+msgstr "Podemos conocer los orígenes del universo."
 
 #. Key:	B41CF0334A59DC837984179B995A16B2
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_FloatRhyme.Default__ParvatiDefault01_FloatRhyme_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_FloatRhyme.Default__ParvatiDefault01_FloatRhyme_C.SessionData.Lines(0).Lines
 msgctxt ",B41CF0334A59DC837984179B995A16B2"
 msgid "Such is how I uncovered the truth of non-duality."
-msgstr "Así es como descubrí la verdad sobre la no dualidad."
+msgstr "Así es como descubrí la verdad de la no-dualidad."
 
 #. Key:	B48E37AC4977FA95BA4EB3B39018F087
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03.Default__FernDefault03_C.SessionData.LinesToFemale(3).LinesToFemale
@@ -9720,140 +9781,140 @@ msgstr "He escuchado leyendas de la Iluminada en algún lugar de la Meseta Bocho
 #: /Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToFuta(0).LinesToFuta
 msgctxt ",B4EFBB67424526E49554149C5ADDE508"
 msgid "Ohhhh your dick! Finally!"
-msgstr "¡Ohhhh tu polla! ¡Finalmente!"
+msgstr "¡Ohhhh, tu pene! ¡Por fin!"
 
 #. Key:	B5227FC24AE0F8318DF7DBAF9AC7553A
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_EnlightenedOne.Default__NeelaDefault01_EnlightenedOne_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_EnlightenedOne.Default__NeelaDefault01_EnlightenedOne_C.SessionData.Lines(0).Lines
 msgctxt ",B5227FC24AE0F8318DF7DBAF9AC7553A"
 msgid "So you want to learn new sex positions I see..."
-msgstr "Entonces quieres aprender nuevas posiciones sexuales, ya veo..."
+msgstr "Así que quieres aprender nuevas posiciones sexuales, ya veo..."
 
 #. Key:	B5A2F9CD41C677116ECB32818AB2D2D7
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcDefault01.Default__OrcDefault01_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcDefault01.Default__OrcDefault01_C.SessionData.Lines(2).Lines
 msgctxt ",B5A2F9CD41C677116ECB32818AB2D2D7"
 msgid "Take them to Homestead and make offspring."
-msgstr ""
+msgstr "Llévalos a la Granja y haz descendencia."
 
 #. Key:	B5AD6A9A40AB4528FFC0BCBCD051C66B
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowDefault01.Default__WidowDefault01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Widow/Default/WidowDefault01.Default__WidowDefault01_C.SessionData.Lines(1).Lines
 msgctxt ",B5AD6A9A40AB4528FFC0BCBCD051C66B"
 msgid "Ah little one... you are now mine. Don't be afraid, for I only wish to please."
-msgstr ""
+msgstr "Ah, pequeña... ahora eres mía. No tengas miedo, pues solo deseo complacer."
 
 #. Key:	B5B8312540B0C71F1DDBCEADEF6C3E02
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(10).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(10).Lines
 msgctxt ",B5B8312540B0C71F1DDBCEADEF6C3E02"
 msgid "I meant what I said about ye between 'mai jugs. Mayhaps we can have a li'l fun in the future?"
-msgstr "Quise desih lo que dije sobre tí entre mih jarrah. ¿Quisáh podamoh divertirnoh en er futuro?"
+msgstr "Quise desih lo que dije sobre ti entre cántaroh de leshe. ¿Quisáh podamoh divertirnoh un poco en er futuro?"
 
 #. Key:	B5C876DA4DBA230757C412BE4612735C
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcHaveKeystone.Default__OrcHaveKeystone_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcHaveKeystone.Default__OrcHaveKeystone_C.SessionData.Lines(4).Lines
 msgctxt ",B5C876DA4DBA230757C412BE4612735C"
 msgid "Grrrr!!! A cow with some spunk, now get to it human!"
-msgstr ""
+msgstr "¡¡¡Grrrr!!! Una vaca con algo de agallas, ¡ahora hazlo humano!"
 
 #. Key:	B5E173FA45294C4DE256EF836668F092
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFemale(5).LinesToFemale
 #: /Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFemale(5).LinesToFemale
 msgctxt ",B5E173FA45294C4DE256EF836668F092"
 msgid "Both?"
-msgstr ""
+msgstr "¿Ambas?"
 
 #. Key:	B5F3B5B2436545B9AAC067B451FA7563
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchQueen.Default__MonarchQueen_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Monarch/Default/MonarchQueen.Default__MonarchQueen_C.SessionData.Lines(2).Lines
 msgctxt ",B5F3B5B2436545B9AAC067B451FA7563"
 msgid "Her beautiful breasts make so much honey, she has an army of bee daughters to milk her."
-msgstr ""
+msgstr "Sus hermosos pechos producen tanta miel que tiene un ejército de hijas abeja para ordeñarla."
 
 #. Key:	B5FEFBB64D1BFCA1A84984AD156AFD02
 #. SourceLocation:	/Game/Dialogue/Yasmine/Default/YasminePearls.Default__YasminePearls_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Yasmine/Default/YasminePearls.Default__YasminePearls_C.SessionData.Lines(2).Lines
 msgctxt ",B5FEFBB64D1BFCA1A84984AD156AFD02"
 msgid "What else should a clam do?"
-msgstr ""
+msgstr "¿Qué más debería hacer una almeja?"
 
 #. Key:	B601DE914360E4E4962B9BAE17334C67
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryRaiseTraitLvl_Decline.Default__EmissaryRaiseTraitLvl_Decline_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryRaiseTraitLvl_Decline.Default__EmissaryRaiseTraitLvl_Decline_C.SessionData.Lines(0).Lines
 msgctxt ",B601DE914360E4E4962B9BAE17334C67"
 msgid "A pity indeed human... I suppose such low standards are fitting."
-msgstr "Una lástima, de hecho, humana... Supongo que estándares tan bajos son adecuados."
+msgstr "Una lástima, de hecho, humano... supongo que unos estándares tan bajos son adecuados."
 
 #. Key:	B628775D4659A3C72D73DAAB3B931832
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraPracticeMe.Default__PetraPracticeMe_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Petra/Default/PetraPracticeMe.Default__PetraPracticeMe_C.SessionData.Lines(1).Lines
 msgctxt ",B628775D4659A3C72D73DAAB3B931832"
 msgid "Pawsmaati never said I couldn't practice with a human, and I've become quite horny while waiting here."
-msgstr ""
+msgstr "Pawsmaati nunca dijo que no podría practicar con un humano, y me he puesto bastante cachonda mientras esperaba aquí."
 
 #. Key:	B63337A041FFD99C138E44AB261A71CE
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.CBGate_Cove.PlaceMessage
 #: /Game/World/Overworld.Overworld:PersistentLevel.CBGate_Cove.PlaceMessage
 msgctxt ",B63337A041FFD99C138E44AB261A71CE"
 msgid "Cove of Rapture is now accessible."
-msgstr ""
+msgstr "Ensenada del Éxtasis ahora es accesible."
 
 #. Key:	B685468D40290FF6E84B0D812D2A7F2F
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaGreeting01.Default__CamillaGreeting01_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaGreeting01.Default__CamillaGreeting01_C.SessionData.Lines(2).Lines
 msgctxt ",B685468D40290FF6E84B0D812D2A7F2F"
 msgid "Everyone wants Falene. She's so beautiful, and no one cares about the short girthy lump in the corner!"
-msgstr "Todos quieren a Falene. ¡Es tan hermosa, y a nadie le importa el corto y circunscrito bulto en la esquina!"
+msgstr "Todos quieren a Falene. Ella es tan hermosa, ¡y a nadie le importa el pequeño bulto orondo en la esquina!"
 
 #. Key:	B69447294A19D4E4338E36BBB1C2DADE
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_HowToSpiritForm.Default__LeylannaDefault01_HowToSpiritForm_C.SessionData.LinesToFuta(2).LinesToFuta
 #: /Game/Dialogue/Leylanna/Default/LeylannaDefault01_HowToSpiritForm.Default__LeylannaDefault01_HowToSpiritForm_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",B69447294A19D4E4338E36BBB1C2DADE"
 msgid "Catch a futa Foxen if you have not done so, and then return to me. We will then make love and form a covenant."
-msgstr "Atrapa una Zorro futa si aún no lo has hecho, y luego vuelve a mí. Entonces haremos el amor y formaremos un pacto."
+msgstr "Atrapa una futa foxen si aún no lo has hecho, y luego vuelve a mí. Luego haremos el amor y formaremos un pacto."
 
 #. Key:	B69F20F0421426CBBF0D7FBE2E7C76D6
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_BatheAllDay.Default__RomyDefault01_BatheAllDay_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Romy/Default/RomyDefault01_BatheAllDay.Default__RomyDefault01_BatheAllDay_C.SessionData.Lines(1).Lines
 msgctxt ",B69F20F0421426CBBF0D7FBE2E7C76D6"
 msgid "The townsfolk come here to relax and make love, it is beautiful."
-msgstr "La gente del ciudad viene aquí para relajarse y hacer el amor, es hermoso."
+msgstr "La gente del pueblo viene aquí para relajarse y hacer el amor, es hermoso."
 
 #. Key:	B72B154840C9EFADCC67BE89C1C467AA
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadFlowers.Default__DryadFlowers_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Autumn/Default/DryadFlowers.Default__DryadFlowers_C.SessionData.Lines(3).Lines
 msgctxt ",B72B154840C9EFADCC67BE89C1C467AA"
 msgid "I can feel the roots of many cuminus flowers, but no ejaculum-phallis. Hmm..."
-msgstr ""
+msgstr "Puedo sentir las raíces de muchas flores de comino, pero no del ejaculum-phallis. Mmm..."
 
 #. Key:	B740BA7F4ADFB18E32DFE99606B483B3
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeDefault01_SuckJugs.Default__AmberMaeDefault01_SuckJugs_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeDefault01_SuckJugs.Default__AmberMaeDefault01_SuckJugs_C.SessionData.Lines(0).Lines
 msgctxt ",B740BA7F4ADFB18E32DFE99606B483B3"
 msgid "Bless me for say'n so, but I was wish'n you'd ask that!"
-msgstr "¡Bendíseme poh desirlo, pero desearía que me lo pidierah!"
+msgstr "Bendíseme poh desirlo, ¡pero me guhtaría que me preguntarah eso!"
 
 #. Key:	B792D83B44DC1E7BF9DAE08B4D4A3E70
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_UpHere.Default__RomyDefault01_UpHere_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Romy/Default/RomyDefault01_UpHere.Default__RomyDefault01_UpHere_C.SessionData.Lines(0).Lines
 msgctxt ",B792D83B44DC1E7BF9DAE08B4D4A3E70"
 msgid "The real question is: how did you get here human?"
-msgstr "La verdadera pregunta es: ¿cómo llegaste aquí humana?"
+msgstr "La verdadera pregunta es: ¿cómo llegaste aquí humano?"
 
 #. Key:	B79398FF462643C6AD3C78BBEBD9E244
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernBeeFlowers3.Default__FernBeeFlowers3_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Fern/DefaultP3/FernBeeFlowers3.Default__FernBeeFlowers3_C.SessionData.Lines(1).Lines
 msgctxt ",B79398FF462643C6AD3C78BBEBD9E244"
 msgid "Only a dryad would be able to do such a thing."
-msgstr ""
+msgstr "Solo una dríada podría hacer tal cosa."
 
 #. Key:	B79CA71847A95B814D43088A9A29BF45
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadBossomCherries.Default__DryadBossomCherries_C.SessionData.Lines(8).Lines
 #: /Game/Dialogue/Autumn/Default/DryadBossomCherries.Default__DryadBossomCherries_C.SessionData.Lines(8).Lines
 msgctxt ",B79CA71847A95B814D43088A9A29BF45"
 msgid "Besides, when I make love with them it spares them from dealing with the Reaper, and my orgasm creates another bosom cherry."
-msgstr ""
+msgstr "Además, cuando hago el amor con ellas, no tienen que lidiar con la Segadora, y mi orgasmo crea otra cereza de seno."
 
 #. Key:	B79CB910400AA9573644BCA03D3D9F51
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R01.Default__FaleneDefault01_R01_C.SessionData.Lines(15).Lines
@@ -9867,49 +9928,51 @@ msgstr "Mis... \"experimentos\" sugieren que nuestra mitad humana se extrae del 
 #: /Game/Dialogue/Widow/Default/WidowKeystone.Default__WidowKeystone_C.SessionData.Lines(0).Lines
 msgctxt ",B7A48A8D48179006F728B3895940A90C"
 msgid "Ah the glowing rock trapped in my web."
-msgstr ""
+msgstr "Ah, la roca brillante atrapada en mi telaraña."
 
 #. Key:	B7A8AD6E44A41AB54281548D1A882FFC
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaHadSex02.Default__CamillaHadSex02_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/Camilla/Default/CamillaHadSex02.Default__CamillaHadSex02_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",B7A8AD6E44A41AB54281548D1A882FFC"
 msgid "Wow human, you must have been desperate to give this nugget your love."
-msgstr ""
+msgstr "Guau, humana, debes haber estado desesperada por darle a esta pepita tu amor."
 
 #. Key:	B7AB851641C9ABEE4A178B9DFFD50B0B
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(33 - Value).TraitIcons.DisplayName
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(33 - Value).TraitIcons.DisplayName
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(33 -
+#: Value).TraitIcons.DisplayName
 msgctxt ",B7AB851641C9ABEE4A178B9DFFD50B0B"
 msgid "Hybrid"
-msgstr "Híbrida"
+msgstr "Híbrido"
 
 #. Key:	B7ABB23A457CC2E34BB616933364E7F3
 #. SourceLocation:	/Game/Breeding/Positions/Lifted.Default__Lifted_C.SessionData.Description
 #: /Game/Breeding/Positions/Lifted.Default__Lifted_C.SessionData.Description
 msgctxt ",B7ABB23A457CC2E34BB616933364E7F3"
 msgid "A larger giver uses its strength to lift the receiver while penetrating from behind."
-msgstr "Un/a dador/a más grande usa su fuerza para levantar a la receptora mientras penetra desde atrás."
+msgstr "Un donante más grande usa su fuerza para levantar a la receptora mientras la penetra por detrás."
 
 #. Key:	B7C8EAFE428A554328A015A9F572AEDC
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaHadSex01.Default__LeylannaHadSex01_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/Leylanna/Default/LeylannaHadSex01.Default__LeylannaHadSex01_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",B7C8EAFE428A554328A015A9F572AEDC"
 msgid "Make love with me again @BREEDER_NAME@, let us writhe in pleasure before Her gaze."
-msgstr ""
+msgstr "Hazme el amor de nuevo @BREEDER_NAME@, retorciéndonos de placer ante Su mirada."
 
 #. Key:	B7DDB984480E5280CB46B69238C0654E
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(25 - Value).TraitIcons.HelpText
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(25 - Value).TraitIcons.HelpText
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(25 -
+#: Value).TraitIcons.HelpText
 msgctxt ",B7DDB984480E5280CB46B69238C0654E"
 msgid "Chubby: This one has more body fat."
-msgstr "Gordita/o: Esta/e tiene más grasa corporal."
+msgstr "Gordito: este tiene más grasa corporal."
 
 #. Key:	B7F0D9A14870E8556879B3A948639F2A
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchHaveKeystone.Default__MonarchHaveKeystone_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Monarch/Default/MonarchHaveKeystone.Default__MonarchHaveKeystone_C.SessionData.Lines(2).Lines
 msgctxt ",B7F0D9A14870E8556879B3A948639F2A"
 msgid "Collecting nectar as a delicate butterfly is difficult."
-msgstr ""
+msgstr "Recoger néctar como una delicada mariposa es difícil."
 
 #. Key:	B8035279491515770BA6408AEE0EC908
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_Forgot.Default__ParvatiDefault01_Forgot_C.SessionData.Lines(1).Lines
@@ -9923,42 +9986,42 @@ msgstr "No te preocupes por tu mente olvidadiza."
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePlay1.Default__MegaSlimePlay1_C.SessionData.LinesToFemale(4).LinesToFemale
 msgctxt ",B8242BCA4C426CBD3195A28D03A195C3"
 msgid "Well what are you waiting for? Come on in!"
-msgstr ""
+msgstr "¿Bueno, qué estás esperando? ¡Venga!"
 
 #. Key:	B825E1564FCBA4D960D238AFD10804AC
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMMuchEnergy.Default__DMMuchEnergy_C.SessionData.LinesToFuta(3).LinesToFuta
 #: /Game/Dialogue/DragonMatriarch/Default/DMMuchEnergy.Default__DMMuchEnergy_C.SessionData.LinesToFuta(3).LinesToFuta
 msgctxt ",B825E1564FCBA4D960D238AFD10804AC"
 msgid "The lucky Titan's cock won't be able to keep up!"
-msgstr ""
+msgstr "¡La polla del afortunado titán no podrá seguir el ritmo!"
 
 #. Key:	B8297A054AB04B137F3266B6480756F5
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchGreeting01.Default__MonarchGreeting01_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Monarch/Default/MonarchGreeting01.Default__MonarchGreeting01_C.SessionData.Lines(3).Lines
 msgctxt ",B8297A054AB04B137F3266B6480756F5"
 msgid "I'm here to collect nectar for our queen."
-msgstr ""
+msgstr "Estoy aquí para recolectar néctar para nuestra reina."
 
 #. Key:	B82A33C04616825E1FC07F99415D421D
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01_RL_M.Default__FernDefault01_RL_M_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/Fern/Default/FernDefault01_RL_M.Default__FernDefault01_RL_M_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",B82A33C04616825E1FC07F99415D421D"
 msgid "What a lovely talking fern..."
-msgstr "Qué hermosa helecho parlante..."
+msgstr "Qué encantador helecho parlante..."
 
 #. Key:	B82BF1F5413587624AD2A6919AF2A0BA
 #. SourceLocation:	/Game/World/Architecture/CockblockGate/EM_CBGate.Default__EM_CBGate_C.ActivateMessage
 #: /Game/World/Architecture/CockblockGate/EM_CBGate.Default__EM_CBGate_C.ActivateMessage
 msgctxt ",B82BF1F5413587624AD2A6919AF2A0BA"
 msgid "Place Keystone"
-msgstr ""
+msgstr "Coloca la piedra-llave"
 
 #. Key:	B832AA994DBADAA17A15049B206652C5
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R02.Default__CamillaDefault01_R02_C.SessionData.Lines(9).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R02.Default__CamillaDefault01_R02_C.SessionData.Lines(9).Lines
 msgctxt ",B832AA994DBADAA17A15049B206652C5"
 msgid "Well I've answered your question so you probably want to leave now. If you have any more questions you should feel free to ask me. Although I'm sure Falene could answer your questions too."
-msgstr "Bueno, he respondido tu pregunta, así que probablemente quieras irte ya. Si tienes más preguntas, no duda en preguntarme. Aunque estoy segura de que Falene también podría responder tus preguntas."
+msgstr "Bueno, he respondido a tu pregunta, así que probablemente quieras irte ahora. Si tienes más preguntas, no dudes en preguntarme. Aunque estoy segura de que Falene también podría responder a tus preguntas."
 
 #. Key:	B841784842366C72B99D7BABC88D97E6
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_RL.Default__FaleneDefault01_RL_C.ResponseData(3).ResponseData.BreederPrompt
@@ -9972,28 +10035,28 @@ msgstr "¡El embarazo no tiene sentido!"
 #: /Game/Dialogue/Monarch/Default/MonarchHaveKeystone.Default__MonarchHaveKeystone_C.SessionData.Lines(1).Lines
 msgctxt ",B8579E3C4F6006CC5CA3CF899F4C6E39"
 msgid "Can y-y-you help me first?"
-msgstr ""
+msgstr "¿P-p-puedes ayudarme primero?"
 
 #. Key:	B85AAF9E46DEE4DCD0E942BEAB518960
 #. SourceLocation:	/Game/Breeding/Positions/Butterfly.Default__Butterfly_C.SessionData.Description
 #: /Game/Breeding/Positions/Butterfly.Default__Butterfly_C.SessionData.Description
 msgctxt ",B85AAF9E46DEE4DCD0E942BEAB518960"
 msgid "The receiver lays elevated on her back, while the giver stands and thrusts."
-msgstr "La receptora yace elevada sobre su espalda, mientras que el/la dador/a se queda de pie y empuja."
+msgstr "La receptora yace elevada sobre su espalda, mientras que el donante se queda de pie y empuja."
 
 #. Key:	B864A1D642255D8E7C1821AC53EC9231
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMNapSomewhereElse.Default__DMNapSomewhereElse_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMNapSomewhereElse.Default__DMNapSomewhereElse_C.SessionData.Lines(2).Lines
 msgctxt ",B864A1D642255D8E7C1821AC53EC9231"
 msgid "*Yawn*"
-msgstr ""
+msgstr "*Bosteza*"
 
 #. Key:	B87369D344C73AFA3F04D49BC07D8BE3
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiTaskFulfilled.Default__FesssiTaskFulfilled_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiTaskFulfilled.Default__FesssiTaskFulfilled_C.SessionData.Lines(2).Lines
 msgctxt ",B87369D344C73AFA3F04D49BC07D8BE3"
 msgid "My ass can once again sway in the breeze, and trust me human, it will."
-msgstr ""
+msgstr "Mi culo puede mecerse con la brisa una vez más, y confía en mí humano, lo hará."
 
 #. Key:	B87B8D5E4C3F16D731F4EA884051A1FD
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_StartButterfly.Default__ParvatiDefault01_StartButterfly_C.SessionData.Lines(0).Lines
@@ -10007,14 +10070,14 @@ msgstr "..."
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeAboutOrb.Default__MegaSlimeAboutOrb_C.SessionData.Lines(2).Lines
 msgctxt ",B89AB95C43AA6DC8279A10A4ECA0DD22"
 msgid "After being down here alone for so long, I had forgotten what it was like to speak with someone."
-msgstr ""
+msgstr "Después de estar aquí sola durante tanto tiempo, había olvidado lo que era hablar con alguien."
 
 #. Key:	B8C3F96E4BB231CDD5684BA134FF69CB
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaHadSex02.Default__CamillaHadSex02_C.SessionData.LinesToFuta(1).LinesToFuta
 #: /Game/Dialogue/Camilla/Default/CamillaHadSex02.Default__CamillaHadSex02_C.SessionData.LinesToFuta(1).LinesToFuta
 msgctxt ",B8C3F96E4BB231CDD5684BA134FF69CB"
 msgid "Your cock was so big, I didn't think I could take all of it."
-msgstr ""
+msgstr "Tu polla era tan grande, no pensé que pudiera tomarla toda."
 
 #. Key:	B8D3474E436959F3B7C140BFE42CF3C0
 #. SourceLocation:	/Game/Breeding/Positions/Doggy.Default__Doggy_C.SessionData.Description
@@ -10028,42 +10091,42 @@ msgstr "A cuatro patas, la receptora es golpeada por detrás."
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToFuta(6).LinesToFuta
 msgctxt ",B8D5DBD04A2C66CA06A044B457DC1B92"
 msgid "Stick that lovely human dick deep into my Lamia body... yes..."
-msgstr "Inserta esa hermosa polla humana profundamente en mi cuerpo de Lamia... sí..."
+msgstr "Mete ese hermoso pene humano profundamente en mi cuerpo de lamia... sí..."
 
 #. Key:	B8E34EF44104C91D147557A4F02B0AD7
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiHadSex01.Default__FesssiHadSex01_C.SessionData.LinesToFuta(0).LinesToFuta
 #: /Game/Dialogue/Fesssi/Default/FesssiHadSex01.Default__FesssiHadSex01_C.SessionData.LinesToFuta(0).LinesToFuta
 msgctxt ",B8E34EF44104C91D147557A4F02B0AD7"
 msgid "Ahhh... yet another load for my giant ass. Hiss!"
-msgstr ""
+msgstr "Ahhh... otra carga más para mi culo gigante. ¡Sss!"
 
 #. Key:	B92677C94581B16A61827CA24E811637
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeAboutBees.Default__BeeAboutBees_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/QueenBee/Default/BeeAboutBees.Default__BeeAboutBees_C.SessionData.Lines(1).Lines
 msgctxt ",B92677C94581B16A61827CA24E811637"
 msgid "To harvest it, a queen will produce worker bee daughters who then mix the nectar with their breast milk."
-msgstr ""
+msgstr "Para cosecharla, una reina producirá hijas de abejas obreras que luego mezclan el néctar con su leche materna."
 
 #. Key:	B98DBFC944D984D0B00D708EE1B9AB94
 #. SourceLocation:	/Game/Dialogue/Emissary/SexScenes/EmissaryAngelGroinLove.Default__EmissaryAngelGroinLove_C.SessionData.LinesToFuta(0).LinesToFuta
 #: /Game/Dialogue/Emissary/SexScenes/EmissaryAngelGroinLove.Default__EmissaryAngelGroinLove_C.SessionData.LinesToFuta(0).LinesToFuta
 msgctxt ",B98DBFC944D984D0B00D708EE1B9AB94"
 msgid "Indulge yourself human, for I am thy servant."
-msgstr "Degústate humana, pues soy tu sirviente."
+msgstr "Deléitate humana, pues soy tu sirviente."
 
 #. Key:	B9D395FA4457763F84E8BD94863D5FBD
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadFlowers.Default__DryadFlowers_C.SessionData.Lines(6).Lines
 #: /Game/Dialogue/Autumn/Default/DryadFlowers.Default__DryadFlowers_C.SessionData.Lines(6).Lines
 msgctxt ",B9D395FA4457763F84E8BD94863D5FBD"
 msgid "Once the plant has stored enough nectar, it will wait for a horny little bee to come by and... well you know."
-msgstr ""
+msgstr "Una vez que la planta haya almacenado suficiente néctar, esperará a que pase una abejita cachonda y... bueno, ya lo sabes."
 
 #. Key:	B9EEB95A4D8ACD7FAC9BD4AE769758FE
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiHowLong.Default__FesssiHowLong_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiHowLong.Default__FesssiHowLong_C.SessionData.Lines(2).Lines
 msgctxt ",B9EEB95A4D8ACD7FAC9BD4AE769758FE"
 msgid "Occasionally, random travellers would try to get around me, but they soon found their genitals on the receiving end of my tongue."
-msgstr ""
+msgstr "De vez en cuando, viajeros aleatorios intentaban rodearme, pero pronto encontraron sus genitales en el extremo receptor de mi lengua."
 
 #. Key:	B9F630DD484439D0C2B6EFBC3D01D2C5
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_FutaBalls.Default__FaleneDefault01_FutaBalls_C.SessionData.Lines(1).Lines
@@ -10077,21 +10140,21 @@ msgstr "El semen se almacena internamente para reducir el potencial de daño y h
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R02.Default__FaleneDefault01_R02_C.SessionData.Lines(7).Lines
 msgctxt ",BA4F5C334B416E6C99C047BD1AF731C9"
 msgid "Feel free to try though... I will consider it foreplay,  rip your clothes off, and then mate with you for hours!"
-msgstr "Sin embargo, siéntete libre de probarlo... ¡Lo consideraré un juego previo, te arrancaré la ropa y luego me aparearé contigo durante horas!"
+msgstr "Sin embargo, siéntete libre de intentarlo... lo consideraré un juego previo, ¡te arrancaré la ropa y luego me aparearé contigo durante horas!"
 
 #. Key:	BABE7B1340FA36AADAE0E596C6FC1721
 #. SourceLocation:	/Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",BABE7B1340FA36AADAE0E596C6FC1721"
 msgid "How I envy this tall sexy body of yours, but ohhhhh it feels so good!"
-msgstr "¡Cómo envidio este cuerpo alto y sexy tuyo, pero ohhhhh se siente tan bien!"
+msgstr "Cómo envidio este cuerpo alto y sexy tuyo, ¡pero ohhhhh se siente tan bien!"
 
 #. Key:	BAEE9CCB4074E077BFF0FBAE275D41CD
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(1).Lines
 msgctxt ",BAEE9CCB4074E077BFF0FBAE275D41CD"
 msgid "From the Void, she created this universe and began to indulge in creation."
-msgstr "Desde el vacío, ella creó este universo y comenzó a disfrutar de la creación."
+msgstr "Desde el Vacío, Ella creó este universo y comenzó a disfrutar de la creación."
 
 #. Key:	BB0E7B2D4F49CAAB00A884BE87ED9F44
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieGreeting01.Default__CassieGreeting01_C.SessionData.Lines(7).Lines
@@ -10105,14 +10168,14 @@ msgstr "O si realmente quieres untarme el trasero y dejarme ver tu \"propiedad\"
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePlay.Default__MegaSlimePlay_C.SessionData.LinesToFuta(0).LinesToFuta
 msgctxt ",BB111DD44D5B70DED7DD519DD967FEC8"
 msgid "Really?! These truly are the best days of my life!"
-msgstr ""
+msgstr "¡¿En serio?! ¡Estos son verdaderamente los mejores días de mi vida!"
 
 #. Key:	BB8503A14E015AEDED4E1C866261B05C
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeHowLong.Default__MegaSlimeHowLong_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeHowLong.Default__MegaSlimeHowLong_C.SessionData.Lines(3).Lines
 msgctxt ",BB8503A14E015AEDED4E1C866261B05C"
 msgid "If I could only get some townsfolk to come here and feed me warm cum!"
-msgstr ""
+msgstr "¡Si tan solo pudiera hacer que algunos habitantes vinieran aquí y me alimentaran con semen caliente!"
 
 #. Key:	BB8EC0EA497B20CC5A726AA919605178
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R04.Default__CamillaDefault01_R04_C.SessionData.Lines(0).Lines
@@ -10126,28 +10189,28 @@ msgstr "¡Muy gracioso!"
 #: /Game/Dialogue/Fern/DefaultP2/FernGreeting02.Default__FernGreeting02_C.SessionData.LinesToFuta(0).LinesToFuta
 msgctxt ",BBBCA38B49D367A566E07BA607FA7359"
 msgid "Oh Master, you have fed me well."
-msgstr "Oh Maestra, me has alimentado bien."
+msgstr "Oh, Master, me has alimentado bien."
 
 #. Key:	BC25BCBE4F9535F47E145F8384E62BA5
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03_R05.Default__FernDefault03_R05_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03_R05.Default__FernDefault03_R05_C.SessionData.Lines(2).Lines
 msgctxt ",BC25BCBE4F9535F47E145F8384E62BA5"
 msgid "You should name our daughter!"
-msgstr "¡Deberías nombrar a nuestra hija!"
+msgstr "¡Deberías darle un nombre a nuestra hija!"
 
 #. Key:	BC29BB8B478C65C2CBA0898E60299364
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadCherryHelp_RL.Default__DryadCherryHelp_RL_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/Autumn/Default/DryadCherryHelp_RL.Default__DryadCherryHelp_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",BC29BB8B478C65C2CBA0898E60299364"
 msgid "Uh, I only make babies not fruit."
-msgstr ""
+msgstr "Uh, solo hago bebés, no frutas."
 
 #. Key:	BC33AF644FC93D01CDEF628CB3209014
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchHadSex01.Default__MonarchHadSex01_C.SessionData.LinesToFuta(2).LinesToFuta
 #: /Game/Dialogue/Monarch/Default/MonarchHadSex01.Default__MonarchHadSex01_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",BC33AF644FC93D01CDEF628CB3209014"
 msgid "It felt very good. Maybe... w-w-we can do it again?"
-msgstr ""
+msgstr "Se sintió muy bien. ¿Tal vez... p-p-podemos hacerlo de nuevo?"
 
 #. Key:	BC50064D4E4A670A496FFAB77DB95208
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToFemale(4).LinesToFemale
@@ -10161,56 +10224,56 @@ msgstr "Algo mítico... algo prohibido... algo... ¡humano!"
 #: /Game/Dialogue/AmberMae/SexScenes/AmberMilkyF.Default__AmberMilkyF_C.SessionData.Lines(5).Lines
 msgctxt ",BC8D18A04D5B0C96E407F884999310E6"
 msgid "Eeek I'm a sensitve gal! Yer gonna make me pop... ohhh."
-msgstr "¡Eeek soy una shica sensibre! Me vah a aseh explotah... ohhh."
+msgstr "¡Eeek, soy una shica sensibre! Me vah a aseh explotah... ohhh."
 
 #. Key:	BCB1A0F54609C871293D96B90F2E8B8E
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_UpHere.Default__RomyDefault01_UpHere_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Romy/Default/RomyDefault01_UpHere.Default__RomyDefault01_UpHere_C.SessionData.Lines(2).Lines
 msgctxt ",BCB1A0F54609C871293D96B90F2E8B8E"
 msgid "Ponder this, you just manifested on a ranch in front of a purple elf."
-msgstr "Medita sobre esto, acabas de manifestarte en un rancho frente a una elfa morada."
+msgstr "Reflexiona sobre esto, acabas de manifestarte en un rancho frente a una elfa púrpura."
 
 #. Key:	BCCE27C44B7552836451CAB377E5AE75
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R01.Default__CamillaDefault01_R01_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R01.Default__CamillaDefault01_R01_C.SessionData.Lines(2).Lines
 msgctxt ",BCCE27C44B7552836451CAB377E5AE75"
 msgid "You also need to have something to... entice @MONSTER_RACE@ before you can bind them."
-msgstr "También debes tener algo para... atraer a @MONSTER_RACE@ antes de poder vincularte con ellos."
+msgstr "También debes tener algo para... atraer @MONSTER_RACE@ antes de poder vincularte con ellos."
 
 #. Key:	BCD1086643EFC484462E0494A74B5A84
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcTribeSucks.Default__OrcTribeSucks_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcTribeSucks.Default__OrcTribeSucks_C.SessionData.Lines(4).Lines
 msgctxt ",BCD1086643EFC484462E0494A74B5A84"
 msgid "Grrrr! But elves are stupid. They broke gate again."
-msgstr ""
+msgstr "¡Grrrr! Pero los elfos son estúpidos. Rompieron el portón de nuevo."
 
 #. Key:	BD2871634CBCB94F889B2FA98F0BF8DA
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryGreeting01.Default__EmissaryGreeting01_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryGreeting01.Default__EmissaryGreeting01_C.SessionData.Lines(4).Lines
 msgctxt ",BD2871634CBCB94F889B2FA98F0BF8DA"
 msgid "Lost are these souls, and you alone can help them. As we speak, they wander aimlessly, enslaved by their desires."
-msgstr "Perdidas están estas almas, y solo tú puedes ayudarlas. Mientras hablamos, deambulan sin rumbo, esclavizadas por sus deseos."
+msgstr "Perdidas están estas almas, y solo tú puedes ayudarlas. Mientras hablamos, vagan sin rumbo, esclavizadas por sus deseos."
 
 #. Key:	BD299A114393AB7ECF48C8A20700F593
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_RL.Default__EmissaryDefault01_RL_C.ResponseData(6).ResponseData.BreederPrompt
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_RL.Default__EmissaryDefault01_RL_C.ResponseData(6).ResponseData.BreederPrompt
 msgctxt ",BD299A114393AB7ECF48C8A20700F593"
 msgid "What is the endless daze?"
-msgstr ""
+msgstr "¿Qué es el aturdimiento infinito?"
 
 #. Key:	BD326ED44A2732523BC286AA438967A7
 #. SourceLocation:	/Game/Dialogue/Yasmine/Default/YasmineHadSex01.Default__YasmineHadSex01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Yasmine/Default/YasmineHadSex01.Default__YasmineHadSex01_C.SessionData.Lines(1).Lines
 msgctxt ",BD326ED44A2732523BC286AA438967A7"
 msgid "Waves of ecstasy still course through my body."
-msgstr ""
+msgstr "Oleadas de éxtasis todavía recorren mi cuerpo."
 
 #. Key:	BD61F6BE4278688EEA2B878F6E8C6994
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(14).LinesToFemale
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(14).LinesToFemale
 msgctxt ",BD61F6BE4278688EEA2B878F6E8C6994"
 msgid "My vagina is pulsing..."
-msgstr "Mi vagina está latiendo..."
+msgstr "Mi vagina está palpitando..."
 
 #. Key:	BD6CCEB440D9DEC7D0A7988EC78DC07B
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_BlueSmoke2.Default__LeylannaDefault01_BlueSmoke2_C.SessionData.Lines(1).Lines
@@ -10224,35 +10287,36 @@ msgstr "Ahhhh..."
 #: /Game/Dialogue/Kybele/Default/KybeleDragonMatriarch.Default__KybeleDragonMatriarch_C.SessionData.Lines(3).Lines
 msgctxt ",BD73D4BA496C11214C7199AB3A0ED336"
 msgid "But if the sexual encounter were to come to me..."
-msgstr ""
+msgstr "Pero si me llegara el encuentro sexual..."
 
 #. Key:	BDF0CA7D47EE073120067A9FCE686C17
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadBossomCherries.Default__DryadBossomCherries_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Autumn/Default/DryadBossomCherries.Default__DryadBossomCherries_C.SessionData.Lines(1).Lines
 msgctxt ",BDF0CA7D47EE073120067A9FCE686C17"
 msgid "They are for the Ayrshires that roam around here, and oh my can they eat!"
-msgstr ""
+msgstr "Son para las ayrshires que deambulan por aquí, y ¡oh Dios, lo que pueden comer!"
 
 #. Key:	BDF9214F4D266A69032FE9921524969C
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFuta(2).LinesToFuta
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",BDF9214F4D266A69032FE9921524969C"
 msgid "You have just become @WORLD_NAME@'s newest resident!"
-msgstr "¡Acabas de convertirte en la nueva residente de @WORLD_NAME@!"
+msgstr "¡Te acabas de convertir en el residente más nuevo de @WORLD_NAME@!"
 
 #. Key:	BDFBF2444482EC9CA1B83B92138A12DD
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(35 - Value).TraitIcons.HelpText
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(35 - Value).TraitIcons.HelpText
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(35 -
+#: Value).TraitIcons.HelpText
 msgctxt ",BDFBF2444482EC9CA1B83B92138A12DD"
 msgid "Gemini: This one has an identical twin."
-msgstr ""
+msgstr "Géminis: este tiene un gemelo idéntico."
 
 #. Key:	BE16AB634A0B031F9DEEF79B3D80C4A5
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieHadSex01.Default__CassieHadSex01_C.SessionData.LinesToFemale(4).LinesToFemale
 #: /Game/Dialogue/Cassie/Default/CassieHadSex01.Default__CassieHadSex01_C.SessionData.LinesToFemale(4).LinesToFemale
 msgctxt ",BE16AB634A0B031F9DEEF79B3D80C4A5"
 msgid "Meow!"
-msgstr ""
+msgstr "¡Miau!"
 
 #. Key:	BE3E92FA4D0B5FE720EA038B6A6FF27C
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryBlessedInquiry02_RL.Default__EmissaryBlessedInquiry02_RL_C.ResponseData(1).ResponseData.BreederPrompt
@@ -10266,42 +10330,42 @@ msgstr "Bueno saberlo."
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01.Default__CamillaDefault01_C.SessionData.Lines(0).Lines
 msgctxt ",BE946F0645DD9D40528D2A9DB1FB48B4"
 msgid "Sometimes Falene makes me ride on her back around town."
-msgstr "A veces, Falene me obliga a montarme en su espalda por la ciudad."
+msgstr "A veces, Falene me hace montar en su espalda por la ciudad."
 
 #. Key:	BE9F677046DE7F9AE5246FB18D7F8FFB
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01.Default__CamillaDefault01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01.Default__CamillaDefault01_C.SessionData.Lines(1).Lines
 msgctxt ",BE9F677046DE7F9AE5246FB18D7F8FFB"
 msgid "Once she threw me into that pussy portal when Neela wasn't looking!"
-msgstr "¡Una vez me arrojó al coño portal cuando Neela no estaba mirando!"
+msgstr "¡Una vez me arrojó a ese coño portal cuando Neela no estaba mirando!"
 
 #. Key:	BED6E4EB4536C7A1E1D8EF8C6FA3F149
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryCockblockGates.Default__EmissaryCockblockGates_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryCockblockGates.Default__EmissaryCockblockGates_C.SessionData.Lines(3).Lines
 msgctxt ",BED6E4EB4536C7A1E1D8EF8C6FA3F149"
 msgid "But beware, other blessed @MONSTER_RACE@ have collected the keystones over the years."
-msgstr ""
+msgstr "Pero cuidado, otros @MONSTER_RACE@ bendecidos han recolectado las piedras-llave a lo largo de los años."
 
 #. Key:	BEDA154E4410DE62211DBFA48872ED35
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchHadSex01.Default__MonarchHadSex01_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/Monarch/Default/MonarchHadSex01.Default__MonarchHadSex01_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",BEDA154E4410DE62211DBFA48872ED35"
 msgid "Thank you h-h-human!"
-msgstr ""
+msgstr "¡Gracias h-h-humano!"
 
 #. Key:	BEDA7D94498AC1A3091C29BABE2C94F7
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_RL.Default__CamillaDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_RL.Default__CamillaDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",BEDA7D94498AC1A3091C29BABE2C94F7"
 msgid "Falene said you could tell me how to catch @MONSTER_RACE@?"
-msgstr ""
+msgstr "¿Falene dijo que podrías decirme cómo atrapar @MONSTER_RACE@?"
 
 #. Key:	BF0DF5C24AC9872B58BA689D790CE436
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeTaskFulfilled.Default__BeeTaskFulfilled_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/QueenBee/Default/BeeTaskFulfilled.Default__BeeTaskFulfilled_C.SessionData.Lines(3).Lines
 msgctxt ",BF0DF5C24AC9872B58BA689D790CE436"
 msgid "The keystone now belongs to you."
-msgstr ""
+msgstr "La piedra-llave ahora te pertenece."
 
 #. Key:	BF4DCF6B4CBF1E3FAE0D139E494C7673
 #. SourceLocation:	/Game/Characters/Procedural/Variants/Demon/Harvest/DemonHarvest.Default__DemonHarvest_C.Harvest.RaceName
@@ -10315,77 +10379,78 @@ msgstr "Demonio"
 #: /Game/Dialogue/OrcChief/Default/OrcAkabekoCheck.Default__OrcAkabekoCheck_C.SessionData.Lines(3).Lines
 msgctxt ",BF51DA004C841AAF7E6BE4B506111783"
 msgid "Now tribe sisters are making offspring with her. Tonight she will be mine again."
-msgstr ""
+msgstr "Ahora las hermanas de la tribu están teniendo descendencia con ella. Esta noche volverá a ser mía."
 
 #. Key:	BF75C6BF46495EB7F48CD398677B4B16
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeDefault01.Default__BeeDefault01_C.SessionData.LinesToFemale(4).LinesToFemale
 #: /Game/Dialogue/QueenBee/Default/BeeDefault01.Default__BeeDefault01_C.SessionData.LinesToFemale(4).LinesToFemale
 msgctxt ",BF75C6BF46495EB7F48CD398677B4B16"
 msgid "Is t-t-there something... you want human?"
-msgstr ""
+msgstr "¿Hay a-a-algo... que quieras humana?"
 
 #. Key:	BF7F7E1041AD5B8267C70694F83985F6
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R03.Default__CamillaDefault01_R03_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R03.Default__CamillaDefault01_R03_C.SessionData.Lines(0).Lines
 msgctxt ",BF7F7E1041AD5B8267C70694F83985F6"
 msgid "Meh... you're just another one of those who thinks I'm cute because I'm small!"
-msgstr "Meh... ¡eres una más de los que piensan que soy linda porque soy pequeña!"
+msgstr "Meh... ¡eres uno más de los que piensan que soy linda porque soy pequeña!"
 
 #. Key:	BF975F284EF533BA005E9DB9E53ED275
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcBrashDumb.Default__OrcBrashDumb_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcBrashDumb.Default__OrcBrashDumb_C.SessionData.Lines(5).Lines
 msgctxt ",BF975F284EF533BA005E9DB9E53ED275"
 msgid "Orc who wins the most fights and makes the most offspring becomes chieftain."
-msgstr ""
+msgstr "El orco que gana más peleas y tiene más descendientes se convertir en cacique."
 
 #. Key:	BFA3EA894BDCD8476E3C3E83125BF435
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R04.Default__FaleneDefault01_R04_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R04.Default__FaleneDefault01_R04_C.SessionData.Lines(3).Lines
 msgctxt ",BFA3EA894BDCD8476E3C3E83125BF435"
 msgid "Now that I have a human to play with, I look forward to testing these theories!"
-msgstr "Ahora que tengo un humano con el que jugar, ¡espero probar estas teorías!"
+msgstr "Ahora que tengo un ser humano con quien jugar, ¡espero probar estas teorías!"
 
 #. Key:	BFCA3659420358C2CFA5B5B426282E9A
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(9 - Value).TraitIcons.HelpText
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(9 - Value).TraitIcons.HelpText
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(9 -
+#: Value).TraitIcons.HelpText
 msgctxt ",BFCA3659420358C2CFA5B5B426282E9A"
 msgid "Debauched: Offspring have a 20% chance to ignore the negative impacts of inbreeding."
-msgstr "Perversa/o: Su descendencia tiene un 20% de posibilidades de ignorar los impactos negativos de la endogamia."
+msgstr "Perverso: los descendientes tienen un 20% de posibilidades de ignorar los impactos negativos de la endogamia."
 
 #. Key:	BFE1041943E9B477E3A7848FC8505D3E
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_BatheMe.Default__RomyDefault01_BatheMe_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Romy/Default/RomyDefault01_BatheMe.Default__RomyDefault01_BatheMe_C.SessionData.Lines(0).Lines
 msgctxt ",BFE1041943E9B477E3A7848FC8505D3E"
 msgid "Who shall I cleanse of their grungy trait?"
-msgstr "¿A quién debo limpiar de su rasgo sucio?"
+msgstr "¿A quién voy a limpiar de su rasgo Sucio?"
 
 #. Key:	BFE419FB4198F6466864C0A660018BA3
 #. SourceLocation:	/Game/Characters/Procedural/Variants/Thriae/Harvest/ThriaeHarvest.Default__ThriaeHarvest_C.Harvest.Description
 #: /Game/Characters/Procedural/Variants/Thriae/Harvest/ThriaeHarvest.Default__ThriaeHarvest_C.Harvest.Description
 msgctxt ",BFE419FB4198F6466864C0A660018BA3"
 msgid "Thriae body fluids."
-msgstr "Fluidos corporales de Thriae."
+msgstr "Fluidos corporales de Thriaes."
 
 #. Key:	BFE69EFF42781D385F73FFB257B3F5C6
 #. SourceLocation:	/Game/Dialogue/Yasmine/Default/YasmineAwake.Default__YasmineAwake_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Yasmine/Default/YasmineAwake.Default__YasmineAwake_C.SessionData.Lines(3).Lines
 msgctxt ",BFE69EFF42781D385F73FFB257B3F5C6"
 msgid "Wait, you're human?!"
-msgstr ""
+msgstr "Espera, ¡¿eres humano?!"
 
 #. Key:	C0073F7149266435A304ECAB73399664
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadHadSex01.Default__DryadHadSex01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Autumn/Default/DryadHadSex01.Default__DryadHadSex01_C.SessionData.Lines(1).Lines
 msgctxt ",C0073F7149266435A304ECAB73399664"
 msgid "Ahhh... you made me feel so good, I've never produced such a large fruit."
-msgstr ""
+msgstr "Ahhh... me hiciste sentir tan bien, nunca había producido una fruta tan grande."
 
 #. Key:	C034823A4189F2EED2DFEBB7B3005286
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMDefault_RL4.Default__DMDefault_RL4_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/DragonMatriarch/Default/DMDefault_RL4.Default__DMDefault_RL4_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",C034823A4189F2EED2DFEBB7B3005286"
 msgid "Forget the Titan, how about some human?"
-msgstr ""
+msgstr "Olvídate del titán, ¿qué tal un humano?"
 
 #. Key:	C03BBCDD4AACD3CC387AAAB2A4FD00E9
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R01.Default__CamillaDefault01_R01_C.SessionData.Lines(1).Lines
@@ -10406,49 +10471,49 @@ msgstr "Esta es el área más incomprendida y difícil de observar."
 #: /Game/Dialogue/Petra/Default/PetraGreeting01.Default__PetraGreeting01_C.SessionData.Lines(4).Lines
 msgctxt ",C0DA0B9242845DD678C67991582BCF2B"
 msgid "We made love for hours, and she taught me how to position my body in ways I never thought possible!"
-msgstr ""
+msgstr "Hicimos el amor durante horas, ¡y ella me enseñó a colocar mi cuerpo de maneras que nunca creí posible!"
 
 #. Key:	C0E8ACF94F6090E346B6B3BFDB6536AF
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.EM_Keystone_Widow.FailMessage
 #: /Game/World/Overworld.Overworld:PersistentLevel.EM_Keystone_Widow.FailMessage
 msgctxt ",C0E8ACF94F6090E346B6B3BFDB6536AF"
 msgid "It's wrapped in webs."
-msgstr ""
+msgstr "Está envuelto en telarañas."
 
 #. Key:	C1169E76415C88B42A1C1EAA53F38266
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_EnlightenedOne.Default__NeelaDefault01_EnlightenedOne_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_EnlightenedOne.Default__NeelaDefault01_EnlightenedOne_C.SessionData.Lines(2).Lines
 msgctxt ",C1169E76415C88B42A1C1EAA53F38266"
 msgid "We have... uh... met before. Many times."
-msgstr "Nos hemos... am... conocido antes. Muchas veces."
+msgstr "Nos hemos... eh... conocido antes. Muchas veces."
 
 #. Key:	C11A1BE2468282C1EFE3DA9E52978358
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraHadSex01.Default__PetraHadSex01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Petra/Default/PetraHadSex01.Default__PetraHadSex01_C.SessionData.Lines(0).Lines
 msgctxt ",C11A1BE2468282C1EFE3DA9E52978358"
 msgid "Was I a good bunny?"
-msgstr ""
+msgstr "¿Fui una buena conejita?"
 
 #. Key:	C129394C4F9E7B6D0EF3EF87678D5D3B
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeDefault01_RL.Default__BeeDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/QueenBee/Default/BeeDefault01_RL.Default__BeeDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",C129394C4F9E7B6D0EF3EF87678D5D3B"
 msgid "If I must..."
-msgstr ""
+msgstr "Si debo..."
 
 #. Key:	C156402F4738F87B9C9392A5443BE29F
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryGreeting01.Default__EmissaryGreeting01_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryGreeting01.Default__EmissaryGreeting01_C.SessionData.Lines(2).Lines
 msgctxt ",C156402F4738F87B9C9392A5443BE29F"
 msgid "You are unique in this world, for all other living things, myself included, are @MONSTER_RACE@. We are merely half human, crossed with... something else."
-msgstr "Eres única en este mundo, pues todos los demás seres vivos, incluida yo misma, somos @MONSTER_RACE@. Somos simplemente mitad humanos, cruzados con... algo más."
+msgstr "Eres único en este mundo, pues todos los demás seres vivos, incluida yo misma, somos @MONSTER_RACE@. Somos simplemente mitad humanos, cruzados con... algo más."
 
 #. Key:	C18558714C7A7B697778D68CFD03FAF0
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_AboutKrakens.Default__MirruDefault01_AboutKrakens_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_AboutKrakens.Default__MirruDefault01_AboutKrakens_C.SessionData.Lines(4).Lines
 msgctxt ",C18558714C7A7B697778D68CFD03FAF0"
 msgid "Such has caused many a Kraken to force herself on weaker mates."
-msgstr "Esto ha provocado que muchos Kraken sean forzados a tener compañeros más débiles."
+msgstr "Esto ha provocado que muchos kraken se hayan impuesto a sus compañeros más débiles."
 
 #. Key:	C198075048B96603CACC81A045A05956
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_PussyPortals.Default__NeelaDefault01_PussyPortals_C.SessionData.Lines(1).Lines
@@ -10462,42 +10527,42 @@ msgstr "¡Se dice que son una réplica exacta de la vagina de la Diosa misma!"
 #: /Game/Ranch/Upgrades/FormurianPond.Default__FormurianPond_C.Upgrade.Description
 msgctxt ",C2409B0E43C4FECF37A9A4AEC03EA9E7"
 msgid "This allows you to catch and store all Formurian variants."
-msgstr "Esto te permite capturar y almacenar todas las variantes Formurianas."
+msgstr "Esto te permite capturar y almacenar todas las variantes de Formurians."
 
 #. Key:	C25D4CE34387E86F32C4E28046D053D3
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadFatAssLamia.Default__DryadFatAssLamia_C.SessionData.Lines(6).Lines
 #: /Game/Dialogue/Autumn/Default/DryadFatAssLamia.Default__DryadFatAssLamia_C.SessionData.Lines(6).Lines
 msgctxt ",C25D4CE34387E86F32C4E28046D053D3"
 msgid "Ohhh it felt so good.... as I buried my face into her ass and she thrusted her tongue deep into my pussy."
-msgstr ""
+msgstr "Ohhh, se sintió tan bien... mientras enterraba mi cara en su culo y ella empujaba su lengua profundamente en mi coño."
 
 #. Key:	C29993C74D67F8AE960E44826013B47C
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_AboutKrakens.Default__MirruDefault01_AboutKrakens_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_AboutKrakens.Default__MirruDefault01_AboutKrakens_C.SessionData.Lines(1).Lines
 msgctxt ",C29993C74D67F8AE960E44826013B47C"
 msgid "Krakens founded Formuria, and we have upheld lordship ever since. Our subjects respect us, and we rule over them with mercy and honor."
-msgstr "Los Krakens fundaron Formuria, y desde entonces hemos mantenido el señorío. Nuestros súbditos nos respetan y los gobernamos con misericordia y honor."
+msgstr "Los krakens fundaron Formuria, y desde entonces hemos mantenido el señorío. Nuestros súbditos nos respetan y los gobernamos con misericordia y honor."
 
 #. Key:	C2F976F9463088F39315118741B15D32
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_StartKrakVag.Default__MirruDefault01_StartKrakVag_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_StartKrakVag.Default__MirruDefault01_StartKrakVag_C.SessionData.Lines(0).Lines
 msgctxt ",C2F976F9463088F39315118741B15D32"
 msgid "Ohh... you will not regret it human."
-msgstr "Ohh... no te arrepentirás humana."
+msgstr "Ohh... no te arrepentirás humano."
 
 #. Key:	C31358424DDC04F9D0E9C2AFEADAFCE4
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMSoBeItT.Default__DMSoBeItT_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMSoBeItT.Default__DMSoBeItT_C.SessionData.Lines(0).Lines
 msgctxt ",C31358424DDC04F9D0E9C2AFEADAFCE4"
 msgid "Ahhh... so be it!"
-msgstr ""
+msgstr "Ahhh... ¡que así sea!"
 
 #. Key:	C3445C514F78EFD7116EE28D6898079D
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R02.Default__FaleneDefault01_R02_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R02.Default__FaleneDefault01_R02_C.SessionData.Lines(5).Lines
 msgctxt ",C3445C514F78EFD7116EE28D6898079D"
 msgid "Because of our sentience, it's forbidden to catch us. The temple deems it too much like slavery to captivate those whom are blessed."
-msgstr "Debido a nuestra sensibilidad, está prohibido atraparnos. El templo lo considera demasiado parecido con la esclavitud para cautivar a los bendecidos."
+msgstr "Debido a nuestra sensibilidad, está prohibido atraparnos. El templo considera que se parece demasiado a la esclavitud para cautivar a los bendecidos."
 
 #. Key:	C35F97ED47D151CAD06084864F0ED555
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_SpiritForm.Default__LeylannaDefault01_SpiritForm_C.SessionData.Lines(4).Lines
@@ -10518,14 +10583,14 @@ msgstr "¡Baile Erótico!"
 #: /Game/Dialogue/OrcChief/Default/OrcHadSex01.Default__OrcHadSex01_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",C396D17343484B5599E940B3CD9E0AF1"
 msgid "Grrrrr... chieftain horny again. Human shouldn't stay long, things might happen."
-msgstr ""
+msgstr "Grrrrr... cacique cachonda de nuevo. El humano no debería quedarse mucho tiempo, podrían pasar cosas."
 
 #. Key:	C45BFAF14EABF8D1BD3502825C5C1560
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_FloatRhyme.Default__ParvatiDefault01_FloatRhyme_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_FloatRhyme.Default__ParvatiDefault01_FloatRhyme_C.SessionData.Lines(1).Lines
 msgctxt ",C45BFAF14EABF8D1BD3502825C5C1560"
 msgid "And became one with the Goddess who indulged in beastiality."
-msgstr "Y me convertí con la Diosa en una que se entregó a la bestialidad."
+msgstr "Y con la Diosa me convertí en una que se entregaba a la bestialidad."
 
 #. Key:	C462B3344F759413A7C6F28489176C99
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R03_RL.Default__CamillaDefault01_R03_RL_C.ResponseData(1).ResponseData.BreederPrompt
@@ -10539,98 +10604,98 @@ msgstr "Suena como un problema personal."
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R07.Default__FaleneDefault01_R07_C.SessionData.LinesToMale(0).LinesToMale
 msgctxt ",C481F9C149A5312156D0E78C43255CE9"
 msgid "Aww! Someone wants their dick sucked!"
-msgstr "¡Aww! ¡Alguien quiere que le chupen la polla!"
+msgstr "¡Amm! ¡Alguien quiere que le chupen el pene!"
 
 #. Key:	C4A89EE6414BE3013E77CA81E8105E53
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_Teach.Default__ParvatiDefault01_Teach_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_Teach.Default__ParvatiDefault01_Teach_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",C4A89EE6414BE3013E77CA81E8105E53"
 msgid "Remove your garments, for you must be nude."
-msgstr "Quítate la ropa, debes estar desnuda."
+msgstr "Quítate tus prendas, debes estar desnuda."
 
 #. Key:	C4C596ED4DE277B929ABDDB01255A79B
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDungeon.Default__CassieDungeon_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Cassie/Default/CassieDungeon.Default__CassieDungeon_C.SessionData.Lines(1).Lines
 msgctxt ",C4C596ED4DE277B929ABDDB01255A79B"
 msgid "Meow... no one has been down there for as long as I remember."
-msgstr ""
+msgstr "Miau... nadie ha estado allí desde que tengo memoria."
 
 #. Key:	C4F4ECA34FB62457AF54C48B18A75686
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01.Default__EmissaryDefault01_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01.Default__EmissaryDefault01_C.SessionData.Lines(2).Lines
 msgctxt ",C4F4ECA34FB62457AF54C48B18A75686"
 msgid "Or, hath desire brought you abreast my holy golden bosom?"
-msgstr "¿O te ha traído el deseo a mi sagrado y dorado seno?"
+msgstr "¿O acaso el deseo te trajo junto a mi santo seno dorado?"
 
 #. Key:	C4F8D7B9479B1BE8B5FA0AB326EEEF3A
 #. SourceLocation:	/Game/Characters/Procedural/Variants/Formurian/Harvest/FormurianHarvest.Default__FormurianHarvest_C.Harvest.RaceName
 #: /Game/Characters/Procedural/Variants/Formurian/Harvest/FormurianHarvest.Default__FormurianHarvest_C.Harvest.RaceName
 msgctxt ",C4F8D7B9479B1BE8B5FA0AB326EEEF3A"
 msgid "Formurian"
-msgstr "Formuriana"
+msgstr "Formurian"
 
 #. Key:	C5113B72490FFD8142C52EBDED0B4656
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyHadSex01.Default__RomyHadSex01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Romy/Default/RomyHadSex01.Default__RomyHadSex01_C.SessionData.Lines(0).Lines
 msgctxt ",C5113B72490FFD8142C52EBDED0B4656"
 msgid "Oh the songs of pleasure we sang, how good they felt."
-msgstr ""
+msgstr "Oh, las canciones de placer que cantabamos, qué bien se sentían."
 
 #. Key:	C52FEFD44780735A14B2A78C9F57D862
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiGreeting01.Default__ParvatiGreeting01_C.SessionData.LinesToFemale(6).LinesToFemale
 #: /Game/Dialogue/Parvati/Default/ParvatiGreeting01.Default__ParvatiGreeting01_C.SessionData.LinesToFemale(6).LinesToFemale
 msgctxt ",C52FEFD44780735A14B2A78C9F57D862"
 msgid "Give your body to me, and in ecstasy we will make it conform."
-msgstr "Dame tu cuerpo, y en éxtasis lo haremos cumplir."
+msgstr "Entrégame tu cuerpo, y en éxtasis lo haremos conformar."
 
 #. Key:	C540E787424068F17DC21E839F8383CC
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiStuck.Default__FesssiStuck_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiStuck.Default__FesssiStuck_C.SessionData.Lines(2).Lines
 msgctxt ",C540E787424068F17DC21E839F8383CC"
 msgid "I blame that dryad, she kept bringing me her sweet fruit, and before I knew it my ass was too big to leave my cave."
-msgstr ""
+msgstr "Culpo a esa dríada, ella seguía trayendo su dulce fruta, y antes de que me diera cuenta, mi trasero era demasiado grande para salir de mi cueva."
 
 #. Key:	C544F8824FC4DDC6DBEFE084C3987F32
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon2.Default__AmberMaeLockedDungeon2_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon2.Default__AmberMaeLockedDungeon2_C.SessionData.Lines(4).Lines
 msgctxt ",C544F8824FC4DDC6DBEFE084C3987F32"
 msgid "How I miss the old days."
-msgstr ""
+msgstr "Cómo ertraño los viejoh tiempos."
 
 #. Key:	C55370A04CAE38FD1D15A9AC46E99FBD
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaHadSex02.Default__CamillaHadSex02_C.SessionData.LinesToFemale(2).LinesToFemale
 #: /Game/Dialogue/Camilla/Default/CamillaHadSex02.Default__CamillaHadSex02_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",C55370A04CAE38FD1D15A9AC46E99FBD"
 msgid "If you... uh... ever get desperate again, you know where to find me!"
-msgstr ""
+msgstr "Si... eh... alguna vez te desesperas de nuevo, ¡ya sabes dónde encontrarme!"
 
 #. Key:	C5A392E248451A7506C787B6B7724091
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaOldTempleDungeon1.Default__LeylannaOldTempleDungeon1_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Leylanna/Default/LeylannaOldTempleDungeon1.Default__LeylannaOldTempleDungeon1_C.SessionData.Lines(1).Lines
 msgctxt ",C5A392E248451A7506C787B6B7724091"
 msgid "Ahhhh..."
-msgstr ""
+msgstr "Ahhhh..."
 
 #. Key:	C5CEDF194D3B59C00FF3338949A33FDE
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleHaveKeystone2.Default__KybeleHaveKeystone2_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Kybele/Default/KybeleHaveKeystone2.Default__KybeleHaveKeystone2_C.SessionData.Lines(0).Lines
 msgctxt ",C5CEDF194D3B59C00FF3338949A33FDE"
 msgid "A deal is a deal, take it."
-msgstr ""
+msgstr "Un trato es un trato, tómala."
 
 #. Key:	C5E724D9440EB6AC1E01458A6325FC39
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01_R02.Default__FernDefault01_R02_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Fern/Default/FernDefault01_R02.Default__FernDefault01_R02_C.SessionData.Lines(1).Lines
 msgctxt ",C5E724D9440EB6AC1E01458A6325FC39"
 msgid "Me like this name Fern. Hiss!"
-msgstr "Yo gustar este nombre Helecho. ¡Sssss!"
+msgstr "Mi gustar este nombre Fern. ¡Sss!"
 
 #. Key:	C5F9CCA94803FF5DA8A42E947B60C68D
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(12).LinesToMale
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(12).LinesToMale
 msgctxt ",C5F9CCA94803FF5DA8A42E947B60C68D"
 msgid "Just looking at you is filling me with burning desire... "
-msgstr "Solo de mirarte me estoy llenando de ardiente deseo... "
+msgstr "Solo mirarte me llena de ardiente deseo... "
 
 #. Key:	C636175C4CF5AE827A704F85AE8E4032
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_Emissary.Default__LeylannaDefault01_Emissary_C.SessionData.Lines(5).Lines
@@ -10651,21 +10716,21 @@ msgstr "Sabes tan bien... ¡ahhhh!"
 #: /Game/World/Overworld.Overworld:PersistentLevel.CBGate_Hivelands.BlockMessage
 msgctxt ",C65E75D34AC278A104BAD0A7B99C4CA2"
 msgid "Honeycomb blocks this gate."
-msgstr ""
+msgstr "El panal bloquea este portón."
 
 #. Key:	C66928AC49FF8C314FC5339591BF860D
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraGetKeystone.Default__PetraGetKeystone_C.SessionData.Lines(6).Lines
 #: /Game/Dialogue/Petra/Default/PetraGetKeystone.Default__PetraGetKeystone_C.SessionData.Lines(6).Lines
 msgctxt ",C66928AC49FF8C314FC5339591BF860D"
 msgid "You... you must have something to do with it!"
-msgstr ""
+msgstr "¡Tú... tú debes tener algo que ver con eso!"
 
 #. Key:	C6B18EAC4E513704AB264E9A875521FB
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyLockedDungeon.Default__RomyLockedDungeon_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Romy/Default/RomyLockedDungeon.Default__RomyLockedDungeon_C.SessionData.Lines(1).Lines
 msgctxt ",C6B18EAC4E513704AB264E9A875521FB"
 msgid "A very sad song radiates from within..."
-msgstr ""
+msgstr "Una canción muy triste irradia desde dentro..."
 
 #. Key:	C6D9B8644431D431610683A58FC57B84
 #. SourceLocation:	/Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToMale(6).LinesToMale
@@ -10679,7 +10744,7 @@ msgstr "¡Si! Puedo sentir que estás a punto de correrte... Lo quiero todo. Mmm
 #: /Game/Dialogue/Autumn/Default/DryadHaveKeystone2.Default__DryadHaveKeystone2_C.SessionData.Lines(0).Lines
 msgctxt ",C6E5F355439A82543536AA974313674B"
 msgid "It's yours now, I hope it serves you well."
-msgstr ""
+msgstr "Es tuyo ahora, espero que te sirva bien."
 
 #. Key:	C720F2B64D81061E9D1CC7A3ACD4F0BB
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R02.Default__FaleneDefault01_R02_C.SessionData.Lines(12).Lines
@@ -10693,14 +10758,14 @@ msgstr "¡Cuidado, algunos bendecidos pueden sucumbir a sus deseos y sorprendert
 #: /Game/Dialogue/Parvati/Default/ParvatiGreeting01.Default__ParvatiGreeting01_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",C73CE27C41A91E73C54B58B65E56049E"
 msgid "You seek to learn a new way to use your pleasure hole."
-msgstr "Aprendiendo una nueva forma de usar tu agujero de ese placer que es tan seminal."
+msgstr "Buscas aprender una nueva forma de usar tu agujero del placer."
 
 #. Key:	C760FF8B46FA4C58A2012CB2F41CE6F8
 #. SourceLocation:	/Game/Characters/Procedural/Variants/Risu/Harvest/RisuHarvest.Default__RisuHarvest_C.Harvest.RaceName
 #: /Game/Characters/Procedural/Variants/Risu/Harvest/RisuHarvest.Default__RisuHarvest_C.Harvest.RaceName
 msgctxt ",C760FF8B46FA4C58A2012CB2F41CE6F8"
 msgid "Risu"
-msgstr ""
+msgstr "Risu"
 
 #. Key:	C77FA616486308414031F29069272188
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_RL.Default__LeylannaDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
@@ -10711,73 +10776,75 @@ msgstr "Recarguemos mi forma espiritual."
 
 #. Key:	C7BA93A840AB5FA97F357E802955A851
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(1 - Value).TraitIcons.DisplayName
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(1 - Value).TraitIcons.DisplayName
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(1 -
+#: Value).TraitIcons.DisplayName
 msgctxt ",C7BA93A840AB5FA97F357E802955A851"
 msgid "Exotic"
-msgstr "Exótica/o"
+msgstr "Exótico"
 
 #. Key:	C7EBEA0D46D85CCCBE6EDDB796DAB929
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(36 - Value).TraitIcons.DisplayName
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(36 - Value).TraitIcons.DisplayName
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(36 -
+#: Value).TraitIcons.DisplayName
 msgctxt ",C7EBEA0D46D85CCCBE6EDDB796DAB929"
 msgid "Surprise"
-msgstr ""
+msgstr "Sorpresa"
 
 #. Key:	C7F43006419AE76ADB041AA7B3BB8DD1
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowDefault01.Default__WidowDefault01_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Widow/Default/WidowDefault01.Default__WidowDefault01_C.SessionData.Lines(4).Lines
 msgctxt ",C7F43006419AE76ADB041AA7B3BB8DD1"
 msgid "Yes come with me, deeper into my nest of love. You will feel wave after wave of pleasure as I suck on you for every last drop."
-msgstr ""
+msgstr "Sí, ven conmigo, más profundo en mi nido de amor. Sentirás ola tras ola de placer mientras te chupo hasta la última gota."
 
 #. Key:	C80F35DE492B934FC30FBE82A653139B
 #. SourceLocation:	/Game/Dialogue/Yasmine/Default/YasmineAwake.Default__YasmineAwake_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Yasmine/Default/YasmineAwake.Default__YasmineAwake_C.SessionData.Lines(0).Lines
 msgctxt ",C80F35DE492B934FC30FBE82A653139B"
 msgid "Ah shooooot, my pearl went and rolled away again."
-msgstr ""
+msgstr "Ah, disparaaaa, mi perla se fue y rodó de nuevo."
 
 #. Key:	C831296B46D9E6D1B4ECA181BCD5520B
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_SexPositions.Default__EmissaryDefault01_SexPositions_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_SexPositions.Default__EmissaryDefault01_SexPositions_C.SessionData.Lines(1).Lines
 msgctxt ",C831296B46D9E6D1B4ECA181BCD5520B"
 msgid "She will teach you how to position the body for optimal sexual experience."
-msgstr "Ella te enseñará cómo posicionar el cuerpo para una experiencia sexual óptima."
+msgstr "Ella le enseñará cómo colocar el cuerpo para una experiencia sexual óptima."
 
 #. Key:	C8F56B5143EC7D77BCE3D483F91BD832
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeMasturbate.Default__BeeMasturbate_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/QueenBee/Default/BeeMasturbate.Default__BeeMasturbate_C.SessionData.Lines(4).Lines
 msgctxt ",C8F56B5143EC7D77BCE3D483F91BD832"
 msgid "Of course we do... we must. Ahhh..."
-msgstr ""
+msgstr "Por supuesto que lo hacemos... debemos hacerlo. Ahhh..."
 
 #. Key:	C905E77348FA5208DABFD693A69EEBA4
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiIdiots.Default__FesssiIdiots_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiIdiots.Default__FesssiIdiots_C.SessionData.Lines(5).Lines
 msgctxt ",C905E77348FA5208DABFD693A69EEBA4"
 msgid "Hiss! I've got it."
-msgstr ""
+msgstr "¡Sss! Lo tengo."
 
 #. Key:	C90FBEEB4770B7951F9099B01096A1B0
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeMasturbate.Default__BeeMasturbate_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/QueenBee/Default/BeeMasturbate.Default__BeeMasturbate_C.SessionData.Lines(0).Lines
 msgctxt ",C90FBEEB4770B7951F9099B01096A1B0"
 msgid "What... ahhh... a silly thing to ask... ohhh."
-msgstr ""
+msgstr "Qué... ahhh... cosa tan tonta para preguntar... ohhh."
 
 #. Key:	C91B08354F7D144D174BCB8A2C8384CF
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMGreeting01.Default__DMGreeting01_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMGreeting01.Default__DMGreeting01_C.SessionData.Lines(5).Lines
 msgctxt ",C91B08354F7D144D174BCB8A2C8384CF"
 msgid "Now if you don't mind, I'd love to get back to my nap."
-msgstr ""
+msgstr "Ahora, si no le importa, me encantaría volver a mi siesta."
 
 #. Key:	C933962A4C5DD7F022D428AEE50FE2C0
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeDefault01_RL.Default__MegaSlimeDefault01_RL_C.ResponseData(5).ResponseData.BreederPrompt
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeDefault01_RL.Default__MegaSlimeDefault01_RL_C.ResponseData(5).ResponseData.BreederPrompt
 msgctxt ",C933962A4C5DD7F022D428AEE50FE2C0"
 msgid "I want to play in your slime again!"
-msgstr ""
+msgstr "¡Quiero jugar en tu limo de nuevo!"
 
 #. Key:	C93F66124DFE84936731BDBDEB0840B9
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_SexPositions.Default__FaleneDefault01_SexPositions_C.SessionData.Lines(2).Lines
@@ -10791,25 +10858,26 @@ msgstr "Hay mucho sexo alrededor de Hedon para ocupar mi pequeña capacidad de a
 #: /Game/Dialogue/Widow/Default/WidowKeystone.Default__WidowKeystone_C.SessionData.Lines(2).Lines
 msgctxt ",C94B41FA4308FFD8A8F985BFB7D0411F"
 msgid "She landed in my web with a thunderous crash, and ruined the whole thing."
-msgstr ""
+msgstr "Aterrizó en mi telaraña con un estruendo atronador y arruinó todo."
 
 #. Key:	C98355D84D2C12D36A73BC8F7D73D2B1
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToFemale(3).LinesToFemale
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",C98355D84D2C12D36A73BC8F7D73D2B1"
 msgid "You might think that's gross, but not at all."
-msgstr ""
+msgstr "Podrías pensar que es asqueroso, pero no del todo."
 
 #. Key:	C9B4EBAD46E07D79B09C1DBE7BE0F774
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_UpHere.Default__RomyDefault01_UpHere_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Romy/Default/RomyDefault01_UpHere.Default__RomyDefault01_UpHere_C.SessionData.Lines(3).Lines
 msgctxt ",C9B4EBAD46E07D79B09C1DBE7BE0F774"
 msgid "I know you have no memories before that moment, so let it sink in that you should not be here at all."
-msgstr "Sé que no tienes recuerdos antes de ese momento, así que deja que se hunda en que no deberías estar aquí en absoluto."
+msgstr "Sé que no tienes recuerdos antes de ese momento, así que déjalo hundirse en que no deberías estar aquí en absoluto."
 
 #. Key:	C9DFA1EB40C3BF78D4B015AC82833310
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(5 - Value).TraitIcons.DisplayName
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(5 - Value).TraitIcons.DisplayName
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(5 -
+#: Value).TraitIcons.DisplayName
 msgctxt ",C9DFA1EB40C3BF78D4B015AC82833310"
 msgid "Normal Size"
 msgstr "Tamaño Normal"
@@ -10819,56 +10887,56 @@ msgstr "Tamaño Normal"
 #: /Game/Dialogue/Autumn/Default/DryadFlowers.Default__DryadFlowers_C.SessionData.Lines(2).Lines
 msgctxt ",CA7A7B57487A850B58D2F18581846801"
 msgid "Lets see. The flowers native to the Hivelands are cuminus-labialata and ejaculum-phallis."
-msgstr ""
+msgstr "Vamos a ver. Las flores nativas de las tierras altas son cuminus-labialata y ejaculum-phallus."
 
 #. Key:	CA7FAE6645EB660782FB59BB2F359378
 #. SourceLocation:	/Game/Ranch/Upgrades/TitanCave.Default__TitanCave_C.Upgrade.TypeDisplay
 #: /Game/Ranch/Upgrades/TitanCave.Default__TitanCave_C.Upgrade.TypeDisplay
 msgctxt ",CA7FAE6645EB660782FB59BB2F359378"
 msgid "Nephelym Barn"
-msgstr "Granero de Nephelyms"
+msgstr "Granero de Nephelym"
 
 #. Key:	CA8A7F834A44AD0FFD7433BCE63D2DF7
 #. SourceLocation:	/Game/Characters/Procedural/Variants/Starfallen/Harvest/StarfallenHarvest.Default__StarfallenHarvest_C.Harvest.RaceName
 #: /Game/Characters/Procedural/Variants/Starfallen/Harvest/StarfallenHarvest.Default__StarfallenHarvest_C.Harvest.RaceName
 msgctxt ",CA8A7F834A44AD0FFD7433BCE63D2DF7"
 msgid "Starfallen"
-msgstr "Caído de las Estrellas"
+msgstr "Starfallen"
 
 #. Key:	CAB7654B473208B56B23F8857B8CBCA0
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",CAB7654B473208B56B23F8857B8CBCA0"
 msgid "Careful human, a Kraken's lust is not to be underestimated."
-msgstr "Cuidado humana, la lujuria de una Kraken no debe ser subestimada."
+msgstr "Cuidado humana, la lujuria de un kraken no debe ser subestimada."
 
 #. Key:	CAC37D3345B82EE95615E0BB5C42ED5B
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleTittyPony_T.Default__KybeleTittyPony_T_C.SessionData.LinesToMale(1).LinesToMale
 #: /Game/Dialogue/Kybele/Default/KybeleTittyPony_T.Default__KybeleTittyPony_T_C.SessionData.LinesToMale(1).LinesToMale
 msgctxt ",CAC37D3345B82EE95615E0BB5C42ED5B"
 msgid "It's been sometime since I have been mouted, so I might get rough!"
-msgstr ""
+msgstr "Ha pasado algún tiempo desde que me montaron, ¡así que podría ponerme dura!"
 
 #. Key:	CADDB09246D63E86CBE17C8852675D4B
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01_RL_F.Default__FernDefault01_RL_F_C.ResponseData(4).ResponseData.BreederPrompt
 #: /Game/Dialogue/Fern/Default/FernDefault01_RL_F.Default__FernDefault01_RL_F_C.ResponseData(4).ResponseData.BreederPrompt
 msgctxt ",CADDB09246D63E86CBE17C8852675D4B"
 msgid "The Queen Bee demands flowers."
-msgstr ""
+msgstr "La Abeja Reina exige flores."
 
 #. Key:	CADF79DB4BDC5031DE5FA79A12695348
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiCave.Default__FesssiCave_C.SessionData.Lines(7).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiCave.Default__FesssiCave_C.SessionData.Lines(7).Lines
 msgctxt ",CADF79DB4BDC5031DE5FA79A12695348"
 msgid "If you are heading down there, you will no doubt confront Widow. Don't let her frighten you... trust me, she knows how to please. Hiss!"
-msgstr ""
+msgstr "Si te diriges hacia allí, sin duda te enfrentarás a Widow. No dejes que te asuste... créeme, sabe complacer. ¡Sss!"
 
 #. Key:	CB48004E4E339F82564495A0A7D0209C
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcDefault02_RL.Default__OrcDefault02_RL_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/OrcChief/Default/OrcDefault02_RL.Default__OrcDefault02_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",CB48004E4E339F82564495A0A7D0209C"
 msgid "I've gone through worse."
-msgstr ""
+msgstr "He pasado por cosas peores."
 
 #. Key:	CB4B328646049F44CA1AF5B3E7454C29
 #. SourceLocation:	/Game/Ranch/Upgrades/VulwargKennel.Default__VulwargKennel_C.Upgrade.Description
@@ -10889,63 +10957,63 @@ msgstr "Con mis delicados dedos tocaré tu vagina como un instrumento"
 #: /Game/Dialogue/OrcChief/Default/OrcDefault01_RL.Default__OrcDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",CB65DAA6419D0E0F4ADF968694F481DD"
 msgid "Fix your own gate!"
-msgstr ""
+msgstr "¡Arregla tu propio portón!"
 
 #. Key:	CB9F33B74B20BE432B5B2D991CAF7A38
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowScary.Default__WidowScary_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Widow/Default/WidowScary.Default__WidowScary_C.SessionData.Lines(3).Lines
 msgctxt ",CB9F33B74B20BE432B5B2D991CAF7A38"
 msgid "My kind are so feared, yet we are the same. I seek only love and companionship here in my web of solitude."
-msgstr ""
+msgstr "Los de mi especie son tan temidas, pero somos iguales. Solo busco amor y compañerismo aquí en mi telaraña de soledad."
 
 #. Key:	CBCA7A624672A12A721B83B16D8F5A02
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToMale(4).LinesToMale
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToMale(4).LinesToMale
 msgctxt ",CBCA7A624672A12A721B83B16D8F5A02"
 msgid "Imagine all of the places you could slide your dick in human... and I promise I would make them all feel so good..."
-msgstr "Imagina todos los lugares dentro de los que podrías deslizar tu polla, humano... y prometo que te harán sentir tan bien..."
+msgstr "Imagina todos los lugares en los que podrías deslizar tu pene dentro, humano... y te prometo que te harán sentir tan bien..."
 
 #. Key:	CBF60252404E432514F2A08225E15D38
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_Emissary.Default__LeylannaDefault01_Emissary_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Leylanna/Default/LeylannaDefault01_Emissary.Default__LeylannaDefault01_Emissary_C.SessionData.Lines(1).Lines
 msgctxt ",CBF60252404E432514F2A08225E15D38"
 msgid "Of course, as soon as she appeared we made love... for many hours. Well I made love to her... she was sadly not so interested."
-msgstr "Por supuesto, tan pronto como apareció, hicimos el amor... durante muchas horas. Bueno, le hice el amor... lamentablemente no estaba tan interesada."
+msgstr "Por supuesto, tan pronto como apareció ella hicimos el amor... durante muchas horas. Bueno, le hice el amor... lamentablemente no estaba tan interesada."
 
 #. Key:	CC453F864879B9206AA86C866817E4F7
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMHadSex01.Default__DMHadSex01_C.SessionData.LinesToFuta(3).LinesToFuta
 #: /Game/Dialogue/DragonMatriarch/Default/DMHadSex01.Default__DMHadSex01_C.SessionData.LinesToFuta(3).LinesToFuta
 msgctxt ",CC453F864879B9206AA86C866817E4F7"
 msgid "Do come back... my deep dragon pussy yearns for more."
-msgstr ""
+msgstr "Vuelve... mi profundo coño de dragón anhela más."
 
 #. Key:	CC8A60E34A4F302BEBD0CCB8D0F5B282
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiDefault03_RL_T.Default__FesssiDefault03_RL_T_C.ResponseData(3).ResponseData.BreederPrompt
 #: /Game/Dialogue/Fesssi/Default/FesssiDefault03_RL_T.Default__FesssiDefault03_RL_T_C.ResponseData(3).ResponseData.BreederPrompt
 msgctxt ",CC8A60E34A4F302BEBD0CCB8D0F5B282"
 msgid "I want to have fun with your ass!"
-msgstr ""
+msgstr "¡Quiero divertirme con tu culo!"
 
 #. Key:	CCBDEE9E4366EC8D550F4DB7D8C546F8
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaFaleneWeek.Default__CamillaFaleneWeek_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaFaleneWeek.Default__CamillaFaleneWeek_C.SessionData.Lines(4).Lines
 msgctxt ",CCBDEE9E4366EC8D550F4DB7D8C546F8"
 msgid "Then I pose seductively in front whatever she brought back, and she records how it reacts."
-msgstr ""
+msgstr "Luego me poso seductoramente frente a lo que ella trajo, y ella registra cómo reacciona."
 
 #. Key:	CCBE2DF04F273EE3D33DE583845CB545
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeHadSex01.Default__AmberMaeHadSex01_C.SessionData.LinesToMale(0).LinesToMale
 #: /Game/Dialogue/AmberMae/Default/AmberMaeHadSex01.Default__AmberMaeHadSex01_C.SessionData.LinesToMale(0).LinesToMale
 msgctxt ",CCBE2DF04F273EE3D33DE583845CB545"
 msgid "Ye drank so much for a wee lad!"
-msgstr ""
+msgstr "¡Bebihte musho para un moso pequeñito!"
 
 #. Key:	CCFE0CB04C0DD4BC550FE6AF03BFABB3
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R05.Default__FaleneDefault01_R05_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R05.Default__FaleneDefault01_R05_C.SessionData.Lines(1).Lines
 msgctxt ",CCFE0CB04C0DD4BC550FE6AF03BFABB3"
 msgid "Elves are part of the Sylvan race, a large @MONSTER_RACE@ family that spans all sorts! There's lots of different types of elves, but my kind are the cutest I think!"
-msgstr "¡Las elfas son parte de la raza Silvestre, una gran familia @MONSTER_RACE@ que abarca todo tipo! ¡Hay muchos tipos diferentes de elfas, pero creo que las míos son las más lindas!"
+msgstr "¡Los elfos son parte de la raza silvana, una gran familia @MONSTER_RACE@ que abarca de todo tipo! ¡Hay muchos tipos diferentes de elfos, pero creo que los míos son las más lindos!"
 
 #. Key:	CD24CE384C0548CF493A43A0F88CB7A2
 #. SourceLocation:	/Game/Dialogue/Emissary/SexScenes/EmissaryAngelGroinLove.Default__EmissaryAngelGroinLove_C.SessionData.LinesToMale(0).LinesToMale
@@ -10959,70 +11027,71 @@ msgstr "Deléitate humano, pues soy tu sirviente."
 #: /Game/Breeding/Positions/Cowgirl.Default__Cowgirl_C.SessionData.Description
 msgctxt ",CD8C53FE4EAFB9508679088ACC31A4CD"
 msgid "The receiver bounces up and down while facing the giver."
-msgstr "La receptora rebota hacia arriba y hacia abajo mientras mira a el/la dador/a."
+msgstr "La receptora rebota hacia arriba y hacia abajo mientras mira al donante."
 
 #. Key:	CDE042544846EA4EE23B56B0BA650104
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiDefault01.Default__FesssiDefault01_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiDefault01.Default__FesssiDefault01_C.SessionData.Lines(2).Lines
 msgctxt ",CDE042544846EA4EE23B56B0BA650104"
 msgid "My sister Neela is probably worried by now."
-msgstr ""
+msgstr "Probablemente mi hermana Neela ya esté preocupada."
 
 #. Key:	CDEBE2FD40DC775E9639A299E9BF3B83
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeAboutBees.Default__BeeAboutBees_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/QueenBee/Default/BeeAboutBees.Default__BeeAboutBees_C.SessionData.Lines(2).Lines
 msgctxt ",CDEBE2FD40DC775E9639A299E9BF3B83"
 msgid "When consumed by the queen, the mixture will cause her breasts to grow and make honey. Only the queen's breasts can produce honey."
-msgstr ""
+msgstr "Cuando es consumida por la reina, la mezcla hará que sus pechos crezcan y produzcan miel. Solo los pechos de la reina pueden producir miel."
 
 #. Key:	CDF29C5A40823CB4D1E542912EBC57B8
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcTribeSucks.Default__OrcTribeSucks_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcTribeSucks.Default__OrcTribeSucks_C.SessionData.Lines(0).Lines
 msgctxt ",CDF29C5A40823CB4D1E542912EBC57B8"
 msgid "*Snarl*"
-msgstr ""
+msgstr "*Gruñe*"
 
 #. Key:	CE27DDF94397A475B6331E9CAF6EB7C5
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToMale(3).LinesToMale
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToMale(3).LinesToMale
 msgctxt ",CE27DDF94397A475B6331E9CAF6EB7C5"
 msgid "Ahhh... yes. My desires are surging, won't you indulge in my body? I will try to be gentle."
-msgstr "Ahhh... si. Mis deseos están surgiendo, ¿no te complacerás en mi cuerpo? Intentaré ser gentil."
+msgstr "Ahhh... si. Mis deseos están aumentando, ¿no te complacerás con mi cuerpo? Trataré de ser gentil."
 
 #. Key:	CE3354BC4C98FE63B630758F10560253
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFuta(23).LinesToFuta
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFuta(23).LinesToFuta
 msgctxt ",CE3354BC4C98FE63B630758F10560253"
 msgid "Blessed @MONSTER_RACE@ like me have human-level intelligence. Sometimes even greater!"
-msgstr "Bendecidos @MONSTER_RACE@ como yo tienen una inteligencia a nivel humano. ¡A veces incluso mayor!"
+msgstr "@MONSTER_RACE@ bendecidos como yo tienen una inteligencia a nivel humano. ¡A veces incluso mayor!"
 
 #. Key:	CE3738E344825C4371847CB9F0E4445E
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDefault01_WhatCanBuild.Default__CassieDefault01_WhatCanBuild_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Cassie/Default/CassieDefault01_WhatCanBuild.Default__CassieDefault01_WhatCanBuild_C.SessionData.Lines(0).Lines
 msgctxt ",CE3738E344825C4371847CB9F0E4445E"
 msgid "I can build anything your genitalia desires!"
-msgstr "¡Puedo construir todo lo que tus genitales deseen!"
+msgstr "¡Puedo construir cualquier cosa que deseen tus genitales!"
 
 #. Key:	CE38F80044474A7AE6C3A68384DE4350
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadHaveKeystone.Default__DryadHaveKeystone_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Autumn/Default/DryadHaveKeystone.Default__DryadHaveKeystone_C.SessionData.Lines(1).Lines
 msgctxt ",CE38F80044474A7AE6C3A68384DE4350"
 msgid "You can have it if you help me with a little problem."
-msgstr ""
+msgstr "Puedes tenerla si me ayudas con un pequeño problema."
 
 #. Key:	CE50C843466352316F4461BC2722C00E
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(18 - Value).TraitIcons.HelpText
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(18 - Value).TraitIcons.HelpText
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(18 -
+#: Value).TraitIcons.HelpText
 msgctxt ",CE50C843466352316F4461BC2722C00E"
 msgid "Nurturing: Offspring inherit 20% higher stats."
-msgstr "Acogedor/a: Su descendencia hereda unas estadísticas un 20% mejores."
+msgstr "Crianza: la descendencia hereda estadísticas un 20% más altas."
 
 #. Key:	CE59EDA9407017D7F23359822FA77A1D
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcHaveKeystone.Default__OrcHaveKeystone_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcHaveKeystone.Default__OrcHaveKeystone_C.SessionData.Lines(1).Lines
 msgctxt ",CE59EDA9407017D7F23359822FA77A1D"
 msgid "Serve tribe first, or even better bring my tribe mates!"
-msgstr ""
+msgstr "¡Servir a la tribu primero, o mejor aún traer a mis compañeras de tribu!"
 
 #. Key:	CE6754D34D354921713D50B1F67C0F01
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_RL.Default__ParvatiDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
@@ -11036,123 +11105,124 @@ msgstr "Yo... eh... \"olvidé\" una enseñanza."
 #: /Game/Dialogue/DragonMatriarch/Default/DMWantHuman.Default__DMWantHuman_C.SessionData.Lines(5).Lines
 msgctxt ",CE86D5D34609962D9883CD82312DAC88"
 msgid "Are you sure you can handle this human?"
-msgstr ""
+msgstr "¿Estás seguro de que puedes manejar esto humano?"
 
 #. Key:	CEB5AB8346357320346305B899A9C7BB
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeHaveKeystone.Default__BeeHaveKeystone_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/QueenBee/Default/BeeHaveKeystone.Default__BeeHaveKeystone_C.SessionData.Lines(3).Lines
 msgctxt ",CEB5AB8346357320346305B899A9C7BB"
 msgid "Long ago, large flowers grew here. The nectar they produced was worthy of the Goddess Herself."
-msgstr ""
+msgstr "Hace mucho tiempo, aquí crecían grandes flores. El néctar que producían era digno de la propia Diosa."
 
 #. Key:	CEC4092D45D0DBE6546A729EE34F0267
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_AboutMusic.Default__RomyDefault01_AboutMusic_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Romy/Default/RomyDefault01_AboutMusic.Default__RomyDefault01_AboutMusic_C.SessionData.Lines(3).Lines
 msgctxt ",CEC4092D45D0DBE6546A729EE34F0267"
 msgid "Our voices can reach a pitch so pleasant to the ear, that any within reach may become entranced."
-msgstr "Nuestras voces pueden alcanzar un tono tan agradable para el oído que cualquier persona que esté al alcance puede quedar fascinada."
+msgstr "Nuestras voces pueden alcanzar un tono tan agradable para el oído, que cualquiera que esté a su alcance puede quedar fascinado."
 
 #. Key:	CEC660F240FC0F1941C19ABA02D18068
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03.Default__FernDefault03_C.SessionData.LinesToFuta(3).LinesToFuta
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03.Default__FernDefault03_C.SessionData.LinesToFuta(3).LinesToFuta
 msgctxt ",CEC660F240FC0F1941C19ABA02D18068"
 msgid "Let me wrap my lips around that fat cock of yours, my body longs for your warm cum."
-msgstr "Déjame envolver mis labios alrededor de esa polla gorda tuya, mi cuerpo anhela tu semen caliente."
+msgstr "Déjame envolver mis labios alrededor de esa gorda polla tuya, mi cuerpo anhela tu cálido semen."
 
 #. Key:	CECD706A47419BAE65A5B3979BEFCA77
 #. SourceLocation:	/Game/Dialogue/Yasmine/Default/YasmineAwake.Default__YasmineAwake_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Yasmine/Default/YasmineAwake.Default__YasmineAwake_C.SessionData.Lines(2).Lines
 msgctxt ",CECD706A47419BAE65A5B3979BEFCA77"
 msgid "Oh well... I suppose you can have it. I'm going to make a better one!"
-msgstr ""
+msgstr "Oh, bueno... supongo que puedes tenerla. ¡Voy a hacer una mejor!"
 
 #. Key:	CEE2CED74492461582B4EB8D5D2CB4B6
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R02.Default__FaleneDefault01_R02_C.SessionData.Lines(11).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R02.Default__FaleneDefault01_R02_C.SessionData.Lines(11).Lines
 msgctxt ",CEE2CED74492461582B4EB8D5D2CB4B6"
 msgid "Not just with intense pleasure, but useful items that will help you on your quest."
-msgstr "No solo con intenso placer, sino también elementos útiles que te ayudarán en tu búsqueda."
+msgstr "No solo con un placer intenso, sino también con elementos útiles que te ayudarán en tu búsqueda."
 
 #. Key:	CF2AA32C438E34A279D2A599B0899492
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcHaveKeystone.Default__OrcHaveKeystone_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcHaveKeystone.Default__OrcHaveKeystone_C.SessionData.Lines(3).Lines
 msgctxt ",CF2AA32C438E34A279D2A599B0899492"
 msgid "Breed my tribe a fertile female that we can share. A soft cow, but not lazy one from pastures!"
-msgstr ""
+msgstr "Criar para mi tribu una hembra fértil que podamos compartir. ¡Una vaca blanda, pero no perezosa de los pastos!"
 
 #. Key:	CF30D7124F42031F52DA0DA6849D4457
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFemale(6).LinesToFemale
 #: /Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFemale(6).LinesToFemale
 msgctxt ",CF30D7124F42031F52DA0DA6849D4457"
 msgid "Actually, nipples reminds me of something!"
-msgstr ""
+msgstr "En realidad, ¡los pezones me recuerdan algo!"
 
 #. Key:	CF8C923C4436452FD45381813CFCD1F5
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchStartShySex.Default__MonarchStartShySex_C.SessionData.LinesToFemale(3).LinesToFemale
 #: /Game/Dialogue/Monarch/Default/MonarchStartShySex.Default__MonarchStartShySex_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",CF8C923C4436452FD45381813CFCD1F5"
 msgid "So I can, y-y-you know... make you feel good."
-msgstr ""
+msgstr "Entonces puedo, y-y-ya sabes... hacerte sentir bien."
 
 #. Key:	CFA095544A3BB18577988A9489DE24CC
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruGreeting01.Default__MirruGreeting01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Mirru/Default/MirruGreeting01.Default__MirruGreeting01_C.SessionData.Lines(0).Lines
 msgctxt ",CFA095544A3BB18577988A9489DE24CC"
 msgid "Ah so it is true. Indeed, a human does walk the dry land."
-msgstr "Ah, entonces es verdad. De hecho, una humana camina por la tierra seca."
+msgstr "Ah, entonces es verdad. De hecho, un humano camina por tierra firme."
 
 #. Key:	CFB4BE294E1D3D81CE72719BCB08B1C7
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R03.Default__FaleneDefault01_R03_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R03.Default__FaleneDefault01_R03_C.SessionData.Lines(3).Lines
 msgctxt ",CFB4BE294E1D3D81CE72719BCB08B1C7"
 msgid "You know, the floating busty winged statues with the sparkles... I will admit I get all tingly inside around them too!"
-msgstr ""
+msgstr "Ya sabes, las estatuas aladas y tetonas flotantes con los destellos... ¡debo admitir que también siento un hormigueo dentro de ellas!"
 
 #. Key:	CFBBDFD5421C17E7EB1CBBB86EEBD93C
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraAboutPawsmaati.Default__PetraAboutPawsmaati_C.SessionData.Lines(7).Lines
 #: /Game/Dialogue/Petra/Default/PetraAboutPawsmaati.Default__PetraAboutPawsmaati_C.SessionData.Lines(7).Lines
 msgctxt ",CFBBDFD5421C17E7EB1CBBB86EEBD93C"
 msgid "Through orgasm, she can impart a tiny fraction of her knowlege to her partner."
-msgstr ""
+msgstr "A través del orgasmo, puede impartir una pequeña fracción de sus conocimientos a su pareja."
 
 #. Key:	CFDBD54945D68B87A04B7B9DDE06F521
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R07.Default__CamillaDefault01_R07_C.SessionData.LinesToMale(1).LinesToMale
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R07.Default__CamillaDefault01_R07_C.SessionData.LinesToMale(1).LinesToMale
 msgctxt ",CFDBD54945D68B87A04B7B9DDE06F521"
 msgid "Amber's tits are bigger than me! Why is this world so cruel..."
-msgstr "¡Las tetas de Amber son más grandes que yo! Por qué es este mundo tan cruel..."
+msgstr "¡Las tetas de Amber son mas grandes que yo! Por qué este mundo es tan cruel..."
 
 #. Key:	D016E93F4A87C5706D65B1A5E101B0C6
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernHadSex02.Default__FernHadSex02_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Fern/DefaultP2/FernHadSex02.Default__FernHadSex02_C.SessionData.Lines(1).Lines
 msgctxt ",D016E93F4A87C5706D65B1A5E101B0C6"
 msgid "More! More!"
-msgstr ""
+msgstr "¡Más! ¡Más!"
 
 #. Key:	D039FDFA4AB60D6ABD3384AEF3348588
 #. SourceLocation:	/Game/UI/TaskDescriptions.TaskDescriptions.TextEntries(1).TextEntries
 #: /Game/UI/TaskDescriptions.TaskDescriptions.TextEntries(1).TextEntries
 msgctxt ",D039FDFA4AB60D6ABD3384AEF3348588"
 msgid "It's study time! And by that I mean bring me the most well-endowed Nephelym you can breed. As much as I would like to say this study is about furthering the endless endeavor that is science, no I am horny as hell and want you to fix it! Sure, sex twenty times a day is fun and all, but it's not enough. This one will be for... personal alone time at night. Humans can't possibly understand! The desires don't ever stop!!  -Falene"
-msgstr ""
+msgstr "¡Es hora de estudiar! Y con eso me refiero a que me traigas el Nephelym mejor dotado que puedas criar. Por mucho que me gustaría decir que este estudio se trata de promover el esfuerzo interminable que es la ciencia, no, ¡estoy cachonda como el infierno y quiero que lo arregles! Claro, el sexo veinte veces al día es divertido y todo, pero no es suficiente. Este será para... el tiempo personal a solas personal. ¡Los humanos no pueden entenderlo! ¡Los deseos nunca se detienen! -Falene"
 
 #. Key:	D03FE11A4B475C76629C24AF0C738457
 #. SourceLocation:	/Game/Ranch/Upgrades/FormurianPond.Default__FormurianPond_C.Upgrade.DisplayName
 #: /Game/Ranch/Upgrades/FormurianPond.Default__FormurianPond_C.Upgrade.DisplayName
 msgctxt ",D03FE11A4B475C76629C24AF0C738457"
 msgid "Formurian Pond"
-msgstr "Estanque de Formurianas"
+msgstr "Estanque de Formurians"
 
 #. Key:	D05595AA4F7337C7E43FD59874E5E624
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleCentaur.Default__KybeleCentaur_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Kybele/Default/KybeleCentaur.Default__KybeleCentaur_C.SessionData.Lines(2).Lines
 msgctxt ",D05595AA4F7337C7E43FD59874E5E624"
 msgid "Centaurs can get aggressive when we haven't released for an extended period of time."
-msgstr ""
+msgstr "Los centauros pueden volverse agresivos cuando no hemos descargado durante un período de tiempo prolongado."
 
 #. Key:	D066439244AFE855B06F90AB1A4A0829
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TravelShrines(8 - Value).TravelShrines.ShrineName
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TravelShrines(8 - Value).TravelShrines.ShrineName
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TravelShrines(8 -
+#: Value).TravelShrines.ShrineName
 msgctxt ",D066439244AFE855B06F90AB1A4A0829"
 msgid "Sultry Plateau"
 msgstr "Meseta Bochornosa"
@@ -11162,154 +11232,156 @@ msgstr "Meseta Bochornosa"
 #: /Game/Dialogue/Kybele/Default/KybeleHadSex01.Default__KybeleHadSex01_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",D0AFE2FE43D96C0225B202A9DF9DC0CB"
 msgid "You paid the price, now you are filled with a giant load of centaur cum."
-msgstr ""
+msgstr "Pagaste el precio, ahora estás lleno de una carga gigante de semen centauro."
 
 #. Key:	D0D371BB447B4CD8A5A17682F596B922
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDungeon.Default__CamillaDungeon_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaDungeon.Default__CamillaDungeon_C.SessionData.Lines(0).Lines
 msgctxt ",D0D371BB447B4CD8A5A17682F596B922"
 msgid "Do I look like a civil engineer?!!"
-msgstr ""
+msgstr "¡¡¿Me veo como una ingeniera civil?!!"
 
 #. Key:	D0DE0CF44CDB98087C882AA54375F7BD
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleTittyPony_T.Default__KybeleTittyPony_T_C.SessionData.LinesToFemale(2).LinesToFemale
 #: /Game/Dialogue/Kybele/Default/KybeleTittyPony_T.Default__KybeleTittyPony_T_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",D0DE0CF44CDB98087C882AA54375F7BD"
 msgid "That should teach you to cross this titty po--I mean mighty centaur warmaiden, again!"
-msgstr ""
+msgstr "Eso debería enseñarte a cruzar esta poni tet-: ¡otra vez, me refiero a la poderosa doncella-guerrera centauro!"
 
 #. Key:	D0FA90CC4E9378DF7150FB881B18DC60
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(5 - Value).TraitIcons.HelpText
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(5 - Value).TraitIcons.HelpText
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(5 -
+#: Value).TraitIcons.HelpText
 msgctxt ",D0FA90CC4E9378DF7150FB881B18DC60"
 msgid "Normal: Roughly 6ft in height."
-msgstr "Normal: Aproximadamente 1,8m de altura."
+msgstr "Normal: aproximadamente 6 pies (1,8 m) de altura."
 
 #. Key:	D15AF6D44FBD9FB7572622AE572A21D7
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(33 - Value).TraitIcons.HelpText
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(33 - Value).TraitIcons.HelpText
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(33 -
+#: Value).TraitIcons.HelpText
 msgctxt ",D15AF6D44FBD9FB7572622AE572A21D7"
 msgid "Hybrid: This one is a mix of two races."
-msgstr "Híbrida: Esta es una mezcla de dos razas."
+msgstr "Híbrido: este es una mezcla de dos razas."
 
 #. Key:	D168672B4C5B79B56A15E097C9217EBC
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01_R01.Default__FernDefault01_R01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Fern/Default/FernDefault01_R01.Default__FernDefault01_R01_C.SessionData.Lines(0).Lines
 msgctxt ",D168672B4C5B79B56A15E097C9217EBC"
 msgid "You are... lord of this soil... yesss?"
-msgstr "Tú eres... señor/a de este suelo... ¿ssssí?"
+msgstr "Tú eres... señor de este suelo... ¿ssssí?"
 
 #. Key:	D177C30A4E176DA263EBCDB1F6E13158
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeGreeting01.Default__MegaSlimeGreeting01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeGreeting01.Default__MegaSlimeGreeting01_C.SessionData.Lines(0).Lines
 msgctxt ",D177C30A4E176DA263EBCDB1F6E13158"
 msgid "Wow a visitor!"
-msgstr ""
+msgstr "¡Guau, un visitante!"
 
 #. Key:	D18F5F504013858974D982AA49D9035F
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R02.Default__FaleneDefault01_R02_C.SessionData.Lines(13).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R02.Default__FaleneDefault01_R02_C.SessionData.Lines(13).Lines
 msgctxt ",D18F5F504013858974D982AA49D9035F"
 msgid "I'm fighting that urge right now..."
-msgstr "Estoy luchando contra ese impulso en este momento..."
+msgstr "Estoy luchando contra ese impulso ahora mismo..."
 
 #. Key:	D195ECC34D71382CA65FD091CD7680D5
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadBossomCherries.Default__DryadBossomCherries_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Autumn/Default/DryadBossomCherries.Default__DryadBossomCherries_C.SessionData.Lines(0).Lines
 msgctxt ",D195ECC34D71382CA65FD091CD7680D5"
 msgid "It's the giant red fruit you see all over the pastures. Everyone was crafted with love by me."
-msgstr ""
+msgstr "Es la fruta roja gigante que ves por todos los pastos. Todas fueron creadas con amor por mí."
 
 #. Key:	D1984E71418CEF4F3D39AC911B217790
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_Formuria.Default__MirruDefault01_Formuria_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_Formuria.Default__MirruDefault01_Formuria_C.SessionData.Lines(1).Lines
 msgctxt ",D1984E71418CEF4F3D39AC911B217790"
 msgid "Many aquatic @MONSTER_RACE@ inhabit our fair kingdom, but only Krakens have the might and will to rule."
-msgstr "Muchos @MONSTER_RACE@ acuáticos habitan nuestro bello reino, pero solo Krakens tiene el poder y la voluntad de gobernar."
+msgstr "Muchos @MONSTER_RACE@ acuáticos habitan nuestro bello reino, pero solo krakens tiene el poder y la voluntad de gobernar."
 
 #. Key:	D1B21A3544F4242222944E97EA03E1BB
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMHadSex01.Default__DMHadSex01_C.SessionData.LinesToFemale(3).LinesToFemale
 #: /Game/Dialogue/DragonMatriarch/Default/DMHadSex01.Default__DMHadSex01_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",D1B21A3544F4242222944E97EA03E1BB"
 msgid "Do come back... my cock will be waiting."
-msgstr ""
+msgstr "Vuelve... mi polla estará esperando."
 
 #. Key:	D1E7FBF645BBEB29F682D5A4FAB6A2A5
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiWantTongue.Default__FesssiWantTongue_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiWantTongue.Default__FesssiWantTongue_C.SessionData.Lines(0).Lines
 msgctxt ",D1E7FBF645BBEB29F682D5A4FAB6A2A5"
 msgid "How interesting. Hiss!"
-msgstr ""
+msgstr "Que interesante. ¡Sss!"
 
 #. Key:	D1FC026043E82386A07099A46452AB0F
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R04.Default__FaleneDefault01_R04_C.SessionData.Lines(13).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R04.Default__FaleneDefault01_R04_C.SessionData.Lines(13).Lines
 msgctxt ",D1FC026043E82386A07099A46452AB0F"
 msgid "That's why our race desires sex so much--it's so satisfying and beautiful."
-msgstr "Es por eso que nuestra raza desea tanto el sexo, es tan satisfactorio y hermoso."
+msgstr "Es por eso que nuestra raza desea tanto el sexo: es tan satisfactorio y hermoso."
 
 #. Key:	D202E32F436700405E2417A73206A501
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03_R04.Default__FernDefault03_R04_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03_R04.Default__FernDefault03_R04_C.SessionData.Lines(0).Lines
 msgctxt ",D202E32F436700405E2417A73206A501"
 msgid "Oh Master... I have waited for this."
-msgstr "Oh Maestra... He esperado por esto."
+msgstr "Oh, Master... he esperado para esto."
 
 #. Key:	D209ED1D49C6A4C6106AC69A3100D415
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01_R02_R01.Default__FernDefault01_R02_R01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Fern/Default/FernDefault01_R02_R01.Default__FernDefault01_R02_R01_C.SessionData.Lines(1).Lines
 msgctxt ",D209ED1D49C6A4C6106AC69A3100D415"
 msgid "When mastah not want harvest... Fern do it."
-msgstr "Cuando maeztra no quiere cosechar... Helecho lo hace."
+msgstr "Cuando Mastah no quiere cosechar... Fern lo hace."
 
 #. Key:	D251615D4084E3BFFB18D4B26806806F
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMWantHuman.Default__DMWantHuman_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMWantHuman.Default__DMWantHuman_C.SessionData.Lines(2).Lines
 msgctxt ",D251615D4084E3BFFB18D4B26806806F"
 msgid "I admit, it is quite tempting. Humans were a myth until I met you."
-msgstr ""
+msgstr "Lo admito, es bastante tentador. Los humanos eran un mito hasta que te conocí."
 
 #. Key:	D2843C204C6DDAA26611B0B57F67BC41
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcBrashDumb.Default__OrcBrashDumb_C.SessionData.Lines(6).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcBrashDumb.Default__OrcBrashDumb_C.SessionData.Lines(6).Lines
 msgctxt ",D2843C204C6DDAA26611B0B57F67BC41"
 msgid "Grrrrrr! Me human!"
-msgstr ""
+msgstr "¡Grrrrrr! ¡Yo humano!"
 
 #. Key:	D2C5AD664FCA892932A70188B37B1378
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFemale(4).LinesToFemale
 #: /Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFemale(4).LinesToFemale
 msgctxt ",D2C5AD664FCA892932A70188B37B1378"
 msgid "..."
-msgstr ""
+msgstr "..."
 
 #. Key:	D2DF40244F8B96F91F4101A5AD5F08AA
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaGreeting01.Default__CamillaGreeting01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaGreeting01.Default__CamillaGreeting01_C.SessionData.Lines(1).Lines
 msgctxt ",D2DF40244F8B96F91F4101A5AD5F08AA"
 msgid "I'm Camilla! Falene's little goblin assistant! You probably won't need to talk to me much because she's the smart one around here."
-msgstr "Soy Camilla ¡La pequeño asistente duende de Falene! Probablemente no necesites hablar mucho conmigo porque ella es la inteligente por aquí."
+msgstr "Soy Camilla ¡La pequeña asistente goblin de Falene! Probablemente no necesites hablar mucho conmigo porque ella es la inteligente por aquí."
 
 #. Key:	D2F9DD5648274637A18B9A8777C5CF03
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeDefault01_RL.Default__MegaSlimeDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeDefault01_RL.Default__MegaSlimeDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",D2F9DD5648274637A18B9A8777C5CF03"
 msgid "About that orb..."
-msgstr ""
+msgstr "Sobre ese orbe..."
 
 #. Key:	D3139F1545004EAAF227C0A0C62B74E9
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMDefault_RL2.Default__DMDefault_RL2_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/DragonMatriarch/Default/DMDefault_RL2.Default__DMDefault_RL2_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",D3139F1545004EAAF227C0A0C62B74E9"
 msgid "Tell me about dragons!"
-msgstr ""
+msgstr "¡Háblame de los dragones!"
 
 #. Key:	D320A28645DC907082F6169F08223AA5
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault02.Default__CamillaDefault02_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaDefault02.Default__CamillaDefault02_C.SessionData.Lines(0).Lines
 msgctxt ",D320A28645DC907082F6169F08223AA5"
 msgid "Oh great Falene is back."
-msgstr ""
+msgstr "Oh, genial, Falene ha vuelto."
 
 #. Key:	D395A99C4C2FAC4029FBE0A0AACFDE16
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_Leylanna.Default__EmissaryDefault01_Leylanna_C.SessionData.Lines(3).Lines
@@ -11323,63 +11395,63 @@ msgstr "La Diosa le sonríe, y ella permanecerá como suma sacerdotisa."
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(18).LinesToFemale
 msgctxt ",D3E9009E43E0327FC24371950104BD21"
 msgid "*Sigh* As you can tell, we @MONSTER_RACE@ have extremely intense sexual desires."
-msgstr "*Suspiro* Como puedes ver, nosotros @MONSTER_RACE@ tenemos deseos sexuales extremadamente intensos."
+msgstr "*Suspira* Como puedes ver, nosotros los @MONSTER_RACE@ tenemos deseos sexuales extremadamente intensos."
 
 #. Key:	D3EBA5FE4F8C935CB40680BE9D7ED27E
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadHaveKeystone2.Default__DryadHaveKeystone2_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Autumn/Default/DryadHaveKeystone2.Default__DryadHaveKeystone2_C.SessionData.Lines(1).Lines
 msgctxt ",D3EBA5FE4F8C935CB40680BE9D7ED27E"
 msgid "I see I've been slacking off and let my roots overtake the gate to the cove."
-msgstr ""
+msgstr "Veo que me he estado holgazaneando y dejado que mis raíces sobrepasen el portón de la ensenada."
 
 #. Key:	D3EBB7904D4648D8930D5B98189AC73D
 #. SourceLocation:	/Game/Characters/Procedural/Variants/Hybrid/Harvest/HybridHarvest.Default__HybridHarvest_C.Harvest.RaceName
 #: /Game/Characters/Procedural/Variants/Hybrid/Harvest/HybridHarvest.Default__HybridHarvest_C.Harvest.RaceName
 msgctxt ",D3EBB7904D4648D8930D5B98189AC73D"
 msgid "Hybrid"
-msgstr "Híbrida"
+msgstr "Híbrido"
 
 #. Key:	D43D63CB4B6E7B157FD06E89C537F572
 #. SourceLocation:	/Game/Breeding/Positions/Waterfall.Default__Waterfall_C.SessionData.Description
 #: /Game/Breeding/Positions/Waterfall.Default__Waterfall_C.SessionData.Description
 msgctxt ",D43D63CB4B6E7B157FD06E89C537F572"
 msgid "The giver's lower half is elevated while the receiver balances on top."
-msgstr "La mitad inferior de el/la dador/a se eleva mientras la receptora se equilibra encima."
+msgstr "La mitad inferior del donante se eleva mientras que la receptora se balancea en la parte superior."
 
 #. Key:	D456D54240773E6C7DA921A0B4BDBA16
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_R04.Default__FernDefault02_R04_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02_R04.Default__FernDefault02_R04_C.SessionData.Lines(1).Lines
 msgctxt ",D456D54240773E6C7DA921A0B4BDBA16"
 msgid "I need human milk to grow into my final form. Your soft breasts will be emptied as I suck every drop."
-msgstr "Necesito leche humana para crecer en mi forma final. Tus senos suaves se vaciarán a medida que succione cada gota."
+msgstr "Necesito leche materna para crecer hasta mi forma final. Tus suaves pechos se vaciarán mientras chupo cada gota."
 
 #. Key:	D48D138B4D55F9A604E2E0AFFACE1674
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernGreeting02.Default__FernGreeting02_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/Fern/DefaultP2/FernGreeting02.Default__FernGreeting02_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",D48D138B4D55F9A604E2E0AFFACE1674"
 msgid "Look at my beautiful flower, it bloomed! Oh my did it feel weird..."
-msgstr "Mira mi hermosa flor, ¡floreció! Oh, se sintió raro..."
+msgstr "Mira mi hermosa flor, ¡floreció! Oh cielos, se sintió raro..."
 
 #. Key:	D4B876E04002BC56FF720D829DA04785
 #. SourceLocation:	/Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToFemale(6).LinesToFemale
 #: /Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToFemale(6).LinesToFemale
 msgctxt ",D4B876E04002BC56FF720D829DA04785"
 msgid "Ahh... oh... so delicious."
-msgstr "Ahh... oh... tan deliciosa."
+msgstr "Ahh... oh... tan delicioso."
 
 #. Key:	D4BAFDEE4340A6062B18808C4CB9ABF1
 #. SourceLocation:	/Game/Dialogue/Mirru/SexScenes/MirruSnatchF.Default__MirruSnatchF_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Mirru/SexScenes/MirruSnatchF.Default__MirruSnatchF_C.SessionData.Lines(4).Lines
 msgctxt ",D4BAFDEE4340A6062B18808C4CB9ABF1"
 msgid "Soon... ahhh... you will be covered and impregnated by sticky Kraken pleasure..."
-msgstr "Pronto... ahhh... estarás cubierta e impregnada por el pegajoso placer de Kraken..."
+msgstr "Pronto... ahhh... estarás cubierto e impregnado por el pegajoso placer de kraken..."
 
 #. Key:	D4E7C4CC40DA7F02F81C91A5CFBF13E8
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMClimaxPeak.Default__DMClimaxPeak_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMClimaxPeak.Default__DMClimaxPeak_C.SessionData.Lines(5).Lines
 msgctxt ",D4E7C4CC40DA7F02F81C91A5CFBF13E8"
 msgid "Bring me Bovaur milk, and lots of it."
-msgstr ""
+msgstr "Tráeme leche de bovaur, y mucha."
 
 #. Key:	D4F1F3F04E4BCBC46FFF2E9AC9B301C0
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_RechargeSpiritForm_RL_T.Default__LeylannaDefault01_RechargeSpiritForm_RL_T_C.ResponseData(0).ResponseData.BreederPrompt
@@ -11400,21 +11472,22 @@ msgstr "Pocos @MONSTER_RACE@ son mayores que yo, pero Pawsmaati es una excepció
 #: /Game/Dialogue/Autumn/Default/DryadDefault01_RL.Default__DryadDefault01_RL_C.ResponseData(4).ResponseData.BreederPrompt
 msgctxt ",D52E88834BD47EFB47BD74839CEEB65D"
 msgid "Can I have that keystone?"
-msgstr ""
+msgstr "¿Puedo tener esa piedra-llave?"
 
 #. Key:	D535E0D84F73A7E07CA72DA2ED4F1B11
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(17 - Value).TraitIcons.HelpText
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(17 - Value).TraitIcons.HelpText
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(17 -
+#: Value).TraitIcons.HelpText
 msgctxt ",D535E0D84F73A7E07CA72DA2ED4F1B11"
 msgid "Meaty: Strength raises the XP granted to mates when breeding as a percentage."
-msgstr "Carnoso/a: Fuerza aumenta el EXP otorgado a los compañeros cuando se reproduce como un porcentaje."
+msgstr "Carnoso: la Fuerza aumenta la EXP otorgada a los compañeros cuando se reproducen como un porcentaje."
 
 #. Key:	D560F92446F9C63CB113458A9A0ED552
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleTaskFulfilled.Default__KybeleTaskFulfilled_C.SessionData.LinesToFemale(3).LinesToFemale
 #: /Game/Dialogue/Kybele/Default/KybeleTaskFulfilled.Default__KybeleTaskFulfilled_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",D560F92446F9C63CB113458A9A0ED552"
 msgid "She will start sucking it when I'm not paying attention, what a nice surprise!"
-msgstr ""
+msgstr "Ella empezará a chuparlo cuando no le preste atención, ¡qué agradable sorpresa!"
 
 #. Key:	D57D76E842FCC75ECC756BA13E9E8C9B
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToFemale(6).LinesToFemale
@@ -11428,14 +11501,14 @@ msgstr "Déjame lamer esa dulce vagina humana tuya... sí..."
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R01.Default__CamillaDefault01_R01_C.SessionData.Lines(4).Lines
 msgctxt ",D5A1DB2341980090F900379E1AE48051"
 msgid "If you don't, they will!"
-msgstr "¡Si no lo haces, lo harán!"
+msgstr "Si no lo haces, ¡ellos lo harán!"
 
 #. Key:	D5C1C3B248D402846D813ABD2800F061
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_FloatRhyme.Default__ParvatiDefault01_FloatRhyme_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_FloatRhyme.Default__ParvatiDefault01_FloatRhyme_C.SessionData.Lines(2).Lines
 msgctxt ",D5C1C3B248D402846D813ABD2800F061"
 msgid "Mentally I have sex with Her every day."
-msgstr "Mentalmente tengo sexo con Ella a diario."
+msgstr "Mentalmente tengo sexo con Ella todos los días."
 
 #. Key:	D5C1EFC54081F21A6C1F538839E450A2
 #. SourceLocation:	/Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToFuta(3).LinesToFuta
@@ -11449,7 +11522,7 @@ msgstr "¡Si! Ohhhh, tan grande... ¡sigue así humana! Ahh..."
 #: /Game/Dialogue/Romy/Default/RomyDefault01_RL.Default__RomyDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",D5CB7ED64FDBBF8094BDFE9F5271E39E"
 msgid "You hear my uh... music?"
-msgstr "¿Escuchas mi uh... música?"
+msgstr "¿Escuchas mi eh... música?"
 
 #. Key:	D5E48FA54813F998B6D165A5B2F04BF7
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(11).LinesToMale
@@ -11470,28 +11543,28 @@ msgstr "Hay un número infinito de almas @MONSTER_RACE@ esperando en el Vacío p
 #: /Game/Dialogue/Autumn/Default/DryadHaveKeystone.Default__DryadHaveKeystone_C.SessionData.Lines(5).Lines
 msgctxt ",D5F8F9DC452D7E14F022B7A4C04B523C"
 msgid "If you can breed me a lovely honey bee, it would be a massive help."
-msgstr ""
+msgstr "Si puedes criarme una hermosa abeja de la miel, sería de inmensa ayuda."
 
 #. Key:	D60B38ED43ABAC98BCB33FBB4B3477F4
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(4).LinesToFemale
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(4).LinesToFemale
 msgctxt ",D60B38ED43ABAC98BCB33FBB4B3477F4"
 msgid "And I'm one of them! A blessed female Painted Elf to be exact!"
-msgstr "¡Y yo soy una de ellas! ¡Una bendecida elfa pintada para ser exactas!"
+msgstr "¡Y yo soy una de ellos! ¡Una elfa pintada bendecida para ser exactas!"
 
 #. Key:	D673B2CE4FDE4D50F057C0A033DA8F53
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraAboutPawsmaati.Default__PetraAboutPawsmaati_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Petra/Default/PetraAboutPawsmaati.Default__PetraAboutPawsmaati_C.SessionData.Lines(0).Lines
 msgctxt ",D673B2CE4FDE4D50F057C0A033DA8F53"
 msgid "She is amazing!"
-msgstr ""
+msgstr "¡Ella es asombrosa!"
 
 #. Key:	D681E76840B85B19D8C08BBCF50268C8
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToFuta(3).LinesToFuta
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToFuta(3).LinesToFuta
 msgctxt ",D681E76840B85B19D8C08BBCF50268C8"
 msgid "All have been pleasurable and delicious... but oh have I wanted something more..."
-msgstr "Todos han sido placenteros y deliciosos... pero oh he querido algo más..."
+msgstr "Todos han sido placenteros y deliciosos... pero oh, he querido algo más..."
 
 #. Key:	D6BF802E4E5B43F72E7B4F90BD61A387
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_StartWaterfall.Default__ParvatiDefault01_StartWaterfall_C.SessionData.Lines(0).Lines
@@ -11505,56 +11578,56 @@ msgstr "..."
 #: /Game/Dialogue/Monarch/Default/MonarchQueen.Default__MonarchQueen_C.SessionData.Lines(1).Lines
 msgctxt ",D6D627BB4317AEDB4A049A875CA79F63"
 msgid "We bring her nectar and please her sexually, and in return she let's us eat of her h-h-honey."
-msgstr ""
+msgstr "Le traemos néctar y la complacemos sexualmente, y a cambio ella nos deja comer de su m-m-miel."
 
 #. Key:	D6E5B72340D672B892908385DF8BC169
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",D6E5B72340D672B892908385DF8BC169"
 msgid "In my case, that Alchemist Guild on the surface constantly dumps fresh semen down here."
-msgstr ""
+msgstr "En mi caso, ese Gremio de Alquimistas de la superficie arroja constantemente semen fresco aquí."
 
 #. Key:	D6ECEFA141121C7CDA69A5BAC65087CE
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMClimaxPeak.Default__DMClimaxPeak_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMClimaxPeak.Default__DMClimaxPeak_C.SessionData.Lines(0).Lines
 msgctxt ",D6ECEFA141121C7CDA69A5BAC65087CE"
 msgid "Ah, you wish to have sex with the mighty Titans; I can respect that, for I have done it many times."
-msgstr ""
+msgstr "Ah, deseas tener sexo con los poderosos titanes; puedo respetar eso, porque lo he hecho muchas veces."
 
 #. Key:	D720325F44DF14DB1473D0A78512EB8E
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimePlay.Default__MegaSlimePlay_C.SessionData.LinesToFuta(3).LinesToFuta
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePlay.Default__MegaSlimePlay_C.SessionData.LinesToFuta(3).LinesToFuta
 msgctxt ",D720325F44DF14DB1473D0A78512EB8E"
 msgid "Well what are you waiting for? Come on in!"
-msgstr ""
+msgstr "¿Bueno, qué estás esperando? ¡Venga!"
 
 #. Key:	D75F1B6640E7E50789CBE7B4CBEE0FF3
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleTaskFulfilled.Default__KybeleTaskFulfilled_C.SessionData.LinesToFuta(1).LinesToFuta
 #: /Game/Dialogue/Kybele/Default/KybeleTaskFulfilled.Default__KybeleTaskFulfilled_C.SessionData.LinesToFuta(1).LinesToFuta
 msgctxt ",D75F1B6640E7E50789CBE7B4CBEE0FF3"
 msgid "The random mounts I get when I'm not paying attention never gets old."
-msgstr ""
+msgstr "Las montas aleatorias que obtengo cuando no estoy prestando atención nunca envejecen."
 
 #. Key:	D76798CF4DCADF9AF42C6B88C36E27FB
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeAboutOrb_RL.Default__MegaSlimeAboutOrb_RL_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeAboutOrb_RL.Default__MegaSlimeAboutOrb_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",D76798CF4DCADF9AF42C6B88C36E27FB"
 msgid "This won't be easy..."
-msgstr ""
+msgstr "Esto no será fácil..."
 
 #. Key:	D79654914AB8CE6E58B5A28BDCFB3EBC
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToMale(5).LinesToMale
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToMale(5).LinesToMale
 msgctxt ",D79654914AB8CE6E58B5A28BDCFB3EBC"
 msgid "It's a nutritious aphrodisiac, a very powerful one so be careful!"
-msgstr ""
+msgstr "Es un afrodisíaco nutritivo, uno muy poderoso, ¡así que ten cuidado!"
 
 #. Key:	D7A6D67F4C7BFFA071AA8480399A5D41
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMHadSex01.Default__DMHadSex01_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/DragonMatriarch/Default/DMHadSex01.Default__DMHadSex01_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",D7A6D67F4C7BFFA071AA8480399A5D41"
 msgid "I can't believe it!"
-msgstr ""
+msgstr "¡No puedo creerlo!"
 
 #. Key:	D7B87B2D4E7F9B733C981C804A0914C8
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernGreeting02.Default__FernGreeting02_C.SessionData.LinesToFemale(3).LinesToFemale
@@ -11575,175 +11648,176 @@ msgstr "Mira, no hay ningún lugar en @WORLD_NAME@ por el que no me haya desliza
 #: /Game/Breeding/Positions/Missionary.Default__Missionary_C.SessionData.Description
 msgctxt ",D7CD27D2485A136014BAEDA62F225167"
 msgid "The giver lays on top of the receiver and thrusts."
-msgstr "El/La dador/a se coloca encima de la receptora y empuja."
+msgstr "El donante se acuesta encima de la receptora y empuja."
 
 #. Key:	D7D031AA47A9423B1EE418BC71725DDA
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimePlay1.Default__MegaSlimePlay1_C.SessionData.LinesToFuta(2).LinesToFuta
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePlay1.Default__MegaSlimePlay1_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",D7D031AA47A9423B1EE418BC71725DDA"
 msgid "*Yawn* Might need a nap after we make love again."
-msgstr ""
+msgstr "*Bosteza* Puede que necesite una siesta después de que hagamos el amor de nuevo."
 
 #. Key:	D7D29FFE4A41A6DA230B80B0832CBC28
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcWantWrestle.Default__OrcWantWrestle_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcWantWrestle.Default__OrcWantWrestle_C.SessionData.Lines(2).Lines
 msgctxt ",D7D29FFE4A41A6DA230B80B0832CBC28"
 msgid "Chieftain very horny, you will regret this. Come here!"
-msgstr ""
+msgstr "Cacique muy cachonda, te arrepentirás de esto. ¡Ven aquí!"
 
 #. Key:	D7F8B9C2431BFB6ED28ECAAF83BAE062
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03.Default__FernDefault03_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03.Default__FernDefault03_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",D7F8B9C2431BFB6ED28ECAAF83BAE062"
 msgid "Look at my beautiful flower, it bloomed! Oh my did it feel weird..."
-msgstr "Mira mi hermosa flor, ¡floreció! Oh, se sintió raro..."
+msgstr "Mira mi hermosa flor, ¡floreció! Oh cielos, se sintió raro..."
 
 #. Key:	D8048E504EF52CFA3D3F618130F77DB0
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleRideYou_RL.Default__KybeleRideYou_RL_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/Kybele/Default/KybeleRideYou_RL.Default__KybeleRideYou_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",D8048E504EF52CFA3D3F618130F77DB0"
 msgid "Aww what an adorable titty pony."
-msgstr ""
+msgstr "Amm, que adorable poni tetudita."
 
 #. Key:	D839985345EFF273DA362C9BB07DA471
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMAboutDragons.Default__DMAboutDragons_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMAboutDragons.Default__DMAboutDragons_C.SessionData.Lines(1).Lines
 msgctxt ",D839985345EFF273DA362C9BB07DA471"
 msgid "Don't be fooled by those Titans. They might seem like they own the place with their massive size and strength."
-msgstr ""
+msgstr "No te deje engañar por esos titanes. Puede parecer que son dueños del lugar con su enorme tamaño y fuerza."
 
 #. Key:	D857E31D47711B85E634029A4E3EB6E7
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.CBGate_Breaks.PlaceMessage
 #: /Game/World/Overworld.Overworld:PersistentLevel.CBGate_Breaks.PlaceMessage
 msgctxt ",D857E31D47711B85E634029A4E3EB6E7"
 msgid "Virgin Breaks is now accessible."
-msgstr ""
+msgstr "Las Rupturas Vírgenes ahora son accesibles."
 
 #. Key:	D8702B7C4C5E95A9D843A79FCFBFB106
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeVerySad.Default__MegaSlimeVerySad_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeVerySad.Default__MegaSlimeVerySad_C.SessionData.Lines(0).Lines
 msgctxt ",D8702B7C4C5E95A9D843A79FCFBFB106"
 msgid "*Sniff*"
-msgstr ""
+msgstr "*Olfatea*"
 
 #. Key:	D87AAD604344FB1EAE2D0F9DCC51E7EA
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleHaveKeystone2.Default__KybeleHaveKeystone2_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Kybele/Default/KybeleHaveKeystone2.Default__KybeleHaveKeystone2_C.SessionData.Lines(1).Lines
 msgctxt ",D87AAD604344FB1EAE2D0F9DCC51E7EA"
 msgid "But don't tell the Dragon Matriarch!"
-msgstr ""
+msgstr "¡Pero no se lo digas a la Matriarca Dragón!"
 
 #. Key:	D8A6098049B17D17442735B4FDBAB323
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_FutaBalls.Default__FaleneDefault01_FutaBalls_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_FutaBalls.Default__FaleneDefault01_FutaBalls_C.SessionData.Lines(2).Lines
 msgctxt ",D8A6098049B17D17442735B4FDBAB323"
 msgid "It's really a superior design when you think about it--the next stage of evolution."
-msgstr "Realmente es un diseño superior cuando lo piensas. La siguiente etapa de la evolución."
+msgstr "Realmente es un diseño superior cuando lo piensas: la siguiente etapa de la evolución."
 
 #. Key:	D8ADF7FF4D4119D1628F44BF0E97521A
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraGetKeystone.Default__PetraGetKeystone_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Petra/Default/PetraGetKeystone.Default__PetraGetKeystone_C.SessionData.Lines(2).Lines
 msgctxt ",D8ADF7FF4D4119D1628F44BF0E97521A"
 msgid "Pawsmaati tasked me with practicing my recent lesson with a \"winged mountain maiden\"."
-msgstr ""
+msgstr "Pawsmaati me asignó la tarea de practicar mi reciente lección con una \"doncella de la montaña alada\"."
 
 #. Key:	D8D64A6444112501D1C4728A0BB65EB7
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_R02.Default__FernDefault02_R02_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02_R02.Default__FernDefault02_R02_C.SessionData.Lines(1).Lines
 msgctxt ",D8D64A6444112501D1C4728A0BB65EB7"
 msgid "I grow more voluptuous and beautiful everyday, and it feels so good..."
-msgstr "Me vuelvo más voluptuosa y hermosa a cada día, y se siente tan bien..."
+msgstr "Cada día crezco más voluptuosa y hermosa, y se siente tan bien..."
 
 #. Key:	D8F0F94A480E7784CAF965A42BDDDC9A
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeDefault01_RL.Default__MegaSlimeDefault01_RL_C.ResponseData(3).ResponseData.BreederPrompt
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeDefault01_RL.Default__MegaSlimeDefault01_RL_C.ResponseData(3).ResponseData.BreederPrompt
 msgctxt ",D8F0F94A480E7784CAF965A42BDDDC9A"
 msgid "How are slimes made?"
-msgstr ""
+msgstr "¿Cómo se hacen los limos?"
 
 #. Key:	D8F23CE1423B47137E2603AC9C522535
 #. SourceLocation:	/Game/Dialogue/Cassie/SexScenes/CassieSplintersT.Default__CassieSplintersT_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Cassie/SexScenes/CassieSplintersT.Default__CassieSplintersT_C.SessionData.Lines(4).Lines
 msgctxt ",D8F23CE1423B47137E2603AC9C522535"
 msgid "*Purr*"
-msgstr "*Ronroneo*"
+msgstr "*Ronronea*"
 
 #. Key:	D9124E55481B91E85A0884AA58197D19
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeHadSex01.Default__AmberMaeHadSex01_C.SessionData.LinesToFemale(2).LinesToFemale
 #: /Game/Dialogue/AmberMae/Default/AmberMaeHadSex01.Default__AmberMaeHadSex01_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",D9124E55481B91E85A0884AA58197D19"
 msgid "'Mai milk was tasty aye? Plenty more where that came from!"
-msgstr ""
+msgstr "Mi leshe ehtaba zabrosa, ¿no? ¡Musho máh de donde vino eso!"
 
 #. Key:	D913C6254D30AA08E8B01787AE3D1B68
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TravelShrines(4 - Value).TravelShrines.ShrineName
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TravelShrines(4 - Value).TravelShrines.ShrineName
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TravelShrines(4 -
+#: Value).TravelShrines.ShrineName
 msgctxt ",D913C6254D30AA08E8B01787AE3D1B68"
 msgid "Hivelands"
-msgstr "Colmenas"
+msgstr "Tierras-Colmena"
 
 #. Key:	D942BF8C4B6164B1D4F7569E55FC349E
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03_R03.Default__FernDefault03_R03_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03_R03.Default__FernDefault03_R03_C.SessionData.Lines(0).Lines
 msgctxt ",D942BF8C4B6164B1D4F7569E55FC349E"
 msgid "Oh Master... you are too good to me."
-msgstr "Oh maestra... eres demasiado buena para mí."
+msgstr "Oh, Master... eres demasiado bueno para mí."
 
 #. Key:	D946784E4574F80408FA7D82B80E4EAC
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadCherryHelp.Default__DryadCherryHelp_C.SessionData.LinesToMale(2).LinesToMale
 #: /Game/Dialogue/Autumn/Default/DryadCherryHelp.Default__DryadCherryHelp_C.SessionData.LinesToMale(2).LinesToMale
 msgctxt ",D946784E4574F80408FA7D82B80E4EAC"
 msgid "I'm getting wet just thinking about your thick cock seeding me."
-msgstr ""
+msgstr "Me estoy mojando solo de pensar en tu gruesa polla sembrándome."
 
 #. Key:	D970772D478546EA5EFEA68C821EAC60
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcHadSex01.Default__OrcHadSex01_C.SessionData.LinesToFuta(2).LinesToFuta
 #: /Game/Dialogue/OrcChief/Default/OrcHadSex01.Default__OrcHadSex01_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",D970772D478546EA5EFEA68C821EAC60"
 msgid "For one so weak, human did give mighty load!"
-msgstr ""
+msgstr "¡Para uno tan débil, el humano dio una carga poderosa!"
 
 #. Key:	D98B804D4BEB2904234F77AB902776CD
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadAboutDryads.Default__DryadAboutDryads_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Autumn/Default/DryadAboutDryads.Default__DryadAboutDryads_C.SessionData.Lines(2).Lines
 msgctxt ",D98B804D4BEB2904234F77AB902776CD"
 msgid "Every dryad is blessed by the Goddess, there are no wild dryads."
-msgstr ""
+msgstr "Cada dríada es bendecida por la Diosa, no hay dríadas silvestres."
 
 #. Key:	D9AEE5314A7E8A6D9F57F6B9A6116A55
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleTaskFulfilled.Default__KybeleTaskFulfilled_C.SessionData.LinesToFemale(2).LinesToFemale
 #: /Game/Dialogue/Kybele/Default/KybeleTaskFulfilled.Default__KybeleTaskFulfilled_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",D9AEE5314A7E8A6D9F57F6B9A6116A55"
 msgid "Each time she moans a little louder, I think she's starting to get addicted to my cock."
-msgstr ""
+msgstr "Cada vez gime un poco más fuerte, creo que empieza a volverse adicta a mi polla."
 
 #. Key:	D9AEE8B346F04D85CD643FA456C20645
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R05.Default__CamillaDefault01_R05_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R05.Default__CamillaDefault01_R05_C.SessionData.Lines(1).Lines
 msgctxt ",D9AEE8B346F04D85CD643FA456C20645"
 msgid "Did you really just phrase it that way?"
-msgstr "¿Realmente lo dijiste de esa forma?"
+msgstr "¿De verdad simplemente lo expresaste de esa manera?"
 
 #. Key:	D9E588CA4CF77A887584A3B57617B58C
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeVerySad.Default__MegaSlimeVerySad_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeVerySad.Default__MegaSlimeVerySad_C.SessionData.Lines(5).Lines
 msgctxt ",D9E588CA4CF77A887584A3B57617B58C"
 msgid "*Sobbing*"
-msgstr ""
+msgstr "*Sollozando*"
 
 #. Key:	D9E7689541319CEB860F4A99964E97FE
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R03.Default__FaleneDefault01_R03_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R03.Default__FaleneDefault01_R03_C.SessionData.Lines(5).Lines
 msgctxt ",D9E7689541319CEB860F4A99964E97FE"
 msgid "Wild @MONSTER_RACE@ may be dumb, but they need love too!"
-msgstr "@MONSTER_RACE@ salvajes puede ser tontos, ¡pero ellos también necesitan amor!"
+msgstr "Los @MONSTER_RACE@ silvestres pueden ser tontos, ¡pero ellos también necesitan amor!"
 
 #. Key:	D9F1E15344E0F55C0BF0C2BD7FA7EB63
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleHaveKeystone.Default__KybeleHaveKeystone_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Kybele/Default/KybeleHaveKeystone.Default__KybeleHaveKeystone_C.SessionData.Lines(0).Lines
 msgctxt ",D9F1E15344E0F55C0BF0C2BD7FA7EB63"
 msgid "Hmm... I suppose you were a good mate."
-msgstr ""
+msgstr "Hmm... supongo que fuiste una buena pareja."
 
 #. Key:	D9F77A0E43A8B000912D6AB5C30FD924
 #. SourceLocation:	/Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToFuta(7).LinesToFuta
@@ -11757,14 +11831,14 @@ msgstr "*Chupa* *Chupa*"
 #: /Game/Dialogue/OrcChief/Default/OrcAkabekoCheck.Default__OrcAkabekoCheck_C.SessionData.Lines(2).Lines
 msgctxt ",D9FB570C43AD0DD02FC1EA8FBF6685E7"
 msgid "Akabeko not found in the wild, her pussy felt unique! Grrrrr!!"
-msgstr ""
+msgstr "Las akabeko no se encuentran en la naturaleza, ¡su coño se siente único! ¡¡Grrrrr!!"
 
 #. Key:	DA05F5A447D7B5F1C5C75E8A35B95C21
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01_RL_M.Default__FernDefault01_RL_M_C.ResponseData(4).ResponseData.BreederPrompt
 #: /Game/Dialogue/Fern/Default/FernDefault01_RL_M.Default__FernDefault01_RL_M_C.ResponseData(4).ResponseData.BreederPrompt
 msgctxt ",DA05F5A447D7B5F1C5C75E8A35B95C21"
 msgid "The Queen Bee demands flowers."
-msgstr ""
+msgstr "La Abeja Reina exige flores."
 
 #. Key:	DA1107CD4D4DED76EFB5A3BAE5A1C4D0
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_StartLoveMakingF.Default__LeylannaDefault01_StartLoveMakingF_C.SessionData.Lines(0).Lines
@@ -11778,14 +11852,14 @@ msgstr "Ven a mi abrazo."
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R01.Default__CamillaDefault01_R01_C.SessionData.Lines(6).Lines
 msgctxt ",DA2AFA94407EDEA10F42C4A25864E68E"
 msgid "You buy semen from me! I am a first class cum alchemist, and no one knows more about it!"
-msgstr "¡Me compras semen! Soy un alquimista seminal de primera clase, ¡y nadie sabe más al respecto!"
+msgstr "¡Me compras semen! Soy una alquimista de semen de primera clase, ¡y nadie sabe más al respecto!"
 
 #. Key:	DA8A389840F92C11D80A20A1593273B7
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01_R01.Default__FernDefault01_R01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Fern/Default/FernDefault01_R01.Default__FernDefault01_R01_C.SessionData.Lines(1).Lines
 msgctxt ",DA8A389840F92C11D80A20A1593273B7"
 msgid "Me grow in thisss soil... hiss. Still sapling... need mastah to grow into big Alraune!"
-msgstr "Yo crecer en este suelo... ssss. Todavía retoño... ¡necesito maeztra para crecer en una gran Mandrágora!"
+msgstr "Yo crecer en essste suelo... ssss. Todavía retoño... ¡necesito Mastah para crecer en una gran alraune!"
 
 #. Key:	DA9BB43342773BD3A51CEC9C5A48CA82
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01_RL_T.Default__FernDefault01_RL_T_C.ResponseData(3).ResponseData.BreederPrompt
@@ -11799,14 +11873,14 @@ msgstr "¡Puedes tener mi semen!"
 #: /Game/Dialogue/OrcChief/Default/OrcDefault03_RL.Default__OrcDefault03_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",DAA21E23412F638CF86C45BDFEF403A9"
 msgid "Uh... so... want to wrestle?"
-msgstr ""
+msgstr "Uh... entonces... ¿querer luchar?"
 
 #. Key:	DAC926244203A48C0547B89807D93FA8
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R01.Default__FaleneDefault01_R01_C.SessionData.Lines(6).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R01.Default__FaleneDefault01_R01_C.SessionData.Lines(6).Lines
 msgctxt ",DAC926244203A48C0547B89807D93FA8"
 msgid "@MONSTER_RACE@ on the other hand reproduce almost instantly."
-msgstr "@MONSTER_RACE@, por otro lado, se reproducen casi instantáneamente."
+msgstr "Los @MONSTER_RACE@, por otro lado, se reproducen casi instantáneamente."
 
 #. Key:	DADDEBF642EA8FAF8F912C830249D0E6
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(9).Lines
@@ -11820,21 +11894,21 @@ msgstr "@WORLD_NAME@ es mi mundo."
 #: /Game/Dialogue/Yasmine/Default/YasmineHadSex01.Default__YasmineHadSex01_C.SessionData.Lines(0).Lines
 msgctxt ",DAF3ABC54412C70DC128659F2DB1098C"
 msgid "Oh the songs of pleasure we sang, how good they felt."
-msgstr ""
+msgstr "Oh, las canciones de placer que cantamos, qué bien se sentían."
 
 #. Key:	DB00D91D4420A5D9D4F3FBB7DD1AC099
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_R02_R01.Default__FernDefault02_R02_R01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02_R02_R01.Default__FernDefault02_R02_R01_C.SessionData.Lines(0).Lines
 msgctxt ",DB00D91D4420A5D9D4F3FBB7DD1AC099"
 msgid "I can help you harvest fluids from wild @MONSTER_RACE@."
-msgstr "Puedo ayudarte a recolectar fluidos de @MONSTER_RACE@ salvajes."
+msgstr "Puedo ayudarte a recolectar fluidos de @MONSTER_RACE@ silvestres."
 
 #. Key:	DB0CF562471898C2200245955791C3B9
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchGreeting01.Default__MonarchGreeting01_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Monarch/Default/MonarchGreeting01.Default__MonarchGreeting01_C.SessionData.Lines(2).Lines
 msgctxt ",DB0CF562471898C2200245955791C3B9"
 msgid "What brings you here?"
-msgstr ""
+msgstr "¿Qué te trae por aquí?"
 
 #. Key:	DB15AC1342DDCD7D060351944CB369E4
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDefault01.Default__CassieDefault01_C.SessionData.Lines(2).Lines
@@ -11848,7 +11922,7 @@ msgstr "¡Miiiiiau!"
 #: /Game/Dialogue/Kybele/Default/KybeleAnyMeans.Default__KybeleAnyMeans_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",DB1DF3C343E55ED6022897831EFCA30B"
 msgid "Haha! Humans do have a one-track mind... you aren't so different from us after all."
-msgstr ""
+msgstr "¡Jaja! Los humanos tienen una mente de una sola pista... después de todo, no eres tan diferente de nosotros."
 
 #. Key:	DB4129DC426B367CD877BE889495E940
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_RL.Default__CamillaDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
@@ -11862,28 +11936,28 @@ msgstr "¡Intercambiemos semen!"
 #: /Game/Dialogue/Kybele/Default/KybeleAnyMeans_RL_T.Default__KybeleAnyMeans_RL_T_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",DB44149945F62048F1EF0D9C2BF75EFB"
 msgid "Pfff I can handle a titty pony."
-msgstr ""
+msgstr "Pfff, puedo manejar una pony tetudita."
 
 #. Key:	DB49BD62447CAE7EAA40869818522E59
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R03_RL.Default__CamillaDefault01_R03_RL_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R03_RL.Default__CamillaDefault01_R03_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",DB49BD62447CAE7EAA40869818522E59"
 msgid "Aww. I'm no Titan but..."
-msgstr "Aww. No soy una Titán pero..."
+msgstr "Amm. No soy un titán pero..."
 
 #. Key:	DB69E46B4983BD0EAA6594BCFCD514ED
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernGreeting01.Default__FernGreeting01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Fern/Default/FernGreeting01.Default__FernGreeting01_C.SessionData.Lines(0).Lines
 msgctxt ",DB69E46B4983BD0EAA6594BCFCD514ED"
 msgid "Hiss..."
-msgstr "Sssss..."
+msgstr "Sss..."
 
 #. Key:	DB700CCB477FAB622C9638923D9D31D6
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDungeon2.Default__CassieDungeon2_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Cassie/Default/CassieDungeon2.Default__CassieDungeon2_C.SessionData.Lines(3).Lines
 msgctxt ",DB700CCB477FAB622C9638923D9D31D6"
 msgid "That old rusty set of gears above the town entrance controls a pulley system."
-msgstr ""
+msgstr "Ese viejo y oxidado juego de engranajes sobre la entrada de la ciudad controla un sistema de poleas."
 
 #. Key:	DB7D31B143C7D61531D61790BE87667B
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03_R01.Default__FernDefault03_R01_C.SessionData.Lines(1).Lines
@@ -11897,67 +11971,68 @@ msgstr "Crecí en tu suelo, y ahora es mi hogar permanente. ¡Ojalá te guste tu
 #: /Game/Dialogue/Blossom/Default/BlossomDefault01_R02.Default__BlossomDefault01_R02_C.SessionData.Lines(1).Lines
 msgctxt ",DC0025004492CEEAE0F8D1A26E169F34"
 msgid "Me like this name Blossom. Hiss!"
-msgstr "Yo gusto este nombre Flor. ¡Sssss!"
+msgstr "Yo gusta este nombre Blossom. ¡Sss!"
 
 #. Key:	DC23BE8C475FA9FCC7F22596C3D47F3F
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01_R02.Default__FernDefault01_R02_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Fern/Default/FernDefault01_R02.Default__FernDefault01_R02_C.SessionData.Lines(2).Lines
 msgctxt ",DC23BE8C475FA9FCC7F22596C3D47F3F"
 msgid "Fern needsss fluidsss!"
-msgstr "¡Helecho necessssita fluidossss!"
+msgstr "¡Fern necesssita fluidosss!"
 
 #. Key:	DC33A237422E2C40903834AF3706B8E4
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeAboutOrb.Default__MegaSlimeAboutOrb_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeAboutOrb.Default__MegaSlimeAboutOrb_C.SessionData.Lines(3).Lines
 msgctxt ",DC33A237422E2C40903834AF3706B8E4"
 msgid "Then just a few days ago, this orb floated down the drain and got stuck in me."
-msgstr ""
+msgstr "Entonces, hace solo unos días, este orbe flotó por el desagüe y se atascó en mí."
 
 #. Key:	DC3F654D485B4A5558C482B697A01B3C
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiDefault01_RL.Default__FesssiDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/Fesssi/Default/FesssiDefault01_RL.Default__FesssiDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",DC3F654D485B4A5558C482B697A01B3C"
 msgid "Are you ok?"
-msgstr ""
+msgstr "¿Estás bien?"
 
 #. Key:	DC3FF6AD41D27D03E1D980BAD76F4897
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleHadSex01.Default__KybeleHadSex01_C.SessionData.LinesToFuta(2).LinesToFuta
 #: /Game/Dialogue/Kybele/Default/KybeleHadSex01.Default__KybeleHadSex01_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",DC3FF6AD41D27D03E1D980BAD76F4897"
 msgid "Still... you pleased me like a stallion. That's amazing for one of your size!"
-msgstr ""
+msgstr "Aún así... me complaciste como un semental. ¡Eso es increíble para uno de tu tamaño!"
 
 #. Key:	DC59A07E4D2FC78409E32EA7A64B7007
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFemale(7).LinesToFemale
 #: /Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFemale(7).LinesToFemale
 msgctxt ",DC59A07E4D2FC78409E32EA7A64B7007"
 msgid "That creepy golden seraphim, the one in the temple. She appeared only a few days ago, constantly asking to speak with \"the human\"."
-msgstr ""
+msgstr "Esa espeluznante serafín dorada, la del templo. Ella apareció hace solo unos días, constantemente pidiendo hablar con \"el humano\"."
 
 #. Key:	DC843E8A4828B0881624D494C080BC2B
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeDefault01_SuckJugs.Default__AmberMaeDefault01_SuckJugs_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeDefault01_SuckJugs.Default__AmberMaeDefault01_SuckJugs_C.SessionData.Lines(1).Lines
 msgctxt ",DC843E8A4828B0881624D494C080BC2B"
 msgid "Awww... I'm blushing something heavy."
-msgstr "Awww... me ehtoy sonrojahdo pa aburrih."
+msgstr "Ammm... me ehtoy sonrojahdo una barbaridah."
 
 #. Key:	DC85F26F423721D07495E3AB892F86CC
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R01.Default__FaleneDefault01_R01_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R01.Default__FaleneDefault01_R01_C.SessionData.Lines(4).Lines
 msgctxt ",DC85F26F423721D07495E3AB892F86CC"
 msgid "They are very unlike your human counterparts."
-msgstr "Son muy diferentes a sus contrapartes humanas."
+msgstr "Son muy diferentes a sus contrapartidas humanas."
 
 #. Key:	DC880E904973CDED818EF58F9949FB40
 #. SourceLocation:	/Game/Dialogue/Mirru/SexScenes/MirruSnatchF.Default__MirruSnatchF_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Mirru/SexScenes/MirruSnatchF.Default__MirruSnatchF_C.SessionData.Lines(0).Lines
 msgctxt ",DC880E904973CDED818EF58F9949FB40"
 msgid "Submit human... I cannot control my desires!"
-msgstr "Sométete humana... ¡No puedo controlar mis deseos!"
+msgstr "Entrégate humana... ¡No puedo controlar mis deseos!"
 
 #. Key:	DC956C0949E5CA05486F1583CEACA3ED
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(24 - Value).TraitIcons.DisplayName
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(24 - Value).TraitIcons.DisplayName
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(24 -
+#: Value).TraitIcons.DisplayName
 msgctxt ",DC956C0949E5CA05486F1583CEACA3ED"
 msgid "Busty"
 msgstr "Tetona"
@@ -11967,35 +12042,35 @@ msgstr "Tetona"
 #: /Game/World/Overworld.Overworld:PersistentLevel.CBGate_Jungle.BlockMessage
 msgctxt ",DC9E09AE4BC0BE32644CA59E071AE774"
 msgid "Honeycomb blocks this gate."
-msgstr ""
+msgstr "El panal bloquea este portón."
 
 #. Key:	DCA3C7F14DDEBDAEB595FB95AA6A4F3C
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimePlay.Default__MegaSlimePlay_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePlay.Default__MegaSlimePlay_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",DCA3C7F14DDEBDAEB595FB95AA6A4F3C"
 msgid "Really?! These truly are the best days of my life!"
-msgstr ""
+msgstr "¡¿En serio?! ¡Estos son verdaderamente los mejores días de mi vida!"
 
 #. Key:	DCBFA42D4FD9520CA7F586A84DCF3921
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01.Default__LeylannaDefault01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Leylanna/Default/LeylannaDefault01.Default__LeylannaDefault01_C.SessionData.Lines(0).Lines
 msgctxt ",DCBFA42D4FD9520CA7F586A84DCF3921"
 msgid "Make love with me @BREEDER_NAME@, let us writhe in pleasure before Her gaze."
-msgstr "Haz el amor conmigo @BREEDER_NAME@, déjanos retorcernos de placer ante Su mirada."
+msgstr "Haz el amor conmigo @BREEDER_NAME@, nos dejamos retorcer de placer ante Su mirada."
 
 #. Key:	DCFCF2FF45351BEF9BAEACA9BE408F9A
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R03.Default__FaleneDefault01_R03_C.SessionData.Lines(13).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R03.Default__FaleneDefault01_R03_C.SessionData.Lines(13).Lines
 msgctxt ",DCFCF2FF45351BEF9BAEACA9BE408F9A"
 msgid "If the wild @MONSTER_RACE@ loses interest in you, its low attention span will kick in and it will wander off."
-msgstr "Si el salvaje @MONSTER_RACE@ pierde interés en ti, su poca capacidad de atención se activará y se alejará."
+msgstr "Si el @MONSTER_RACE@ silvestres pierde interés en ti, su poca capacidad de atención se activará y se alejará."
 
 #. Key:	DD27BA4F486D3C23B0BAE6ABF193831E
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchGreeting01.Default__MonarchGreeting01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Monarch/Default/MonarchGreeting01.Default__MonarchGreeting01_C.SessionData.Lines(1).Lines
 msgctxt ",DD27BA4F486D3C23B0BAE6ABF193831E"
 msgid "A human... t-t-that's not something you see everyday."
-msgstr ""
+msgstr "Un humano... e-e-eso no es algo que se ve todos los días."
 
 #. Key:	DD3959194243B910FF07BC8D7CA651AB
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_Emissary.Default__LeylannaDefault01_Emissary_C.SessionData.Lines(0).Lines
@@ -12009,70 +12084,70 @@ msgstr "La hermosa ángel dorada apareció solo unos días antes que tú."
 #: /Game/Dialogue/Widow/Default/WidowKeystone.Default__WidowKeystone_C.SessionData.Lines(6).Lines
 msgctxt ",DD71570B40252FFC58EE9CAB7B9A3230"
 msgid "Breed this lonely spider a juicy elf, and the rock will be yours."
-msgstr ""
+msgstr "Cría para esta araña solitaria una elfa jugosa y la roca será tuya."
 
 #. Key:	DD7ECB9E437DDF8975868AA3934E909D
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernGreeting02.Default__FernGreeting02_C.SessionData.LinesToFuta(1).LinesToFuta
 #: /Game/Dialogue/Fern/DefaultP2/FernGreeting02.Default__FernGreeting02_C.SessionData.LinesToFuta(1).LinesToFuta
 msgctxt ",DD7ECB9E437DDF8975868AA3934E909D"
 msgid "Look at my beautiful flower, it bloomed! Oh my did it feel weird..."
-msgstr "Mira mi hermosa flor, ¡floreció! Oh, se sintió raro..."
+msgstr "Mira mi hermosa flor, ¡floreció! Oh cielos, se sintió raro..."
 
 #. Key:	DD90913F4C544CDB2D79CDAE67287C68
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01.Default__ParvatiDefault01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01.Default__ParvatiDefault01_C.SessionData.Lines(0).Lines
 msgctxt ",DD90913F4C544CDB2D79CDAE67287C68"
 msgid "Returning to me with that familiar glint in your eye."
-msgstr "Volviendo a mí con ese brillo familiar en tu ojo."
+msgstr "Volviendo a mí con ese brillo familiar en tus ojos."
 
 #. Key:	DDC7B99042CEA89C790895990EB876BE
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R02.Default__FaleneDefault01_R02_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R02.Default__FaleneDefault01_R02_C.SessionData.Lines(1).Lines
 msgctxt ",DDC7B99042CEA89C790895990EB876BE"
 msgid "Most @MONSTER_RACE@ are wild, that is they roam by instict and are as animals."
-msgstr "La mayoría de @MONSTER_RACE@ son salvajes, es decir, deambulan por instinto y son como animales."
+msgstr "La mayoría de @MONSTER_RACE@ son silvestres, es decir, deambulan por instinto y son como animales."
 
 #. Key:	DDC88AD7412D1B9E7696ED8213C21E27
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieGreeting01.Default__CassieGreeting01_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Cassie/Default/CassieGreeting01.Default__CassieGreeting01_C.SessionData.Lines(3).Lines
 msgctxt ",DDC88AD7412D1B9E7696ED8213C21E27"
 msgid "Though, whoever drew up your fence line is a lunatic!"
-msgstr "Aunque, ¡quien haya trazado tu cerca es un loco!"
+msgstr "Sin embargo, ¡quien sea que haya trazado la línea de la cerca es un lunático!"
 
 #. Key:	DDEC9C474F3624331E30EEB35B19842A
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadHaveKeystone2.Default__DryadHaveKeystone2_C.SessionData.Message
 #: /Game/Dialogue/Autumn/Default/DryadHaveKeystone2.Default__DryadHaveKeystone2_C.SessionData.Message
 msgctxt ",DDEC9C474F3624331E30EEB35B19842A"
 msgid "Autumn is satisfied."
-msgstr ""
+msgstr "Autumn está satisfecha."
 
 #. Key:	DE21C1784F767D32E852689C8D264665
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeHadSex01.Default__MegaSlimeHadSex01_C.SessionData.LinesToFemale(2).LinesToFemale
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeHadSex01.Default__MegaSlimeHadSex01_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",DE21C1784F767D32E852689C8D264665"
 msgid "It's been so long since I have given slime."
-msgstr ""
+msgstr "Ha pasado tanto tiempo desde que le di limo."
 
 #. Key:	DE7B484C4224680737F160881A189942
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_Emissary.Default__LeylannaDefault01_Emissary_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Leylanna/Default/LeylannaDefault01_Emissary.Default__LeylannaDefault01_Emissary_C.SessionData.Lines(2).Lines
 msgctxt ",DE7B484C4224680737F160881A189942"
 msgid "She only spoke one phrase to me: \"I must speak with the human.\""
-msgstr "Ella solo me dijo una frase: \"Debo hablar con la humana\"."
+msgstr "Ella solo me dijo una frase: \"Debo hablar con el humano\"."
 
 #. Key:	DED16C92469A536D38021EBB9437E929
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R05.Default__CamillaDefault01_R05_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R05.Default__CamillaDefault01_R05_C.SessionData.Lines(2).Lines
 msgctxt ",DED16C92469A536D38021EBB9437E929"
 msgid "I think we're going to get along well human."
-msgstr "Creo que nos llevaremos bien humana."
+msgstr "Creo que nos llevaremos bien humano."
 
 #. Key:	DED8326741203DABBF5FDBB2B97D6492
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_Formuria.Default__MirruDefault01_Formuria_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_Formuria.Default__MirruDefault01_Formuria_C.SessionData.Lines(0).Lines
 msgctxt ",DED8326741203DABBF5FDBB2B97D6492"
 msgid "Formuria is a kingdom deep beneath the sea, and it is my home."
-msgstr "Formuria es un reino profundo debajo del mar, y es mi hogar."
+msgstr "Formuria es un reino en las profundidades bajo el mar, y es mi hogar."
 
 #. Key:	DF6BBB7E43776E94C988FCA9C4AD5110
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_StartForgotten.Default__ParvatiDefault01_StartForgotten_C.SessionData.Lines(0).Lines
@@ -12086,49 +12161,49 @@ msgstr "Una vez que aprendas una nueva posición, podemos practicarla en cualqui
 #: /Game/Dialogue/Leylanna/Default/LeylannaDefault01_HowToSpiritForm_RL_T.Default__LeylannaDefault01_HowToSpiritForm_RL_T_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",DF7ACA4545FC48FBC7FBD9816CFDE6DA"
 msgid "I have caught the variant you requested."
-msgstr "He captado la variante que solicitaste."
+msgstr "He capturado la variante que solicitaste."
 
 #. Key:	DF82C5BA4FA233DFB96C8A9B6BBE86E2
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R06.Default__FaleneDefault01_R06_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R06.Default__FaleneDefault01_R06_C.SessionData.Lines(0).Lines
 msgctxt ",DF82C5BA4FA233DFB96C8A9B6BBE86E2"
 msgid "It's from the ancient mythology of the Goddess, which has become the modern day religion."
-msgstr "Es de la antigua mitología de la Diosa, que se ha convertido en la religión moderna."
+msgstr "Es de la mitología antigua de la Diosa, que se ha convertido en la religión moderna."
 
 #. Key:	DFB5CC1D474B332C39BEB6B951A88142
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeDefault01_RL.Default__AmberMaeDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/AmberMae/Default/AmberMaeDefault01_RL.Default__AmberMaeDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",DFB5CC1D474B332C39BEB6B951A88142"
 msgid "What's with your accent?"
-msgstr "¿Qué le pasa a tu acento?"
+msgstr "¿Qué pasa con tu acento?"
 
 #. Key:	DFC4AEBB489C5D9B74E6F79CC91F1DB0
 #. SourceLocation:	/Game/Ranch/Upgrades/MuttHut.Default__MuttHut_C.Upgrade.TypeDisplay
 #: /Game/Ranch/Upgrades/MuttHut.Default__MuttHut_C.Upgrade.TypeDisplay
 msgctxt ",DFC4AEBB489C5D9B74E6F79CC91F1DB0"
 msgid "Nephelym Barn"
-msgstr "Granero de Nephelyms"
+msgstr "Granero de Nephelym"
 
 #. Key:	E01ADC7A41DCC8C65CA87E9C9561359D
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03_R02.Default__FernDefault03_R02_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03_R02.Default__FernDefault03_R02_C.SessionData.Lines(0).Lines
 msgctxt ",E01ADC7A41DCC8C65CA87E9C9561359D"
 msgid "Indeed! Your delicious fluid has done wonders."
-msgstr "¡En efecto! Tu delicioso líquido ha hecho maravillas."
+msgstr "¡En efecto! Tu delicioso fluido ha hecho maravillas."
 
 #. Key:	E043108D41291B6169E3579CE41F44B3
 #. SourceLocation:	/Game/Dialogue/Emissary/SexScenes/EmissaryAngelGroinLove.Default__EmissaryAngelGroinLove_C.SessionData.LinesToFemale(2).LinesToFemale
 #: /Game/Dialogue/Emissary/SexScenes/EmissaryAngelGroinLove.Default__EmissaryAngelGroinLove_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",E043108D41291B6169E3579CE41F44B3"
 msgid "Does my soft golden skin please you @BREEDER_NAME@?"
-msgstr "¿Mi suave piel dorada te agrada @BREEDER_NAME@?"
+msgstr "¿Mi suave piel dorada te complace, @BREEDER_NAME@?"
 
 #. Key:	E04E71634CD5DA9067A43C8F3AE1A4F3
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadAboutDryads.Default__DryadAboutDryads_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Autumn/Default/DryadAboutDryads.Default__DryadAboutDryads_C.SessionData.Lines(1).Lines
 msgctxt ",E04E71634CD5DA9067A43C8F3AE1A4F3"
 msgid "After decades of growth, the fruit will fall off and a dryad will emerge."
-msgstr ""
+msgstr "Después de décadas de crecimiento, el fruto se caerá y surgirá una dríada."
 
 #. Key:	E0699FC749A0DDDF3E385CA8D6F3E80E
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R07.Default__FaleneDefault01_R07_C.SessionData.LinesToMale(1).LinesToMale
@@ -12156,28 +12231,28 @@ msgstr "¡Puedes tener mi leche materna!"
 #: /Game/Dialogue/Monarch/Default/MonarchPrettyButterfly.Default__MonarchPrettyButterfly_C.SessionData.Lines(2).Lines
 msgctxt ",E0C87F904575D628A6EAEFAD7A1DD491"
 msgid "As such, we frequently find ourselves on the receiving end of sex..."
-msgstr ""
+msgstr "Como tal, con frecuencia nos encontramos en el extremo receptor del sexo..."
 
 #. Key:	E0CB0262419C2D4379873799FB2844BC
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadAboutDryads.Default__DryadAboutDryads_C.SessionData.Lines(6).Lines
 #: /Game/Dialogue/Autumn/Default/DryadAboutDryads.Default__DryadAboutDryads_C.SessionData.Lines(6).Lines
 msgctxt ",E0CB0262419C2D4379873799FB2844BC"
 msgid "I guess I do spoil them..."
-msgstr ""
+msgstr "Supongo que las arruino..."
 
 #. Key:	E0E93AA54E36B2C3F876CEBE1F52C2FC
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_Emissary.Default__LeylannaDefault01_Emissary_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Leylanna/Default/LeylannaDefault01_Emissary.Default__LeylannaDefault01_Emissary_C.SessionData.Lines(4).Lines
 msgctxt ",E0E93AA54E36B2C3F876CEBE1F52C2FC"
 msgid "*Sigh* How I wish she would fly over here and sit her golden nethers upon my face... so that I might taste her once more."
-msgstr "*Suspiro* Cómo desearía que volara hasta aquí y sentara sus dorados bajos sobre mi cara... para que pudiera saborearla una vez más."
+msgstr "*Suspira* Cómo desearía que volara hasta aquí y sentara sus dorados bajos sobre mi cara... para que pudiera saborearla una vez más."
 
 #. Key:	E1403BCA4E98EC6272FC2E86F860771C
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToFemale(3).LinesToFemale
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",E1403BCA4E98EC6272FC2E86F860771C"
 msgid "All have been pleasurable and delicious... but oh have I wanted something more..."
-msgstr "Todos han sido placenteros y deliciosos... pero he querido algo más..."
+msgstr "Todos han sido placenteros y deliciosos... pero oh, he querido algo más..."
 
 #. Key:	E1682EC8470332A4284BBB8EEDB147A2
 #. SourceLocation:	/Game/Dialogue/Blossom/Default/BlossomGreeting01.Default__BlossomGreeting01_C.SessionData.Lines(3).Lines
@@ -12191,42 +12266,43 @@ msgstr "..."
 #: /Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon.Default__AmberMaeLockedDungeon_C.SessionData.Lines(1).Lines
 msgctxt ",E17B89624E06BB5038FB7A90A70FFD12"
 msgid "As Hedon's oldest citizen, I remember trying to fit in there ages ago."
-msgstr ""
+msgstr "Como ziudadana de mayoh edah de Hedon, recuerdo habeh intentao encajah allí hase musho tiempo."
 
 #. Key:	E1AA64794D412D85279E1C928CB75EFF
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_RL.Default__FaleneDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_RL.Default__FaleneDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",E1AA64794D412D85279E1C928CB75EFF"
 msgid "What are wild @MONSTER_RACE@?"
-msgstr "¿Qué son los @MONSTER_RACE@ salvajes?"
+msgstr "¿Qué son los @MONSTER_RACE@ silvestres?"
 
 #. Key:	E1E308E24203BE20934F4FBC8BEC61C7
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_YourMusic.Default__RomyDefault01_YourMusic_C.SessionData.LinesToFuta(1).LinesToFuta
 #: /Game/Dialogue/Romy/Default/RomyDefault01_YourMusic.Default__RomyDefault01_YourMusic_C.SessionData.LinesToFuta(1).LinesToFuta
 msgctxt ",E1E308E24203BE20934F4FBC8BEC61C7"
 msgid "With my voluptuous mermaid body, I shall play your dick like an instrument"
-msgstr "Con mi voluptuoso cuerpo de sirena, tocaré tu polla como un instrumento"
+msgstr "Con mi voluptuoso cuerpo de sirena, tocaré tu pene como un instrumento"
 
 #. Key:	E1E5995441F81E5B6E79E8A5481789F0
 #. SourceLocation:	/Game/Dialogue/Mirru/SexScenes/MirruSnatchF.Default__MirruSnatchF_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Mirru/SexScenes/MirruSnatchF.Default__MirruSnatchF_C.SessionData.Lines(1).Lines
 msgctxt ",E1E5995441F81E5B6E79E8A5481789F0"
 msgid "Ahh... ohhhh... yes! Please both of my tentacle heads..."
-msgstr "Ahh... ohhhh... si! Complace mis dos cabezas de tentáculos..."
+msgstr "¡Ahh... ohhhh... sí! Por favor, mis dos cabezales de tentáculo..."
 
 #. Key:	E1FD0C3A455475E0E474A0A50646DBA8
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon.Default__AmberMaeLockedDungeon_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon.Default__AmberMaeLockedDungeon_C.SessionData.Lines(3).Lines
 msgctxt ",E1FD0C3A455475E0E474A0A50646DBA8"
 msgid "Once they built that new temple, the door was sealed... golly 'twas well over 1000 years ago now."
-msgstr ""
+msgstr "Una veh que construyeron ese nuevo templo, la puerta fue sellaa... Caramba, fue hase máh de 1000 añoh."
 
 #. Key:	E20511A746C7BFEF4C46D5A2F2586CD0
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(28 - Value).TraitIcons.HelpText
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(28 - Value).TraitIcons.HelpText
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(28 -
+#: Value).TraitIcons.HelpText
 msgctxt ",E20511A746C7BFEF4C46D5A2F2586CD0"
 msgid "Slick: Inherited slick oily skin."
-msgstr "Resbalosa/o: Heredó una piel oleo resbalosa."
+msgstr "Resbaloso: heredó una piel aceitosa y resbaladiza."
 
 #. Key:	E227A6EF4C9C296BC4394FA1701CA51F
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_RechargeSpiritForm_RL_F.Default__LeylannaDefault01_RechargeSpiritForm_RL_F_C.ResponseData(0).ResponseData.BreederPrompt
@@ -12240,7 +12316,7 @@ msgstr "¡¡Vamos a hacer el amor!!"
 #: /Game/Dialogue/Fesssi/Default/FesssiIdiots.Default__FesssiIdiots_C.SessionData.Lines(6).Lines
 msgctxt ",E255306C4E1CCD9DDB61B0AAC4AFBF04"
 msgid "A titan with plenty of muscle should work, use those breeding skillsssss."
-msgstr ""
+msgstr "Un titán con mucho músculo debería funcionar, usa esas habilidades de crianza."
 
 #. Key:	E264C5AA4DFA58630DD1B5AF551D5C38
 #. SourceLocation:	/Game/Dialogue/Blossom/Default/BlossomGreeting01.Default__BlossomGreeting01_C.SessionData.Lines(1).Lines
@@ -12254,49 +12330,49 @@ msgstr "..."
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R01.Default__CamillaDefault01_R01_C.SessionData.Lines(0).Lines
 msgctxt ",E267B04149B1C5C63B246BB9B347927F"
 msgid "Oh she did, did she? Hmph. Well then. The first thing you need to do is find Cassie and contract her to build enclosures for @MONSTER_RACE@. She should be pretty easy to find - she's the Neko that wears a 'tool belt' and not much else."
-msgstr "Oh, ella lo hizo, ¿verdad? Hmph Bien entonces. Lo primero que debes hacer es encontrar a Cassie y contratarla para construir recintos para @MONSTER_RACE@. Debería ser bastante fácil de encontrar: es la Neko que usa un 'cinturón de herramientas' y no mucho más."
+msgstr "Oh, lo hizo, ¿verdad? Hmph. Bien entonces. Lo primero que debes hacer es encontrar a Cassie y contratarla para que construya recintos para los @MONSTER_RACE@. Debería ser bastante fácil de encontrar: es la neko que usa un 'cinturón de herramientas' y no mucho más."
 
 #. Key:	E27A479A496E7D5504357E85E45466FC
 #. SourceLocation:	/Game/Dialogue/Blossom/Default/BlossomGreeting01.Default__BlossomGreeting01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Blossom/Default/BlossomGreeting01.Default__BlossomGreeting01_C.SessionData.Lines(0).Lines
 msgctxt ",E27A479A496E7D5504357E85E45466FC"
 msgid "Hiss..."
-msgstr "Sssss..."
+msgstr "Sss..."
 
 #. Key:	E28456C04008409976B97DAD9E483D99
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleTittyPony_T.Default__KybeleTittyPony_T_C.SessionData.LinesToFuta(2).LinesToFuta
 #: /Game/Dialogue/Kybele/Default/KybeleTittyPony_T.Default__KybeleTittyPony_T_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",E28456C04008409976B97DAD9E483D99"
 msgid "That should teach you to cross this titty po--I mean mighty centaur warmaiden, again!"
-msgstr ""
+msgstr "Eso debería enseñarte a cruzar esta poni tet-: ¡otra vez, me refiero a la poderosa doncella-guerrera centauro!"
 
 #. Key:	E29F5BAA40F6C8758245C58555D4F73E
 #. SourceLocation:	/Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToFemale(2).LinesToFemale
 #: /Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",E29F5BAA40F6C8758245C58555D4F73E"
 msgid "Ahhhh, your fingers are magical, go deeper! Deeper human, oh yesss."
-msgstr "Ahhhh, tus dedos son mágicos, ¡ve más profundo! Más profundo humana, oh sí."
+msgstr "Ahhhh, tus dedos son mágicos, ¡ve más profundo! Humana más profundo, oh sí."
 
 #. Key:	E2D78DC6488712103CF0A59E6DE95E47
 #. SourceLocation:	/Game/Dialogue/AmberMae/SexScenes/AmberMilkyF.Default__AmberMilkyF_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/AmberMae/SexScenes/AmberMilkyF.Default__AmberMilkyF_C.SessionData.Lines(1).Lines
 msgctxt ",E2D78DC6488712103CF0A59E6DE95E47"
 msgid "Oh yer hand feels so good. Don't stop strok'n me box!"
-msgstr "Oh, tu mano se siente tah bien. No dejeh de acarisiarme la caja!"
+msgstr "Oh, tu mano se siente tan bien. No dejeh de acarisiarme el ehtushe!"
 
 #. Key:	E2F13B714EEE6046C9069A8F6F71DA0B
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMAboutDragons.Default__DMAboutDragons_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMAboutDragons.Default__DMAboutDragons_C.SessionData.Lines(5).Lines
 msgctxt ",E2F13B714EEE6046C9069A8F6F71DA0B"
 msgid "Why I remember when this area was just grasslands and trees!"
-msgstr ""
+msgstr "¡Por qué recuerdo cuando esta zona era solo praderas y árboles!"
 
 #. Key:	E32B21044CA4F23C751CD4AC2F814FC7
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcFixOwnGate.Default__OrcFixOwnGate_C.SessionData.LinesToFuta(4).LinesToFuta
 #: /Game/Dialogue/OrcChief/Default/OrcFixOwnGate.Default__OrcFixOwnGate_C.SessionData.LinesToFuta(4).LinesToFuta
 msgctxt ",E32B21044CA4F23C751CD4AC2F814FC7"
 msgid "You get crushed under muscles and ass until chieftain satisfied!"
-msgstr ""
+msgstr "¡Te aplasto debajo de los músculos y el culo hasta que la cacique esté satisfecha!"
 
 #. Key:	E34457BA4EEA184519C5E4AAD2E0B122
 #. SourceLocation:	/Game/Dialogue/Fern/SexScenes/FernCum_01.Default__FernCum_01_C.SessionData.Lines(7).Lines
@@ -12310,105 +12386,106 @@ msgstr "*Chupa* *Chupa*"
 #: /Game/Dialogue/Kybele/Default/KybeleTaskFulfilled.Default__KybeleTaskFulfilled_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",E3AE7B054DC0BBA83F3A75BBB8565010"
 msgid "I've taken advantage of her fat ass many times, and pumped her full of my seed."
-msgstr ""
+msgstr "Me aproveché de su culo gordo muchas veces, y la llené de mi semilla."
 
 #. Key:	E3E470CD447870D4FC3D96BD5BD10264
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimePlay_RL.Default__MegaSlimePlay_RL_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePlay_RL.Default__MegaSlimePlay_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",E3E470CD447870D4FC3D96BD5BD10264"
 msgid "Whoa... that's more than I bargained for!"
-msgstr ""
+msgstr "Buah... ¡eso es más de lo que esperaba!"
 
 #. Key:	E41A1FB14C3203DC5709BD9DDA4C90B4
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMClimaxPeak.Default__DMClimaxPeak_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMClimaxPeak.Default__DMClimaxPeak_C.SessionData.Lines(1).Lines
 msgctxt ",E41A1FB14C3203DC5709BD9DDA4C90B4"
 msgid "Perhaps we can strike a bargain."
-msgstr ""
+msgstr "Quizás podamos hacer un trato."
 
 #. Key:	E44DC681421F83D23915B6BCE7AF12EF
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeAboutOrb.Default__MegaSlimeAboutOrb_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeAboutOrb.Default__MegaSlimeAboutOrb_C.SessionData.Lines(0).Lines
 msgctxt ",E44DC681421F83D23915B6BCE7AF12EF"
 msgid "I love it... it makes me so happy!"
-msgstr ""
+msgstr "Me encanta... ¡me hace tan feliz!"
 
 #. Key:	E456792841D9433268D3C186837C9B2F
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleTaskFulfilled.Default__KybeleTaskFulfilled_C.SessionData.LinesToFuta(3).LinesToFuta
 #: /Game/Dialogue/Kybele/Default/KybeleTaskFulfilled.Default__KybeleTaskFulfilled_C.SessionData.LinesToFuta(3).LinesToFuta
 msgctxt ",E456792841D9433268D3C186837C9B2F"
 msgid "The perfect toy for such a boring task. You have my thanks."
-msgstr ""
+msgstr "El juguete perfecto para una tarea tan aburrida. Tienes mi agradecimiento."
 
 #. Key:	E45685834D7AE2795D9FA29F5CCF8B18
 #. SourceLocation:	/Game/Dialogue/Mirru/SexScenes/MirruSnatchT.Default__MirruSnatchT_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Mirru/SexScenes/MirruSnatchT.Default__MirruSnatchT_C.SessionData.Lines(1).Lines
 msgctxt ",E45685834D7AE2795D9FA29F5CCF8B18"
 msgid "Ahh... ohhhh... yes!"
-msgstr "Ahh... ohhhh... ¡si!"
+msgstr "¡Ahh... ohhhh... sí!"
 
 #. Key:	E460226A4FF1B186BCA5DE85158B49AF
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03.Default__FernDefault03_C.SessionData.LinesToFemale(2).LinesToFemale
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03.Default__FernDefault03_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",E460226A4FF1B186BCA5DE85158B49AF"
 msgid "I am a growing Alraune, perhaps you have fluids to spare?"
-msgstr "Soy una Mandrágora en crecimiento, ¿quizás tengas fluidos de sobra?"
+msgstr "Soy una alraune en crecimiento, ¿tal vez te sobran fluidos?"
 
 #. Key:	E48F12854CF0D281AA9E52B611BEFF61
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryHadSex01.Default__EmissaryHadSex01_C.SessionData.LinesToMale(2).LinesToMale
 #: /Game/Dialogue/Emissary/Default/EmissaryHadSex01.Default__EmissaryHadSex01_C.SessionData.LinesToMale(2).LinesToMale
 msgctxt ",E48F12854CF0D281AA9E52B611BEFF61"
 msgid "Is that a comforting feeling?"
-msgstr ""
+msgstr "¿Es un sentimiento reconfortante?"
 
 #. Key:	E499F0E4452FBC3AAE82E18BCF77B28B
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryBlessedInquiry01_R01.Default__EmissaryBlessedInquiry01_R01_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryBlessedInquiry01_R01.Default__EmissaryBlessedInquiry01_R01_C.SessionData.Lines(2).Lines
 msgctxt ",E499F0E4452FBC3AAE82E18BCF77B28B"
 msgid "My senses detect your desires @BREEDER_NAME@. You see my exposed body before you, and you wish to please yourself with it."
-msgstr "Mis sentidos detectan tus deseos @BREEDER_NAME@. Ves mi cuerpo expuesto delante de ti y deseas complacerte con él."
+msgstr "Mis sentidos detectan tus deseos, @BREEDER_NAME@. Ves mi cuerpo expuesto delante de ti y deseas complacerte con él."
 
 #. Key:	E4AA6F334E8152CCB55879A1FD73219D
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaFaleneWeek.Default__CamillaFaleneWeek_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaFaleneWeek.Default__CamillaFaleneWeek_C.SessionData.Lines(0).Lines
 msgctxt ",E4AA6F334E8152CCB55879A1FD73219D"
 msgid "Every week she embarks on a \"field study\"."
-msgstr ""
+msgstr "Cada semana se embarca en un \"estudio de campo\"."
 
 #. Key:	E4B026D641AF98C38A86DC827DC789C9
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeHowLong.Default__MegaSlimeHowLong_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeHowLong.Default__MegaSlimeHowLong_C.SessionData.Lines(0).Lines
 msgctxt ",E4B026D641AF98C38A86DC827DC789C9"
 msgid "For nearly 1000 years I have been growing... all alone..."
-msgstr ""
+msgstr "Durante casi 1000 años he estado creciendo... completamente sola..."
 
 #. Key:	E4BB37CF496E2ECB97F60B861C42188F
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeDefault02_RL.Default__BeeDefault02_RL_C.ResponseData(2).ResponseData.BreederPrompt
 #: /Game/Dialogue/QueenBee/Default/BeeDefault02_RL.Default__BeeDefault02_RL_C.ResponseData(2).ResponseData.BreederPrompt
 msgctxt ",E4BB37CF496E2ECB97F60B861C42188F"
 msgid "Tell me about bees."
-msgstr ""
+msgstr "Háblame de las abejas."
 
 #. Key:	E4C07523420122C952973D869A7F228C
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMDefault_RL2.Default__DMDefault_RL2_C.ResponseData(2).ResponseData.BreederPrompt
 #: /Game/Dialogue/DragonMatriarch/Default/DMDefault_RL2.Default__DMDefault_RL2_C.ResponseData(2).ResponseData.BreederPrompt
 msgctxt ",E4C07523420122C952973D869A7F228C"
 msgid "Now that you have so much energy..."
-msgstr ""
+msgstr "Ahora que tienes tanta energía..."
 
 #. Key:	E4D00AF649A1E7AC5659FFA04BB04427
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault02.Default__EmissaryDefault02_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault02.Default__EmissaryDefault02_C.SessionData.Lines(0).Lines
 msgctxt ",E4D00AF649A1E7AC5659FFA04BB04427"
 msgid "Well done @BREEDER_NAME@, thou hast restored my world's link to the Void."
-msgstr ""
+msgstr "Bien hecho @BREEDER_NAME@, has restaurado el vínculo de mi mundo con el Vacío."
 
 #. Key:	E4F530D54D663ADF27773EB024081B52
 #. SourceLocation:	/Game/World/Events/EM_Pearl.EM_Pearl_C:ExecuteUbergraph_EM_Pearl [Script Bytecode]
-#: /Game/World/Events/EM_Pearl.EM_Pearl_C:ExecuteUbergraph_EM_Pearl [Script Bytecode]
+#: /Game/World/Events/EM_Pearl.EM_Pearl_C:ExecuteUbergraph_EM_Pearl [Script
+#: Bytecode]
 msgctxt ",E4F530D54D663ADF27773EB024081B52"
 msgid "Beautiful Pearl acquired."
-msgstr ""
+msgstr "Perla Preciosa adquirida."
 
 #. Key:	E5058E9246E1827F928D6681023A71A0
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(10).LinesToFemale
@@ -12422,35 +12499,35 @@ msgstr "Pero lo que realmente queremos es reproducirnos contigo."
 #: /Game/Dialogue/Fesssi/Default/FesssiHowLong.Default__FesssiHowLong_C.SessionData.Lines(0).Lines
 msgctxt ",E52DB615469C458EDFDE9380BA351713"
 msgid "No idea, a year or two perhaps."
-msgstr ""
+msgstr "Ni idea, quizás un año o dos."
 
 #. Key:	E535E57A4387D4FB6EB39EA5A3988B61
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(17).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(17).Lines
 msgctxt ",E535E57A4387D4FB6EB39EA5A3988B61"
 msgid "Their offspring were restored to strong immortal forms, and the Goddess called all of Her creations the @MONSTER_RACE@."
-msgstr "Sus descendientes fueron restaurados a fuertes formas inmortales, y la Diosa llamó a todas sus creaciones los @MONSTER_RACE@."
+msgstr "Sus descendientes fueron restaurados a fuertes formas inmortales, y la Diosa llamó a todas Sus creaciones los @MONSTER_RACE@."
 
 #. Key:	E5582CD145475FD1FDA1C88BC2821A2A
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleHaveKeystone.Default__KybeleHaveKeystone_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Kybele/Default/KybeleHaveKeystone.Default__KybeleHaveKeystone_C.SessionData.Lines(2).Lines
 msgctxt ",E5582CD145475FD1FDA1C88BC2821A2A"
 msgid "The Dragon Matriarch probably wouldn't mind if I let you BORROW it for awhile."
-msgstr ""
+msgstr "A la Matriarca Dragón probablemente no le importaría si te la dejo PRESTADA por un tiempo."
 
 #. Key:	E594716B40413B6747D21BA87B26EE43
 #. SourceLocation:	/Game/Breeding/Positions/Test4.Default__Test4_C.SessionData.PositionName
 #: /Game/Breeding/Positions/Test4.Default__Test4_C.SessionData.PositionName
 msgctxt ",E594716B40413B6747D21BA87B26EE43"
 msgid "Test4"
-msgstr "Test4"
+msgstr ""
 
 #. Key:	E5B424C34D393C3602C0EA8AF2AB1F9E
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadTaskFulfilled.Default__DryadTaskFulfilled_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Autumn/Default/DryadTaskFulfilled.Default__DryadTaskFulfilled_C.SessionData.Lines(0).Lines
 msgctxt ",E5B424C34D393C3602C0EA8AF2AB1F9E"
 msgid "What a sweet little honey bee."
-msgstr ""
+msgstr "Qué dulce abejita de la miel."
 
 #. Key:	E5B7F2E2469864C41253FC892250ED92
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_YourMusic_Start.Default__RomyDefault01_YourMusic_Start_C.SessionData.Lines(0).Lines
@@ -12464,7 +12541,7 @@ msgstr "¡Si! Canta conmigo humana."
 #: /Game/Dialogue/Mirru/Default/MirruHadSex01.Default__MirruHadSex01_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",E5ED1DF6437395916BD42CBCD355E384"
 msgid "I hope my tentacles were not too much for you... yes they can deliver quite the load."
-msgstr ""
+msgstr "Espero que mis tentáculos no hayan sido demasiado para ti... sí, pueden llevar bastante de la carga."
 
 #. Key:	E5F734734AC1001F041105949672E015
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R04.Default__FaleneDefault01_R04_C.SessionData.Lines(11).Lines
@@ -12478,98 +12555,99 @@ msgstr "Además de los placeres de la reproducción, ¡realmente amamos la vida!
 #: /Game/Dialogue/Leylanna/Default/LeylannaDefault01.Default__LeylannaDefault01_C.SessionData.Lines(2).Lines
 msgctxt ",E60B504F4E0F613CDC4974B7C3F19AC1"
 msgid "Only through our love can you find favor with the Goddess and meet your spirit form."
-msgstr "Solo a través de nuestro amor puedes encontrar el favor de la Diosa y conocer tu forma espiritual."
+msgstr "Solo a través de nuestro amor puedes encontrar el favor de la Diosa y encontrar tu forma espiritual."
 
 #. Key:	E616C96848EB54386E6532BF634CD0EA
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcHaveKeystone.Default__OrcHaveKeystone_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcHaveKeystone.Default__OrcHaveKeystone_C.SessionData.Lines(0).Lines
 msgctxt ",E616C96848EB54386E6532BF634CD0EA"
 msgid "No! *snarl*"
-msgstr ""
+msgstr "¡No! *gruñe*"
 
 #. Key:	E6284AF048B97D804F6434804C0A6D5C
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowTaskFulfilled.Default__WidowTaskFulfilled_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Widow/Default/WidowTaskFulfilled.Default__WidowTaskFulfilled_C.SessionData.Lines(2).Lines
 msgctxt ",E6284AF048B97D804F6434804C0A6D5C"
 msgid "Elves taste just as I dreamed they would... and this little one is all mine."
-msgstr ""
+msgstr "Los elfos saben como soñé que serían... y esta pequeña es toda mía."
 
 #. Key:	E63E125C4A07D646D1BFD48E816B5B37
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryRaiseTraitLvl_Accept.Default__EmissaryRaiseTraitLvl_Accept_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryRaiseTraitLvl_Accept.Default__EmissaryRaiseTraitLvl_Accept_C.SessionData.Lines(0).Lines
 msgctxt ",E63E125C4A07D646D1BFD48E816B5B37"
 msgid "A wise choice human, for the Goddess has further endowed wild @MONSTER_RACE@."
-msgstr "Una sabia elección humana, pues la Diosa ha dotado aún más salvajes @MONSTER_RACE@."
+msgstr "Una sabia elección humana, pues la Diosa ha dotado aún más a @MONSTER_RACE@ silvestres."
 
 #. Key:	E663A2A8494081C671EA74A317740FAD
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(31 - Value).TraitIcons.DisplayName
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(31 - Value).TraitIcons.DisplayName
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(31 -
+#: Value).TraitIcons.DisplayName
 msgctxt ",E663A2A8494081C671EA74A317740FAD"
 msgid "Atypical"
-msgstr "Atípica"
+msgstr "Atípico"
 
 #. Key:	E6729AE74984F181641135921F97D449
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeMoreHoney.Default__BeeMoreHoney_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/QueenBee/Default/BeeMoreHoney.Default__BeeMoreHoney_C.SessionData.Lines(0).Lines
 msgctxt ",E6729AE74984F181641135921F97D449"
 msgid "Ahhh yes... I knew you wouldn't be able to resist."
-msgstr ""
+msgstr "Ahhh, sí... sabía que no serías capaz de resistirte."
 
 #. Key:	E69826E04F46B36F08DF61ADC6BE1350
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchHaveKeystone.Default__MonarchHaveKeystone_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Monarch/Default/MonarchHaveKeystone.Default__MonarchHaveKeystone_C.SessionData.Lines(0).Lines
 msgctxt ",E69826E04F46B36F08DF61ADC6BE1350"
 msgid "You were nice to me... I can part with it."
-msgstr ""
+msgstr "Fuiste amable conmigo... puedo separarme de eso."
 
 #. Key:	E6AE999D442B37DD898ED3B14ADA261A
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R05.Default__FaleneDefault01_R05_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R05.Default__FaleneDefault01_R05_C.SessionData.Lines(2).Lines
 msgctxt ",E6AE999D442B37DD898ED3B14ADA261A"
 msgid "Wild elves aren't as common as other @MONSTER_RACE@, Painted Elves even less so."
-msgstr "Las elfas salvajes no son tan comunes como otros @MONSTER_RACE@, las elfas pintadas aún menos."
+msgstr "Las elfas silvestres no son tan comunes como otros @MONSTER_RACE@, las elfas pintadas aún menos."
 
 #. Key:	E6EFAF84489D0FE3730843AEC3483A12
 #. SourceLocation:	/Game/Ranch/Upgrades/DragonHoard.Default__DragonHoard_C.Upgrade.DisplayName
 #: /Game/Ranch/Upgrades/DragonHoard.Default__DragonHoard_C.Upgrade.DisplayName
 msgctxt ",E6EFAF84489D0FE3730843AEC3483A12"
 msgid "Dragon Hoard"
-msgstr "Tesorero de Dragón"
+msgstr "Tesoro Escondido del Dragón"
 
 #. Key:	E71D6B9A4400127440C060AAD55FB07B
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiWantAss.Default__FesssiWantAss_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiWantAss.Default__FesssiWantAss_C.SessionData.Lines(0).Lines
 msgctxt ",E71D6B9A4400127440C060AAD55FB07B"
 msgid "Hiss! I knew you wanted it. Don't think I haven't noticed you gazing upon my girthy glory."
-msgstr ""
+msgstr "¡Sss! Sabía que lo querías. No creas que no te he visto contemplando mi oronda gloria."
 
 #. Key:	E771BFFB4897C621A00726862D211233
 #. SourceLocation:	/Game/Breeding/Positions/ReverseCowgirl.Default__ReverseCowgirl_C.SessionData.Description
 #: /Game/Breeding/Positions/ReverseCowgirl.Default__ReverseCowgirl_C.SessionData.Description
 msgctxt ",E771BFFB4897C621A00726862D211233"
 msgid "The receiver bounces up and down while facing away from the giver."
-msgstr "El/La receptor/a rebota hacia arriba y hacia abajo mientras mira al lado contrario al dador/a."
+msgstr "La receptora rebota hacia arriba y hacia abajo mientras mira en dirección opuesta al donante."
 
 #. Key:	E785DF8A4F91C040EC352CA7D80C247E
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyHadSex01.Default__RomyHadSex01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Romy/Default/RomyHadSex01.Default__RomyHadSex01_C.SessionData.Lines(1).Lines
 msgctxt ",E785DF8A4F91C040EC352CA7D80C247E"
 msgid "Waves of ecstasy still course through my body."
-msgstr ""
+msgstr "Oleadas de éxtasis todavía recorren mi cuerpo."
 
 #. Key:	E786C6B44314BBD71D79DA9FE5AF0C96
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDungeon.Default__CassieDungeon_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Cassie/Default/CassieDungeon.Default__CassieDungeon_C.SessionData.Lines(3).Lines
 msgctxt ",E786C6B44314BBD71D79DA9FE5AF0C96"
 msgid "Cassie thinks there is a way to open it!"
-msgstr ""
+msgstr "¡Cassie cree que hay una manera de abrirlo!"
 
 #. Key:	E79C52514246BC9F37D1229336510455
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeHadSex01.Default__MegaSlimeHadSex01_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeHadSex01.Default__MegaSlimeHadSex01_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",E79C52514246BC9F37D1229336510455"
 msgid "*Yawn*"
-msgstr ""
+msgstr "*Bosteza*"
 
 #. Key:	E7BA70CA4CDE49CD26EE3A92475B70E2
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(12).Lines
@@ -12583,77 +12661,79 @@ msgstr "Comenzaron a crear formas de vida propias, pero carecían del poder y la
 #: /Game/Dialogue/QueenBee/Default/BeeAboutBees.Default__BeeAboutBees_C.SessionData.Lines(3).Lines
 msgctxt ",E82ABEEB4DFDC274912B3E9EA8ECF8F2"
 msgid "At the end of each day, the worker bees will milk the queen and store the honey in jars and combs."
-msgstr ""
+msgstr "Al final de cada día, las abejas obreras ordeñarán a la reina y almacenarán la miel en tarros y panales."
 
 #. Key:	E82D05B04D7461ACFB177EBE4ED8C772
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.EM_OrcSwitch.Message
 #: /Game/World/Overworld.Overworld:PersistentLevel.EM_OrcSwitch.Message
 msgctxt ",E82D05B04D7461ACFB177EBE4ED8C772"
 msgid "A gate was opened."
-msgstr ""
+msgstr "Se abrió un portón."
 
 #. Key:	E869210B499044B8227AF0B4F982A564
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.CBGate_Cavern.PlaceMessage
 #: /Game/World/Overworld.Overworld:PersistentLevel.CBGate_Cavern.PlaceMessage
 msgctxt ",E869210B499044B8227AF0B4F982A564"
 msgid "Amorous Hallows is now accessible."
-msgstr ""
+msgstr "Las Reliquias Amorosas ahora son accesibles."
 
 #. Key:	E8789C0E4CCC57BB8A98178902DA8110
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(1 - Value).TraitIcons.HelpText
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(1 - Value).TraitIcons.HelpText
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(1 -
+#: Value).TraitIcons.HelpText
 msgctxt ",E8789C0E4CCC57BB8A98178902DA8110"
 msgid "Exotic: Inherited more monster traits."
-msgstr "Exótica/o: Heredó mas rasgos de monstruo."
+msgstr "Exótico: heredó mas rasgos de monstruo."
 
 #. Key:	E884B8E5410C3C8C00BFC3AFDA4097F9
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleDefault01.Default__KybeleDefault01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Kybele/Default/KybeleDefault01.Default__KybeleDefault01_C.SessionData.Lines(0).Lines
 msgctxt ",E884B8E5410C3C8C00BFC3AFDA4097F9"
 msgid "By any means necessary, I will not let you pass human."
-msgstr ""
+msgstr "Por cualquier medio que sea necesario, no dejaré que pases humano."
 
 #. Key:	E887131048CFFB8EF5A2E0A1DA1194FE
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraTaskFulfilled.Default__PetraTaskFulfilled_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Petra/Default/PetraTaskFulfilled.Default__PetraTaskFulfilled_C.SessionData.Lines(2).Lines
 msgctxt ",E887131048CFFB8EF5A2E0A1DA1194FE"
 msgid "I got the keystone for you as promised, take it. Don't be a stranger though!"
-msgstr ""
+msgstr "Tengo la piedra-llave para ti como prometí, tómala. ¡Aunque no seas un extraño!"
 
 #. Key:	E89A6BB74D15111C98632A99F45745CC
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(17 - Value).TraitIcons.DisplayName
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(17 - Value).TraitIcons.DisplayName
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(17 -
+#: Value).TraitIcons.DisplayName
 msgctxt ",E89A6BB74D15111C98632A99F45745CC"
 msgid "Meaty"
-msgstr "Carnosa"
+msgstr "Carnoso"
 
 #. Key:	E89B660E4DCD6EDBFE7FBDB73A354FD0
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01_R02_R01.Default__FernDefault01_R02_R01_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Fern/Default/FernDefault01_R02_R01.Default__FernDefault01_R02_R01_C.SessionData.Lines(2).Lines
 msgctxt ",E89B660E4DCD6EDBFE7FBDB73A354FD0"
 msgid "If mastah let Fern drink mastah's fluids, Fern give shiny. Hiss!"
-msgstr "Si maeztra deja que Helecho beba los fluidos de maeztra, Helecho dar brillante. ¡Ssss!"
+msgstr "Si Mastah deja que Fern beba los fluidos de Mastah, Fern dar brillante. ¡Sss!"
 
 #. Key:	E8E336B64B994547FA9BF2A5CFD5F9EE
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault02.Default__CamillaDefault02_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaDefault02.Default__CamillaDefault02_C.SessionData.Lines(3).Lines
 msgctxt ",E8E336B64B994547FA9BF2A5CFD5F9EE"
 msgid "Yeah... one time she brought a leech in here and it swallowed me whole."
-msgstr ""
+msgstr "Sí... una vez ella trajo una sanguijuela aquí y me tragó entera."
 
 #. Key:	E90C40EC48C37A3A560F8083C83692A7
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMTaskFulfilled.Default__DMTaskFulfilled_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMTaskFulfilled.Default__DMTaskFulfilled_C.SessionData.Lines(2).Lines
 msgctxt ",E90C40EC48C37A3A560F8083C83692A7"
 msgid "Perhaps I should do this from now on instead of wasting days slumbering."
-msgstr ""
+msgstr "Quizás debería hacer esto de ahora en adelante en lugar de perder los días durmiendo."
 
 #. Key:	E91EF4164FCD12832A52B095A8557B4A
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.DragonHoard.ManageActionMessage
 #: /Game/World/Overworld.Overworld:PersistentLevel.DragonHoard.ManageActionMessage
 msgctxt ",E91EF4164FCD12832A52B095A8557B4A"
 msgid "Manage your Dragons"
-msgstr "Gestiona tus Dragones"
+msgstr "Gestiona tus Dragons"
 
 #. Key:	E9306878425673698C22F9AA8CD2A8CC
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(9).LinesToFemale
@@ -12664,7 +12744,8 @@ msgstr "Nos encanta reproducirnos con todos los demás @MONSTER_RACE@."
 
 #. Key:	E95C5DA945F5D8A92099E9892F4615A7
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TravelShrines(1 - Value).TravelShrines.ShrineName
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TravelShrines(1 - Value).TravelShrines.ShrineName
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TravelShrines(1 -
+#: Value).TravelShrines.ShrineName
 msgctxt ",E95C5DA945F5D8A92099E9892F4615A7"
 msgid "Amorous Hallows"
 msgstr "Reliquias Amorosas"
@@ -12674,28 +12755,28 @@ msgstr "Reliquias Amorosas"
 #: /Game/Ranch/Upgrades/RisuHutch.Default__RisuHutch_C.Upgrade.DisplayName
 msgctxt ",E97D557A4CC9B101F2F7E1A43C6C27B9"
 msgid "Risu Hutch"
-msgstr ""
+msgstr "Conejera de Risus"
 
 #. Key:	E999DFEA4E92B84DC1426192191A75AA
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadFatAssLamia.Default__DryadFatAssLamia_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Autumn/Default/DryadFatAssLamia.Default__DryadFatAssLamia_C.SessionData.Lines(3).Lines
 msgctxt ",E999DFEA4E92B84DC1426192191A75AA"
 msgid "As she turned to face me, her massive ass jiggled and settled into place."
-msgstr ""
+msgstr "Cuando se volvió para mirarme, su inmenso culo se sacudió y se colocó en su lugar."
 
 #. Key:	E9A374BB46F94E4B206A549D48B4D6FD
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMNap_RL.Default__DMNap_RL_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/DragonMatriarch/Default/DMNap_RL.Default__DMNap_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",E9A374BB46F94E4B206A549D48B4D6FD"
 msgid "But I must go to Climax Peak."
-msgstr ""
+msgstr "Pero debo ir a la Cumbre del Clímax."
 
 #. Key:	E9AB731F47E3F6759C9BEA90AA3E32CB
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchPrettyButterfly.Default__MonarchPrettyButterfly_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Monarch/Default/MonarchPrettyButterfly.Default__MonarchPrettyButterfly_C.SessionData.Lines(0).Lines
 msgctxt ",E9AB731F47E3F6759C9BEA90AA3E32CB"
 msgid "W-w-whoa easy human... I'm fragile."
-msgstr ""
+msgstr "B-b-buah fácil, humano... soy frágil."
 
 #. Key:	E9B8B1C5455710ECF7299ABDF56BBA47
 #. SourceLocation:	/Game/Characters/Procedural/Variants/Neko/Harvest/NekoHarvest.Default__NekoHarvest_C.Harvest.Description
@@ -12709,56 +12790,56 @@ msgstr "Fluidos corporales de Neko."
 #: /Game/Dialogue/Kybele/Default/KybeleAnyMeans.Default__KybeleAnyMeans_C.SessionData.LinesToFemale(4).LinesToFemale
 msgctxt ",EA2B04154B0261A512D72EBBD877304B"
 msgid "Well... my back legs. You can't miss it, nor handle it for that matter."
-msgstr ""
+msgstr "Bueno... mis patas traseras. No te lo puedes perder, ni tampoco puedes manejarlo."
 
 #. Key:	EA5E734B4238AB7601156A936E5E99DF
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchStartShySex.Default__MonarchStartShySex_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/Monarch/Default/MonarchStartShySex.Default__MonarchStartShySex_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",EA5E734B4238AB7601156A936E5E99DF"
 msgid "Oh... m-m-my... uh."
-msgstr ""
+msgstr "Oh... m-m-mi... eh."
 
 #. Key:	EA5FEF4E48F8E04291135AA9D42A6CE4
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_Formuria.Default__MirruDefault01_Formuria_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_Formuria.Default__MirruDefault01_Formuria_C.SessionData.Lines(2).Lines
 msgctxt ",EA5FEF4E48F8E04291135AA9D42A6CE4"
 msgid "It is I, Mirru, who will be next in line to become queen, for all of my siblings are of low birth."
-msgstr "Soy yo, Mirru, quien será la próxima en convertirse en reina, ya que todos mis hermanos son de bajo nacimiento."
+msgstr "Soy yo, Mirru, la que será la siguiente en la línea para convertirse en reina, ya que todos mis hermanos son de bajo nacimiento."
 
 #. Key:	EAB6EBE14AAB0E16FF7079998969A562
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleHadSex01.Default__KybeleHadSex01_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/Kybele/Default/KybeleHadSex01.Default__KybeleHadSex01_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",EAB6EBE14AAB0E16FF7079998969A562"
 msgid "What a massive release, it's been far too many days."
-msgstr ""
+msgstr "Qué descarga inmensa, han pasado demasiados días."
 
 #. Key:	EAC5867744C78DCB09760896409A7850
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcTribeSucks.Default__OrcTribeSucks_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcTribeSucks.Default__OrcTribeSucks_C.SessionData.Lines(5).Lines
 msgctxt ",EAC5867744C78DCB09760896409A7850"
 msgid "Take my tribe sisters back to Homestead... breed them well!"
-msgstr ""
+msgstr "Llevar mis hermanas de tribu de vuelta a Granja... ¡críalas bien!"
 
 #. Key:	EAE306A64EE7F2719CB1719962D3F107
 #. SourceLocation:	/Game/Ranch/Upgrades/DemonPool.Default__DemonPool_C.Upgrade.Description
 #: /Game/Ranch/Upgrades/DemonPool.Default__DemonPool_C.Upgrade.Description
 msgctxt ",EAE306A64EE7F2719CB1719962D3F107"
 msgid "This allows you to catch and store all variants of Demon."
-msgstr "Esto te permite atrapar y almacenar todas las variantes de Demonio."
+msgstr "Esto te permite capturar y almacenar todas las variantes de Demonios."
 
 #. Key:	EB1406C440D3EF18AF3C78B296137764
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.RisuHutch.ManageActionMessage
 #: /Game/World/Overworld.Overworld:PersistentLevel.RisuHutch.ManageActionMessage
 msgctxt ",EB1406C440D3EF18AF3C78B296137764"
 msgid "Manage your Risu"
-msgstr ""
+msgstr "Gestiona tus Risus"
 
 #. Key:	EB2D583D443FA7DB15278C95780CBC37
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDefault01_Meow.Default__CassieDefault01_Meow_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/Cassie/Default/CassieDefault01_Meow.Default__CassieDefault01_Meow_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",EB2D583D443FA7DB15278C95780CBC37"
 msgid "Meow! Hehehe don't get me started!"
-msgstr "¡Miau! Jejeje ¡no me hagas empezar!"
+msgstr "¡Miau! ¡Jejeje, no me hagas empezar!"
 
 #. Key:	EB54AD484FADC0D1DA6A95B5B6780E36
 #. SourceLocation:	/Game/Breeding/Positions/Test1.Default__Test1_C.SessionData.PositionName
@@ -12772,7 +12853,7 @@ msgstr "Sorpresa"
 #: /Game/Dialogue/Widow/Default/WidowScary.Default__WidowScary_C.SessionData.Lines(5).Lines
 msgctxt ",EB6E4330432136A859E45AAF024E2DC0"
 msgid "And perhaps to suck my companion dry when the hunger arises... but I always strive to make it feel good."
-msgstr ""
+msgstr "Y tal vez para chupar a mi compañera hasta secarla cuando surja el hambre... pero siempre me esfuerzo por hacer que se sienta bien."
 
 #. Key:	EB717BA44A439427B1DE6CA60FA650A2
 #. SourceLocation:	/Game/Dialogue/Mirru/SexScenes/MirruKrakVag.Default__MirruKrakVag_C.SessionData.Lines(2).Lines
@@ -12786,7 +12867,7 @@ msgstr "¿Te gusta mi vagina gruesa y profunda? Ahh... penétrala con todas tus 
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R02.Default__CamillaDefault01_R02_C.SessionData.Lines(5).Lines
 msgctxt ",EB8281BE4BDC307B5C0B208F2E5CDCED"
 msgid "Titans like the mountain caves of the Climax Peak."
-msgstr "A las titanes les gustan las cuevas de montaña del Pico de Climax."
+msgstr "A los titanes les gustan las cuevas de montaña de la Cumbre del Clímax."
 
 #. Key:	EB9CEE7C492834A71E0684923E36AB86
 #. SourceLocation:	/Game/Dialogue/Fern/SexScenes/FernCum_01.Default__FernCum_01_C.SessionData.Lines(5).Lines
@@ -12804,52 +12885,53 @@ msgstr "Ah, bueno, podría concederte acceso, pero... hay algo que quiero a camb
 
 #. Key:	EC01A5624439E2DDB75614A1656451DD
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(26 - Value).TraitIcons.HelpText
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(26 - Value).TraitIcons.HelpText
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(26 -
+#: Value).TraitIcons.HelpText
 msgctxt ",EC01A5624439E2DDB75614A1656451DD"
 msgid "Hung: Inherited a larger dick."
-msgstr "Polluda/o: Heredó una polla más grande."
+msgstr "Polludo: heredó un pene más grande."
 
 #. Key:	EC505AF645F08A603F4BDF98F4F09BAC
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadDefault01.Default__DryadDefault01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Autumn/Default/DryadDefault01.Default__DryadDefault01_C.SessionData.Lines(0).Lines
 msgctxt ",EC505AF645F08A603F4BDF98F4F09BAC"
 msgid "So many bosom cherries to make, the cows are always ready to eat them."
-msgstr ""
+msgstr "Tantas cerezas de seno para hacer, las vacas siempre están listas para comerlas."
 
 #. Key:	EC6BFF394580DB5B2B148096C2994439
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_RL_M.Default__FernDefault02_RL_M_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02_RL_M.Default__FernDefault02_RL_M_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",EC6BFF394580DB5B2B148096C2994439"
 msgid "Why did you call me master?"
-msgstr "¿Por qué me llamaste maestra?"
+msgstr "¿Por qué me llamaste, Master?"
 
 #. Key:	EC7903464D18A00937FD1CB94B22B7B8
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMDefault_RL.Default__DMDefault_RL_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/DragonMatriarch/Default/DMDefault_RL.Default__DMDefault_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",EC7903464D18A00937FD1CB94B22B7B8"
 msgid "Lame. I thought the Dragon Matriarch would be better!"
-msgstr ""
+msgstr "Aburrida. ¡Pensé que la Matriarca Dragón sería mejor!"
 
 #. Key:	EC7D97C640A2B4A5E3BFACACD27F84F8
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDungeon2.Default__CassieDungeon2_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Cassie/Default/CassieDungeon2.Default__CassieDungeon2_C.SessionData.Lines(2).Lines
 msgctxt ",EC7D97C640A2B4A5E3BFACACD27F84F8"
 msgid "It was locked for many years."
-msgstr ""
+msgstr "Estuvo bloqueado durante muchos años."
 
 #. Key:	EC82D74441832F387397BE94F0621215
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeGreeting02.Default__BeeGreeting02_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/QueenBee/Default/BeeGreeting02.Default__BeeGreeting02_C.SessionData.Lines(0).Lines
 msgctxt ",EC82D74441832F387397BE94F0621215"
 msgid "Kneel before your queen... ahhh.... ohhh..."
-msgstr ""
+msgstr "Arrodíllate ante tu reina... ahhh... ohhh..."
 
 #. Key:	EC9757E141CD427BCC7326B974A16B82
 #. SourceLocation:	/Game/Dialogue/Neela/SexScenes/NeelaSnakeCuddleF.Default__NeelaSnakeCuddleF_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Neela/SexScenes/NeelaSnakeCuddleF.Default__NeelaSnakeCuddleF_C.SessionData.Lines(4).Lines
 msgctxt ",EC9757E141CD427BCC7326B974A16B82"
 msgid "Oh human, your thighs are soft... ahhh..."
-msgstr "Oh humana, tus muslos son suaves... ahhh..."
+msgstr "Oh, humano, tus muslos son suaves... ahhh..."
 
 #. Key:	ECA6FC524716FE3EA1D0A181491FCFC8
 #. SourceLocation:	/Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToFemale(0).LinesToFemale
@@ -12863,28 +12945,28 @@ msgstr "Siente mi lengua mientras se desliza entre tus labios, humana. Ohhh..."
 #: /Game/UI/TaskDescriptions.TaskDescriptions.TextEntries(0).TextEntries
 msgctxt ",ECE1ACB84FCF8F8A06C64385D7909E98"
 msgid "We need another wild one to extract fluids from! You may think such a thing would be easy, but Falene and I go through... many fluids. Don't ask! Besides, I'm too small to do any real fluid harvesting remember?! That's what big human breeders are for. AND YES IN CASE YOU WERE WONDERING, I PINNED THIS ON THE BOARD MYSELF... using a box. I don't need any help from tall folk!!  -Camilla"
-msgstr ""
+msgstr "¡Necesitamos otro silvestre del que extraer fluidos! Puedes pensar que tal cosa sería fácil, pero Falene y yo pasamos por... muchos fluidos. ¡No preguntes! Además, soy demasiado pequeña para hacer una verdadera recolección de fluidos, ¿recuerdas? Para eso están los grandes criadores humanos. Y SÍ, EN CASO DE QUE TE ESTÁS PREGUNTANDO, YO MISMA PEGÉ ESTO EN EL TABLERO... usando una caja. ¡¡No necesito ayuda de gente alta!! -Camilla"
 
 #. Key:	ECE912E146D6A887F2F7C39091185320
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadHaveKeystone.Default__DryadHaveKeystone_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Autumn/Default/DryadHaveKeystone.Default__DryadHaveKeystone_C.SessionData.Lines(0).Lines
 msgctxt ",ECE912E146D6A887F2F7C39091185320"
 msgid "Oh that old thing stuck in my roots?"
-msgstr ""
+msgstr "¿Oh, esa cosa vieja clavada en mis raíces?"
 
 #. Key:	ECF633104DBC2948B9EE9FB8C499DCA5
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcHadSex01.Default__OrcHadSex01_C.SessionData.LinesToFuta(1).LinesToFuta
 #: /Game/Dialogue/OrcChief/Default/OrcHadSex01.Default__OrcHadSex01_C.SessionData.LinesToFuta(1).LinesToFuta
 msgctxt ",ECF633104DBC2948B9EE9FB8C499DCA5"
 msgid "Human feel good. Lucky chieftain let you squirt weak seed in her."
-msgstr ""
+msgstr "El humano se siente bien. La cacique afortunada te permite rociar semillas débiles en ella."
 
 #. Key:	ED31F33C43B35F55174029803CC7A311
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernGreeting03.Default__FernGreeting03_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/Fern/DefaultP3/FernGreeting03.Default__FernGreeting03_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",ED31F33C43B35F55174029803CC7A311"
 msgid "I am a full grown Alraune now!"
-msgstr "¡Ahora soy una Mandrágora adulta!"
+msgstr "¡Ahora soy una alraune completamente desarrollada!"
 
 #. Key:	ED550A2148D3A000A85A3888AF7B31B1
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_AboutLamias.Default__NeelaDefault01_AboutLamias_C.SessionData.Lines(3).Lines
@@ -12898,35 +12980,35 @@ msgstr "..."
 #: /Game/Dialogue/Parvati/Default/ParvatiGreeting01.Default__ParvatiGreeting01_C.SessionData.LinesToFemale(8).LinesToFemale
 msgctxt ",EDA3DF9D4C1774AA8DDFC69C0EFD0035"
 msgid "Favor from the Goddess will you require."
-msgstr "Favor de la Diosa tu persona requerirá."
+msgstr "Favor de la Diosa tu requerirás."
 
 #. Key:	EDB37C414F34D2DB942D46BC07E82687
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraGetKeystone.Default__PetraGetKeystone_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Petra/Default/PetraGetKeystone.Default__PetraGetKeystone_C.SessionData.Lines(3).Lines
 msgctxt ",EDB37C414F34D2DB942D46BC07E82687"
 msgid "I've been sitting here every day waiting for whatever that is to visit me."
-msgstr ""
+msgstr "He estado sentada aquí todos los días esperando lo que sea que me visite."
 
 #. Key:	EDC3705644F1B11509FCD4A1CD88991D
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault02.Default__FaleneDefault02_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault02.Default__FaleneDefault02_C.SessionData.Lines(0).Lines
 msgctxt ",EDC3705644F1B11509FCD4A1CD88991D"
 msgid "This is the Alchemist Guild! YAY!!!"
-msgstr ""
+msgstr "¡Este es el Gremio de Alquimistas! ¡¡¡HURRA!!!"
 
 #. Key:	EDFEC0864067F06F1A5A1C9F3501DE00
 #. SourceLocation:	/Game/Dialogue/Fern/SexScenes/FernCum_01.Default__FernCum_01_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Fern/SexScenes/FernCum_01.Default__FernCum_01_C.SessionData.Lines(2).Lines
 msgctxt ",EDFEC0864067F06F1A5A1C9F3501DE00"
 msgid "Fern mouth too... ahhh... small."
-msgstr "Boca de Helecho muy... ahhh... pequeña."
+msgstr "Boca de Fern demasiado... ahhh... pequeña."
 
 #. Key:	EDFF0F6F4588A69F5A1D5EA8DB0A78AA
 #. SourceLocation:	/Game/UI/TaskDescriptions.TaskDescriptions.TextEntries(10).TextEntries
 #: /Game/UI/TaskDescriptions.TaskDescriptions.TextEntries(10).TextEntries
 msgctxt ",EDFF0F6F4588A69F5A1D5EA8DB0A78AA"
 msgid "Falene and I are attempting to extract the magical essense from wild Nephelym, so that we might better understand what makes some of us blessed. We can't remember being born, so this is an ancient puzzle that you can help with. Whatever you can make, we can take!  -Camilla"
-msgstr ""
+msgstr "Falene y yo estamos intentando extraer la esencia mágica de los Nephelym silvestres, para que podamos entender mejor qué nos hace bendecidos a algunos de nosotros. No podemos recordar haber nacido, así que este es un antiguo rompecabezas en el que puedes ayudar. ¡Todo lo que puedas hacer, nosotras lo podemos aprovechar! -Camilla"
 
 #. Key:	EE11DC6C4F3DE85807004E93DB73A0B2
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToFuta(5).LinesToFuta
@@ -12947,63 +13029,64 @@ msgstr "¿Quién es la Iluminada?"
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02.Default__FernDefault02_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",EE8FDFD64822DC7BFDD6C9A70419163D"
 msgid "Oh Master, you have fed me well."
-msgstr "Oh Maestra, me has alimentado bien."
+msgstr "Oh, Master, me has alimentado bien."
 
 #. Key:	EEBA2B7C475E9710DEB122887C14BEE9
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(8 - Value).TraitIcons.HelpText
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(8 - Value).TraitIcons.HelpText
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(8 -
+#: Value).TraitIcons.HelpText
 msgctxt ",EEBA2B7C475E9710DEB122887C14BEE9"
 msgid "Charmer: Allure raises XP from breeding as a percentage."
-msgstr "Encantador/a: Seducción aumenta la EXP de la reproducción como un porcentaje."
+msgstr "Encantador: el Atractivo aumenta la EXP de la reproducción como un porcentaje."
 
 #. Key:	EF1AB21445DDAE7CA5453BB814817514
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryHadSex01.Default__EmissaryHadSex01_C.SessionData.LinesToFemale(3).LinesToFemale
 #: /Game/Dialogue/Emissary/Default/EmissaryHadSex01.Default__EmissaryHadSex01_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",EF1AB21445DDAE7CA5453BB814817514"
 msgid "It has been thousands of years since this holy vessel was touched in such a way, and it felt nothing."
-msgstr ""
+msgstr "Han pasado miles de años desde que este recipiente sagrado fue tocado de esa manera, y no sintió nada."
 
 #. Key:	EF23DE3948A14D6E8E26C397EFF2D243
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMNapSomewhereElse.Default__DMNapSomewhereElse_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMNapSomewhereElse.Default__DMNapSomewhereElse_C.SessionData.Lines(3).Lines
 msgctxt ",EF23DE3948A14D6E8E26C397EFF2D243"
 msgid "You're just jealous and want it for yourself!"
-msgstr ""
+msgstr "¡Estás celoso y lo quieres para ti!"
 
 #. Key:	EF7904964EA5BDAA8F91D29F54021C40
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowSpiders.Default__WidowSpiders_C.SessionData.Lines(8).Lines
 #: /Game/Dialogue/Widow/Default/WidowSpiders.Default__WidowSpiders_C.SessionData.Lines(8).Lines
 msgctxt ",EF7904964EA5BDAA8F91D29F54021C40"
 msgid "Oh don't give me that look, we love our catches and never harm them."
-msgstr ""
+msgstr "Oh, no me mires así, amamos nuestras capturas y nunca las lastimamos."
 
 #. Key:	EF902B4F424735BE83B622865F58AED8
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadStartMakeCherry.Default__DryadStartMakeCherry_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Autumn/Default/DryadStartMakeCherry.Default__DryadStartMakeCherry_C.SessionData.Lines(0).Lines
 msgctxt ",EF902B4F424735BE83B622865F58AED8"
 msgid "Climb up here with me..."
-msgstr ""
+msgstr "Sube trepando aquí conmigo..."
 
 #. Key:	EFEE39A441DF6F79110B608104881B11
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeAboutOrb.Default__MegaSlimeAboutOrb_C.SessionData.Lines(7).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeAboutOrb.Default__MegaSlimeAboutOrb_C.SessionData.Lines(7).Lines
 msgctxt ",EFEE39A441DF6F79110B608104881B11"
 msgid "But I love it down here, it's perfect for a slime... if only I had more company."
-msgstr ""
+msgstr "Pero me encanta estar aquí, es perfecto para una limo... si tan solo tuviera más compañía."
 
 #. Key:	EFF175ED431E22A2893E90913974E354
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchTaskFulfilled.Default__MonarchTaskFulfilled_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Monarch/Default/MonarchTaskFulfilled.Default__MonarchTaskFulfilled_C.SessionData.Lines(0).Lines
 msgctxt ",EFF175ED431E22A2893E90913974E354"
 msgid "Whoa... this Foxen is f-f-fast!"
-msgstr ""
+msgstr "Buah... ¡este foxen es r-r-rápido!"
 
 #. Key:	EFFEEA9A4CC82094FD20CABC0AF432BB
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMDefault_RL5_T.Default__DMDefault_RL5_T_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/DragonMatriarch/Default/DMDefault_RL5_T.Default__DMDefault_RL5_T_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",EFFEEA9A4CC82094FD20CABC0AF432BB"
 msgid "Eeek... big genitals!"
-msgstr ""
+msgstr "¡Eeek... genitales grandes!"
 
 #. Key:	F010E1B74164FC7DBBA07E8F73124FEF
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_RL.Default__EmissaryDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
@@ -13017,14 +13100,14 @@ msgstr "¿Qué hace la Diosa con mis @MONSTER_RACE@?"
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R04.Default__FaleneDefault01_R04_C.SessionData.Lines(10).Lines
 msgctxt ",F018F7BF46C60F9708C3828E74D271BD"
 msgid "We have a hard time setting our desires aside, but we manage somehow."
-msgstr "Tenemos dificultades para dejar a un lado nuestros deseos, pero nos las arreglamos de alguna manera."
+msgstr "Nos cuesta dejar de lado nuestros deseos, pero de alguna manera nos las arreglamos."
 
 #. Key:	F02F8B45410D1DAB710358A53AE119D7
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiIdiots.Default__FesssiIdiots_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiIdiots.Default__FesssiIdiots_C.SessionData.Lines(2).Lines
 msgctxt ",F02F8B45410D1DAB710358A53AE119D7"
 msgid "Hiss... hmm... perhaps a centaur. No no, she will want money."
-msgstr ""
+msgstr "Sss... hmm... quizás un centauro. No, no, querrá dinero."
 
 #. Key:	F042509A4B58E96016C6A38E05689C66
 #. SourceLocation:	/Game/Dialogue/Fern/SexScenes/FernMilk_01.Default__FernMilk_01_C.SessionData.Lines(1).Lines
@@ -13038,14 +13121,14 @@ msgstr "*Chupa* *Lame*"
 #: /Game/Dialogue/Autumn/Default/DryadBossomCherries.Default__DryadBossomCherries_C.SessionData.Lines(4).Lines
 msgctxt ",F04A18AC479B4181D244928A4D159C06"
 msgid "Most of the time they fall, and then immediately sleep from over exertion."
-msgstr ""
+msgstr "La mayoría de las veces se caen y luego duermen inmediatamente debido al esfuerzo excesivo."
 
 #. Key:	F05FD1324ABB81C7141ED7A41A996723
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R02.Default__CamillaDefault01_R02_C.SessionData.Lines(7).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R02.Default__CamillaDefault01_R02_C.SessionData.Lines(7).Lines
 msgctxt ",F05FD1324ABB81C7141ED7A41A996723"
 msgid "Last but by no means least, you can find the Seraphim in their temporary home Esoteric Glade."
-msgstr "Por último, pero no menos importante, puedes encontrar a las Serafines en su hogar temporal, el Claro Esotérico."
+msgstr "Por último, pero no menos importante, puedes encontrar a las serafines en su hogar temporal, el Claro Esotérico."
 
 #. Key:	F06D080B472FAC8F39770EB5B3818956
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(15).Lines
@@ -13059,28 +13142,28 @@ msgstr "Indignada, la Diosa Misma descendió y maldijo a los demonios por sus pe
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(14).LinesToMale
 msgctxt ",F091EDAA4504CD138BB740BD4D4EBCB6"
 msgid "I'm getting wetter by the second..."
-msgstr "Me estoy humedeciendo más a cada segundo..."
+msgstr "Me estoy mojando más a cada segundo..."
 
 #. Key:	F0A3AEEB4B43B9230E0996961D788CD4
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMGreeting01.Default__DMGreeting01_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMGreeting01.Default__DMGreeting01_C.SessionData.Lines(4).Lines
 msgctxt ",F0A3AEEB4B43B9230E0996961D788CD4"
 msgid "I am the Dragon Matriarch of Virgin Breaks, and you have awoken me from my slumber."
-msgstr ""
+msgstr "Soy la Matriarca Dragón de Rupturas Vírgenes, y me has despertado de mi letargo."
 
 #. Key:	F0AE51CA47FD221A60043B81E2DB05FB
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaHadSex01.Default__CamillaHadSex01_C.SessionData.LinesToFuta(2).LinesToFuta
 #: /Game/Dialogue/Camilla/Default/CamillaHadSex01.Default__CamillaHadSex01_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",F0AE51CA47FD221A60043B81E2DB05FB"
 msgid "Ohhh but I did!"
-msgstr ""
+msgstr "¡Ohhh, pero lo hice!"
 
 #. Key:	F0B9252A42792A03062E66B1D8354922
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchHaveKeystone.Default__MonarchHaveKeystone_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Monarch/Default/MonarchHaveKeystone.Default__MonarchHaveKeystone_C.SessionData.Lines(5).Lines
 msgctxt ",F0B9252A42792A03062E66B1D8354922"
 msgid "Can you please breed me a swift helper?"
-msgstr ""
+msgstr "¿Podrías criarme un ayudante rápido?"
 
 #. Key:	F12F82174560F4F28E10D3A06B282D0A
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R02.Default__CamillaDefault01_R02_C.SessionData.Lines(0).Lines
@@ -13094,7 +13177,7 @@ msgstr "Se pueden encontrar diferentes @MONSTER_RACE@ en varios lugares, pero ge
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R07.Default__CamillaDefault01_R07_C.SessionData.LinesToMale(0).LinesToMale
 msgctxt ",F13E7CAC4E86FD0C4B9F639D0F536883"
 msgid "Don't waste your delicious body fluid on me. Just wait for Falene to come back, or go suck on Amber's tits."
-msgstr "No desperdicies tu delicioso líquido corporal en mí. Solo espera a que Falene regrese, o ve a chupar las tetas de Amber."
+msgstr "No desperdicies tu delicioso fluido corporal en mí. Solo espera a que vuelva Falene o ve a chupar las tetas de Amber."
 
 #. Key:	F15CA5AC442824FB00747A8771A80403
 #. SourceLocation:	/Game/Dialogue/Mirru/SexScenes/MirruKrakVag.Default__MirruKrakVag_C.SessionData.Lines(4).Lines
@@ -13108,98 +13191,99 @@ msgstr "Sí, ohh... dame toda tu semilla. Ahhhhh..."
 #: /Game/Dialogue/Monarch/Default/MonarchQueen.Default__MonarchQueen_C.SessionData.Lines(4).Lines
 msgctxt ",F177E2D543CD7E7EEE8D7D8675341E30"
 msgid "I miss my little sister! She's s-s-stil a caterpillar."
-msgstr ""
+msgstr "¡Extraño a mi hermana pequeña! Ella s-s-sigue siendo una oruga."
 
 #. Key:	F1C0D9374BF1D4EC73102080D4855555
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadFlowers.Default__DryadFlowers_C.SessionData.Lines(7).Lines
 #: /Game/Dialogue/Autumn/Default/DryadFlowers.Default__DryadFlowers_C.SessionData.Lines(7).Lines
 msgctxt ",F1C0D9374BF1D4EC73102080D4855555"
 msgid "Ejaculum-phallis is the product of dragon semen. If you bring me a large amount of it, I can use it to heal the Hivelands."
-msgstr ""
+msgstr "Ejaculum-phallis es el producto del semen de dragón. Si me traes una gran cantidad de el, puedo usarlo para curar las Tierras-Colmena."
 
 #. Key:	F1D3A2E044E22D62A15FD2A3C291C751
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(6 - Value).TraitIcons.HelpText
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(6 - Value).TraitIcons.HelpText
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(6 -
+#: Value).TraitIcons.HelpText
 msgctxt ",F1D3A2E044E22D62A15FD2A3C291C751"
 msgid "Small: Roughly 5ft in height."
-msgstr "Pequeña: Aproximadamente 1,5m de altura."
+msgstr "Pequeño: aproximadamente 5 pies (1,5 m) de altura."
 
 #. Key:	F1DF0EFD4196365D249B2EBDA93F7F85
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMGreeting01.Default__DMGreeting01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMGreeting01.Default__DMGreeting01_C.SessionData.Lines(0).Lines
 msgctxt ",F1DF0EFD4196365D249B2EBDA93F7F85"
 msgid "*Yawn*"
-msgstr ""
+msgstr "*Bosteza*"
 
 #. Key:	F1E5410345C530DA657424BD124E30D9
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernHadSex03.Default__FernHadSex03_C.SessionData.LinesToFemale(2).LinesToFemale
 #: /Game/Dialogue/Fern/DefaultP3/FernHadSex03.Default__FernHadSex03_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",F1E5410345C530DA657424BD124E30D9"
 msgid "You squirted a ton in here, how fun!"
-msgstr ""
+msgstr "Chorreaste una tonelada aquí, ¡qué divertido!"
 
 #. Key:	F1EF1BEA4E4AF008C65539ADC6740F61
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01_RL_M.Default__FernDefault01_RL_M_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/Fern/Default/FernDefault01_RL_M.Default__FernDefault01_RL_M_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",F1EF1BEA4E4AF008C65539ADC6740F61"
 msgid "Why did you call me master?"
-msgstr "¿Por qué me has llamado maestra?"
+msgstr "¿Por qué me llamaste, Master?"
 
 #. Key:	F20D52F44B97970311709CBA65ACF998
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleCentaur.Default__KybeleCentaur_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Kybele/Default/KybeleCentaur.Default__KybeleCentaur_C.SessionData.Lines(0).Lines
 msgctxt ",F20D52F44B97970311709CBA65ACF998"
 msgid "The feared centaur warmaiden Kybele!"
-msgstr ""
+msgstr "¡La temida doncella de guerra centauro Kybele!"
 
 #. Key:	F20F724C47A982D41C8EE29F4756992A
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_RL.Default__FaleneDefault01_RL_C.ResponseData(4).ResponseData.BreederPrompt
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_RL.Default__FaleneDefault01_RL_C.ResponseData(4).ResponseData.BreederPrompt
 msgctxt ",F20F724C47A982D41C8EE29F4756992A"
 msgid "So @MONSTER_RACE@ are really horny..."
-msgstr "Entonces @MONSTER_RACE@ son realmente cachondas..."
+msgstr "Entonces los @MONSTER_RACE@ son realmente cachondos..."
 
 #. Key:	F2106FBD47C33358DD8CBE9C4F4ABE40
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeHadSex01.Default__AmberMaeHadSex01_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/AmberMae/Default/AmberMaeHadSex01.Default__AmberMaeHadSex01_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",F2106FBD47C33358DD8CBE9C4F4ABE40"
 msgid "Ahhh... I sure do appreciate tak'n yer time to please this old milkmaid."
-msgstr ""
+msgstr "Ahhh... Rearmente apresio tomahte tu tiempo para complaseh a esta vieja leshera."
 
 #. Key:	F21C5AFA463E6FCE44980EAAEE23498C
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchDefault01_RL.Default__MonarchDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/Monarch/Default/MonarchDefault01_RL.Default__MonarchDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",F21C5AFA463E6FCE44980EAAEE23498C"
 msgid "Pretty butterfly!"
-msgstr ""
+msgstr "¡Mariposa linda!"
 
 #. Key:	F267FA90451165F036048A9D768C4718
 #. SourceLocation:	/Game/Dialogue/Fern/SexScenes/FernCum_01.Default__FernCum_01_C.SessionData.Lines(8).Lines
 #: /Game/Dialogue/Fern/SexScenes/FernCum_01.Default__FernCum_01_C.SessionData.Lines(8).Lines
 msgctxt ",F267FA90451165F036048A9D768C4718"
 msgid "Please give Fern all drops. Fern grow faster with more drops... no more drops for purple elf."
-msgstr "Por favor, dale a Helecho todas las gotas. Helecho crece más rápido con más gotas ... no más gotas para la elfa púrpura."
+msgstr "Por favor, dale a Fern todas las gotas. Fern crece más rápido con más gotas... no más gotas para la elfa púrpura."
 
 #. Key:	F2F1647F46528F5AE94959AFFBE62500
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcGreeting01.Default__OrcGreeting01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcGreeting01.Default__OrcGreeting01_C.SessionData.Lines(0).Lines
 msgctxt ",F2F1647F46528F5AE94959AFFBE62500"
 msgid "Human! *snarl*"
-msgstr ""
+msgstr "¡Humano! *gruñe*"
 
 #. Key:	F37DF7694328A3895D54B3BC4DB0147D
 #. SourceLocation:	/Game/Dialogue/Blossom/Default/BlossomDefault01_R03.Default__BlossomDefault01_R03_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Blossom/Default/BlossomDefault01_R03.Default__BlossomDefault01_R03_C.SessionData.Lines(0).Lines
 msgctxt ",F37DF7694328A3895D54B3BC4DB0147D"
 msgid "Blossom help mastah! Blossom harvest fluidssss for you!"
-msgstr "¡Flor ayuda maeztra! ¡Flor cosecha fluidossss para usted!"
+msgstr "¡Blossom ayuda Mastah! ¡Blossom cosecha fluidossss para ti!"
 
 #. Key:	F39F0EAF49B80BDC208978900604CC74
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R03.Default__FaleneDefault01_R03_C.SessionData.Lines(10).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R03.Default__FaleneDefault01_R03_C.SessionData.Lines(10).Lines
 msgctxt ",F39F0EAF49B80BDC208978900604CC74"
 msgid "But be warned, wild @MONSTER_RACE@ have no control over their desires and will surprise you with sex!"
-msgstr "¡Pero ten cuidado, @MONSTER_RACE@ salvajes no tienen control sobre sus deseos y te sorprenderá con sexo!"
+msgstr "¡Pero ten cuidado, los @MONSTER_RACE@ silvestres no tienen control sobre sus deseos, ¡y te sorprenderán con sexo!"
 
 #. Key:	F3CA61414720C714BBD4FB98C38684ED
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_RL.Default__EmissaryDefault01_RL_C.ResponseData(4).ResponseData.BreederPrompt
@@ -13213,7 +13297,7 @@ msgstr "¿Cómo aprendo las posiciones sexuales?"
 #: /Game/Dialogue/Petra/Default/PetraGetKeystone.Default__PetraGetKeystone_C.SessionData.Lines(5).Lines
 msgctxt ",F3E1DD1B4ED3DA2D29DB4CA040F01A59"
 msgid "Am I to undertake a journey to find this winged maiden... no, she said to remain in the jungle."
-msgstr ""
+msgstr "Debo emprender un viaje para encontrar a esta doncella alada... no, dijo que permanezca en la jungla."
 
 #. Key:	F3F4124041D97034B836478BD7FE0BF9
 #. SourceLocation:	/Game/Characters/Procedural/Variants/Demon/Harvest/DemonHarvest.Default__DemonHarvest_C.Harvest.Description
@@ -13234,42 +13318,42 @@ msgstr "Thriae"
 #: /Game/Dialogue/Leylanna/Default/LeylannaDefault01_NoSpiritVariant.Default__LeylannaDefault01_NoSpiritVariant_C.SessionData.LinesToMale(0).LinesToMale
 msgctxt ",F44AC0034E9517A0581F3EA383C623F9"
 msgid "Return to me when you have caught a male Vulwarg."
-msgstr "Vuelve a verme cuando hayas atrapado a un Vulwarg macho."
+msgstr "Vuelve a verme cuando hayas atrapado un macho vulwarg."
 
 #. Key:	F4CADE7A441CE6B749B76B9F7EC26371
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_SmokeRL.Default__LeylannaDefault01_SmokeRL_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/Leylanna/Default/LeylannaDefault01_SmokeRL.Default__LeylannaDefault01_SmokeRL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",F4CADE7A441CE6B749B76B9F7EC26371"
 msgid "So it makes you high?"
-msgstr "¿Entonces te hace drogar?"
+msgstr "¿Entonces eso te hace \"volar\"?"
 
 #. Key:	F5276F72433DAADC3348C9937061AB06
 #. SourceLocation:	/Game/Ranch/Upgrades/StarfallenMonolith.Default__StarfallenMonolith_C.Upgrade.Description
 #: /Game/Ranch/Upgrades/StarfallenMonolith.Default__StarfallenMonolith_C.Upgrade.Description
 msgctxt ",F5276F72433DAADC3348C9937061AB06"
 msgid "This allows you to catch and store all variants of Starfallen."
-msgstr "Esto te permite capturar y almacenar todas las variantes de Caídos de las Estrellas."
+msgstr "Esto te permite capturar y almacenar todas las variantes de Starfallen."
 
 #. Key:	F539C90E493265602920739266B04C87
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimePearl.Default__MegaSlimePearl_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePearl.Default__MegaSlimePearl_C.SessionData.Lines(1).Lines
 msgctxt ",F539C90E493265602920739266B04C87"
 msgid "Are you sure you want to give this to me? Oh... I don't know what to say."
-msgstr ""
+msgstr "¿Estás seguro de que quieres dármela? Oh... no sé qué decir."
 
 #. Key:	F5C8C3C7475F573785E31C934B9F38B9
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleRideYou.Default__KybeleRideYou_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Kybele/Default/KybeleRideYou.Default__KybeleRideYou_C.SessionData.Lines(1).Lines
 msgctxt ",F5C8C3C7475F573785E31C934B9F38B9"
 msgid "Just for asking that, you are going to be my sex toy for the rest of the day!"
-msgstr ""
+msgstr "Solo por preguntar eso, ¡serás mi juguete sexual por el resto del día!"
 
 #. Key:	F5D89EF24DD4E97F5789B4AF367D8E47
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R04.Default__FaleneDefault01_R04_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R04.Default__FaleneDefault01_R04_C.SessionData.Lines(4).Lines
 msgctxt ",F5D89EF24DD4E97F5789B4AF367D8E47"
 msgid "It's our genitalia and hormones. They are extremely robust and powerful compared to humans."
-msgstr "Son nuestros genitales y hormonas. Son extremadamente robustos y poderosos en comparación con los de los humanos."
+msgstr "Son nuestros genitales y hormonas. Son extremadamente robustos y poderosos en comparación con los humanos."
 
 #. Key:	F5ED58D749F2CCE9DC0F23BD22E35C2D
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_RechargeSpiritForm.Default__LeylannaDefault01_RechargeSpiritForm_C.SessionData.Lines(1).Lines
@@ -13283,21 +13367,21 @@ msgstr "¡Los espíritus han revelado que nuestro futuro contiene muchos encuent
 #: /Game/Dialogue/Fern/DefaultP3/FernGreeting03.Default__FernGreeting03_C.SessionData.LinesToFuta(3).LinesToFuta
 msgctxt ",F685E190400D71BAA030AE8630162626"
 msgid "I suppose there is no need to feed me anymore, but there is another place your fluids can go!"
-msgstr "Supongo que ya no hay necesidad de alimentarme, ¡pero hay otro lugar al que pueden ir tus fluidos!"
+msgstr "Supongo que ya no hay necesidad de alimentarme nunca más, ¡pero hay otro lugar donde tus fluidos pueden ir!"
 
 #. Key:	F6969BA84DEC3DFDB3D93F9DDA026D6A
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeDefault01_RL.Default__MegaSlimeDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeDefault01_RL.Default__MegaSlimeDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
 msgctxt ",F6969BA84DEC3DFDB3D93F9DDA026D6A"
 msgid "How long have you been down here?"
-msgstr ""
+msgstr "¿Cuánto tiempo llevas aquí abajo?"
 
 #. Key:	F69BD2354184895C493EA985FE74F5CC
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault02.Default__EmissaryDefault02_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault02.Default__EmissaryDefault02_C.SessionData.Lines(1).Lines
 msgctxt ",F69BD2354184895C493EA985FE74F5CC"
 msgid "To think your vessel made love with a pathetic blob to achieve this."
-msgstr ""
+msgstr "Pensar que tu recipiente hizo el amor con una mancha patética para lograr esto."
 
 #. Key:	F6A2BD8D4CBE73666D030B83D56908E8
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_RaiseTraitLvl.Default__EmissaryDefault01_RaiseTraitLvl_C.SessionData.Lines(2).Lines
@@ -13311,98 +13395,98 @@ msgstr "@TRAIT_LVL_COST@ será suficiente."
 #: /Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToMale(0).LinesToMale
 msgctxt ",F74061254D2D2A0904956FA983C624F3"
 msgid "Ohhh how I have waited to wrap my soft lips around a human dick! Ahhh..."
-msgstr "¡Oh, cómo he esperado para envolver mis suaves labios alrededor de una polla humana! Ahhh..."
+msgstr "¡Ohhh, cómo he esperado para envolver mis suaves labios alrededor de un pene humano! Ahhh..."
 
 #. Key:	F743D4EB4B4F3333AEE950BA4458ECE8
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01.Default__RomyDefault01_C.SessionData.LinesGrungy(0).LinesGrungy
 #: /Game/Dialogue/Romy/Default/RomyDefault01.Default__RomyDefault01_C.SessionData.LinesGrungy(0).LinesGrungy
 msgctxt ",F743D4EB4B4F3333AEE950BA4458ECE8"
 msgid "Oh you dirty dirty human... what have you done to yourself?"
-msgstr "Oh tú sucia sucia humana... ¿qué te has hecho a ti misma?"
+msgstr "Oh, sucio, sucio humano... ¿Qué te has hecho a ti mismo?"
 
 #. Key:	F74E8BFF48A0493236F0C6B2CDD1F4DB
 #. SourceLocation:	/Game/Dialogue/Leylanna/SexScenes/LeylannaLeyCov.Default__LeylannaLeyCov_C.SessionData.LinesToFemale(2).LinesToFemale
 #: /Game/Dialogue/Leylanna/SexScenes/LeylannaLeyCov.Default__LeylannaLeyCov_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",F74E8BFF48A0493236F0C6B2CDD1F4DB"
 msgid "*Moan*"
-msgstr "*Gemido*"
+msgstr "*Gime*"
 
 #. Key:	F7525328451BBC6ED4F59587DBE6C854
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDungeon.Default__CassieDungeon_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Cassie/Default/CassieDungeon.Default__CassieDungeon_C.SessionData.Lines(2).Lines
 msgctxt ",F7525328451BBC6ED4F59587DBE6C854"
 msgid "It has been locked for many years."
-msgstr ""
+msgstr "Ha estado bloqueado durante muchos años."
 
 #. Key:	F75595714B06DF676D20B5B79FB8C222
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(20).LinesToMale
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(20).LinesToMale
 msgctxt ",F75595714B06DF676D20B5B79FB8C222"
 msgid "Since you're a breeder, it's your job to catch and mate as many @MONSTER_RACE@ as possible!"
-msgstr "¡Ya que eres un criador, es tu trabajo atrapar y aparear tantos @MONSTER_RACE@ como sea posible!"
+msgstr "Ya que eres un criador, ¡es tu trabajo atrapar y aparearte con tantos @MONSTER_RACE@ como sea posible!"
 
 #. Key:	F790EDFC4B6DF5886C322687396F4E9C
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleDragonMatriarch.Default__KybeleDragonMatriarch_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Kybele/Default/KybeleDragonMatriarch.Default__KybeleDragonMatriarch_C.SessionData.Lines(0).Lines
 msgctxt ",F790EDFC4B6DF5886C322687396F4E9C"
 msgid "She has charged me with guarding her offspring."
-msgstr ""
+msgstr "Me ha encargado que cuide a su descendencia."
 
 #. Key:	F79308E4449E12AB211CF78CC8200DA9
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(21).LinesToMale
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(21).LinesToMale
 msgctxt ",F79308E4449E12AB211CF78CC8200DA9"
 msgid "@MONSTER_RACE@ you catch won't be blessed like me!"
-msgstr "¡@MONSTER_RACE@ que atrapes no serán bendecidos como yo!"
+msgstr "¡Los @MONSTER_RACE@ que atrapes no serán bendecidos como yo!"
 
 #. Key:	F7A6401147093A75B20588870BFA39C7
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToFuta(0).LinesToFuta
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToFuta(0).LinesToFuta
 msgctxt ",F7A6401147093A75B20588870BFA39C7"
 msgid "Careful human, a Kraken's lust is not to be underestimated."
-msgstr "Cuidado humana, la lujuria de una Kraken no debe ser subestimada."
+msgstr "Cuidado humana, la lujuria de un kraken no debe ser subestimada."
 
 #. Key:	F7B920EC4CAAD4CD4E61C8915489F45C
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiIdiots.Default__FesssiIdiots_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiIdiots.Default__FesssiIdiots_C.SessionData.Lines(3).Lines
 msgctxt ",F7B920EC4CAAD4CD4E61C8915489F45C"
 msgid "Those damn centaurs only care about money and sticking their spears in places."
-msgstr ""
+msgstr "A esos malditos centauros solo les importa el dinero y clavar sus lanzas en algunos lugares."
 
 #. Key:	F7C4336C4CE85A985EE8819488AD2853
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMYourChildren.Default__DMYourChildren_C.SessionData.LinesToFuta(1).LinesToFuta
 #: /Game/Dialogue/DragonMatriarch/Default/DMYourChildren.Default__DMYourChildren_C.SessionData.LinesToFuta(1).LinesToFuta
 msgctxt ",F7C4336C4CE85A985EE8819488AD2853"
 msgid "Who knows which of them are mine, and I don't care. This matriarch will continue reproducing until the end of time."
-msgstr ""
+msgstr "Quién sabe cuáles son míos, y no me importa. Esta matriarca seguirá reproduciéndose hasta el fin de los tiempos."
 
 #. Key:	F80CC71F49A124229467EC98902D86F9
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleCentaur.Default__KybeleCentaur_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Kybele/Default/KybeleCentaur.Default__KybeleCentaur_C.SessionData.Lines(4).Lines
 msgctxt ",F80CC71F49A124229467EC98902D86F9"
 msgid "Count yourself fortunate, in case you haven't noticed the challenge present for a centuar to please herself."
-msgstr ""
+msgstr "Considérese afortunado, en caso de que no hayas notado el desafío que presenta para complacerse a sí mismo un centauro."
 
 #. Key:	F84550BD45785F99DC5ACC9F2C125EDF
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleDefault01_RL.Default__KybeleDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/Kybele/Default/KybeleDefault01_RL.Default__KybeleDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",F84550BD45785F99DC5ACC9F2C125EDF"
 msgid "Dragon Matriarch?"
-msgstr ""
+msgstr "¿Matriarca Dragón?"
 
 #. Key:	F88AA516424D4DB3A67953803B2F3000
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_Formuria.Default__MirruDefault01_Formuria_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_Formuria.Default__MirruDefault01_Formuria_C.SessionData.Lines(3).Lines
 msgctxt ",F88AA516424D4DB3A67953803B2F3000"
 msgid "*Sigh* I hold them dear, but pity them for not being born Kraken."
-msgstr "*Suspiro* Los tengo cariño, pero los compadezco por no haber nacido Kraken."
+msgstr "*Suspira* Les tengo cariño, pero los compadezco por no haber nacido kraken."
 
 #. Key:	F890DAF744D2EC5F55BEE5AFC5CA772A
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowHadSex01.Default__WidowHadSex01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Widow/Default/WidowHadSex01.Default__WidowHadSex01_C.SessionData.Lines(0).Lines
 msgctxt ",F890DAF744D2EC5F55BEE5AFC5CA772A"
 msgid "Sweet succulent human, you were delicious..."
-msgstr ""
+msgstr "Dulce y suculento humano, estabas delicioso..."
 
 #. Key:	F8A579884E09A8EAFE39C78D6B221425
 #. SourceLocation:	/Game/Dialogue/AmberMae/SexScenes/AmberMilkyF.Default__AmberMilkyF_C.SessionData.Lines(2).Lines
@@ -13416,7 +13500,7 @@ msgstr "Bébelo, ahhhh... ohhh..."
 #: /Game/Dialogue/OrcChief/Default/OrcHaveKeystone.Default__OrcHaveKeystone_C.SessionData.Lines(2).Lines
 msgctxt ",F8B7E4C84269C81CD36B5CB136D0AA4F"
 msgid "Mates... yes. Human is breeder!"
-msgstr ""
+msgstr "Compañeras... sí. ¡El humano es criador!"
 
 #. Key:	F8E2DB524A01D500B2ED3BB19853D247
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToMale(5).LinesToMale
@@ -13430,28 +13514,28 @@ msgstr "Ohhh... ¿podrías complacer a esta vieja guardiana? Es una vida solitar
 #: /Game/Dialogue/Blossom/Default/BlossomGreeting01.Default__BlossomGreeting01_C.SessionData.Lines(2).Lines
 msgctxt ",F8E720D345661A45019656BB02DC9809"
 msgid "Mastah?"
-msgstr "¿Maeztra?"
+msgstr "¿Mastah?"
 
 #. Key:	F91CB0D5406C6A0CEF265AACB268DDE0
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernGreeting01.Default__FernGreeting01_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Fern/Default/FernGreeting01.Default__FernGreeting01_C.SessionData.Lines(2).Lines
 msgctxt ",F91CB0D5406C6A0CEF265AACB268DDE0"
 msgid "Mastah?"
-msgstr "¿Maeztra?"
+msgstr "¿Mastah?"
 
 #. Key:	F98CD43545B39F2F962E56AF0DC2ADAA
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraAboutPawsmaati.Default__PetraAboutPawsmaati_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Petra/Default/PetraAboutPawsmaati.Default__PetraAboutPawsmaati_C.SessionData.Lines(5).Lines
 msgctxt ",F98CD43545B39F2F962E56AF0DC2ADAA"
 msgid "I never wanted it to end! She was in complete control the entire time, not releasing until I came ten times."
-msgstr ""
+msgstr "¡Nunca quise que terminara! Ella tuvo el control total todo el tiempo, no descargó hasta que me corrí diez veces."
 
 #. Key:	F9C66FA74BAA102FE1238A952823D3D9
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R01.Default__FaleneDefault01_R01_C.SessionData.Lines(17).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R01.Default__FaleneDefault01_R01_C.SessionData.Lines(17).Lines
 msgctxt ",F9C66FA74BAA102FE1238A952823D3D9"
 msgid "I wish I could remember my own birth and childhood, it would make this a lot easier. Hell, I wish I could remember how I got here, some 300 years ago. Hehe I lost count."
-msgstr "Desearía poder recordar mi propio nacimiento e infancia, eso haría que esto fuera mucho más fácil. Demonios, desearía poder recordar cómo llegué aquí, hace unos 300 años. Jeje perdí la cuenta."
+msgstr "Desearía poder recordar mi propio nacimiento e infancia, eso haría esto mucho más fácil. Demonios, desearía poder recordar cómo llegué aquí, hace unos 300 años. Jeje, perdí la cuenta."
 
 #. Key:	F9EF68BC4CE831DD669546BF6213C846
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDefault01_Meow_StartButterButt.Default__CassieDefault01_Meow_StartButterButt_C.SessionData.Lines(0).Lines
@@ -13462,52 +13546,54 @@ msgstr "¡¡¡MIAU!!! ¡Cassie te va a llenar de semilla de gatito!"
 
 #. Key:	FA099D00490628CE02692F98F8341539
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(34 - Value).TraitIcons.DisplayName
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(34 - Value).TraitIcons.DisplayName
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(34 -
+#: Value).TraitIcons.DisplayName
 msgctxt ",FA099D00490628CE02692F98F8341539"
 msgid "Buxom"
 msgstr "Exuberante"
 
 #. Key:	FA16663A4C4765BC8F4CBC80FF774B75
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(12 - Value).TraitIcons.HelpText
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(12 - Value).TraitIcons.HelpText
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(12 -
+#: Value).TraitIcons.HelpText
 msgctxt ",FA16663A4C4765BC8F4CBC80FF774B75"
 msgid "Grungy: Mates have a 20% of getting dirty, reducing allure by 50%."
-msgstr "Sucio/a: Los/as compañeros/as tienen un 20% de suciedad, lo que reduce el atractivo en un 50%."
+msgstr "Sucio: los compañeros tienen un 20% de ensuciarse, lo que reduce el Atractivo en un 50%."
 
 #. Key:	FA28913344F5F91202D288867FDD4829
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchPrettyButterfly.Default__MonarchPrettyButterfly_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Monarch/Default/MonarchPrettyButterfly.Default__MonarchPrettyButterfly_C.SessionData.Lines(3).Lines
 msgctxt ",FA28913344F5F91202D288867FDD4829"
 msgid "If y-y-you know what I mean."
-msgstr ""
+msgstr "Si s-s-sabes a lo que me refiero."
 
 #. Key:	FA2C70284FBA2B074235FD87FF6B8D64
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDefault01.Default__CassieDefault01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Cassie/Default/CassieDefault01.Default__CassieDefault01_C.SessionData.Lines(1).Lines
 msgctxt ",FA2C70284FBA2B074235FD87FF6B8D64"
 msgid "*Purr*"
-msgstr "*Ronroneo*"
+msgstr "*Ronronea*"
 
 #. Key:	FA4364AD420E7246DD976FA55489258C
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_AboutKrakens.Default__MirruDefault01_AboutKrakens_C.SessionData.Lines(9).Lines
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_AboutKrakens.Default__MirruDefault01_AboutKrakens_C.SessionData.Lines(9).Lines
 msgctxt ",FA4364AD420E7246DD976FA55489258C"
 msgid "At least, I can promise a Kraken's body will provide our mates with enormous pleasure."
-msgstr "Al menos, puedo prometer que el cuerpo de un Kraken proporcionará a nuestros compañeros un enorme placer."
+msgstr "Al menos, puedo prometer que el cuerpo de un kraken proporcionará a nuestros compañeros un enorme placer."
 
 #. Key:	FA986E53459F35B9F05FE5909E9153CE
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMDefault01.Default__DMDefault01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMDefault01.Default__DMDefault01_C.SessionData.Lines(0).Lines
 msgctxt ",FA986E53459F35B9F05FE5909E9153CE"
 msgid "*Yawn*"
-msgstr ""
+msgstr "*Bosteza*"
 
 #. Key:	FAA596EC4B5291C8FF02FC9966C3C4B6
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeDefault01.Default__MegaSlimeDefault01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeDefault01.Default__MegaSlimeDefault01_C.SessionData.Lines(1).Lines
 msgctxt ",FAA596EC4B5291C8FF02FC9966C3C4B6"
 msgid "AND I have!! For nearly 1000 years, down here all by myself..."
-msgstr ""
+msgstr "¡¡Y yo tengo!! Durante casi 1000 años, aquí abajo toda para mi misma..."
 
 #. Key:	FAA5B41940157F8963E69CB4ACE814A4
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeDefault01_MilkyProducts.Default__AmberMaeDefault01_MilkyProducts_C.SessionData.Lines(0).Lines
@@ -13528,77 +13614,77 @@ msgstr "¡Has cambiado!"
 #: /Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",FAB1F6F548473C3126B60F9981FBA341"
 msgid "Ohhh @BREEDER_NAME@... you were amazing."
-msgstr ""
+msgstr "Ohhh, @BREEDER_NAME@... estuviste increíble."
 
 #. Key:	FAC3B1AA48B55AC22C81BABA4025A329
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_TheVoid.Default__NeelaDefault01_TheVoid_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_TheVoid.Default__NeelaDefault01_TheVoid_C.SessionData.Lines(3).Lines
 msgctxt ",FAC3B1AA48B55AC22C81BABA4025A329"
 msgid "However, by stepping into a sacred pussy portal one can enter the Void from this plane."
-msgstr "Sin embargo, al entrar en un sagrado coño portal, uno puede ingresar al Vacío desde este plano."
+msgstr "Sin embargo, al entrar en un coño portal sagrado, uno puede entrar al Vacío desde este plano."
 
 #. Key:	FAD4B31949B0D1AC3DE5B3A79B8048C6
 #. SourceLocation:	/Game/Dialogue/Mirru/SexScenes/MirruSnatchF.Default__MirruSnatchF_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Mirru/SexScenes/MirruSnatchF.Default__MirruSnatchF_C.SessionData.Lines(5).Lines
 msgctxt ",FAD4B31949B0D1AC3DE5B3A79B8048C6"
 msgid "Ohhh yes... ahhh..."
-msgstr "Ohhh si ... ahhh ..."
+msgstr "Ohhh, sí... ahhh..."
 
 #. Key:	FAF0FA2D4B10AE21D5D8D2A27EAE488D
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruHadSex01.Default__MirruHadSex01_C.SessionData.LinesToFemale(5).LinesToFemale
 #: /Game/Dialogue/Mirru/Default/MirruHadSex01.Default__MirruHadSex01_C.SessionData.LinesToFemale(5).LinesToFemale
 msgctxt ",FAF0FA2D4B10AE21D5D8D2A27EAE488D"
 msgid "Perhaps next time I will indulge myself and not go so easy on you..."
-msgstr ""
+msgstr "Quizás la próxima vez me deleite a mi misma y no sea tan fácil contigo..."
 
 #. Key:	FAF57AE645B3D2B5A5373CA6FA1C5EA6
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadFlowers.Default__DryadFlowers_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Autumn/Default/DryadFlowers.Default__DryadFlowers_C.SessionData.Lines(1).Lines
 msgctxt ",FAF57AE645B3D2B5A5373CA6FA1C5EA6"
 msgid "However I am going to require a lot of... seed."
-msgstr ""
+msgstr "Sin embargo, voy a necesitar mucha... semilla."
 
 #. Key:	FB09A1964EDEBFF9F5E3839307040AEB
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchDefault01.Default__MonarchDefault01_C.SessionData.LinesToFemale(4).LinesToFemale
 #: /Game/Dialogue/Monarch/Default/MonarchDefault01.Default__MonarchDefault01_C.SessionData.LinesToFemale(4).LinesToFemale
 msgctxt ",FB09A1964EDEBFF9F5E3839307040AEB"
 msgid "Is t-t-there something... you want human?"
-msgstr ""
+msgstr "¿Hay a-a-algo... que quieras humano?"
 
 #. Key:	FB2BB3B44297DAF2860982BAD6C1819A
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToMale(0).LinesToMale
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToMale(0).LinesToMale
 msgctxt ",FB2BB3B44297DAF2860982BAD6C1819A"
 msgid "Careful human, a Kraken's lust is not to be underestimated."
-msgstr "Cuidado humano, la lujuria de una Kraken no debe ser subestimada."
+msgstr "Cuidado humano, la lujuria de un kraken no debe ser subestimada."
 
 #. Key:	FB4D6F564D28EE26BC34658F3C9B1F73
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimePlay.Default__MegaSlimePlay_C.SessionData.LinesToFemale(2).LinesToFemale
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePlay.Default__MegaSlimePlay_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",FB4D6F564D28EE26BC34658F3C9B1F73"
 msgid "Well what are you waiting for? Come on in!"
-msgstr ""
+msgstr "¿Bueno, qué estás esperando? ¡Venga!"
 
 #. Key:	FB6284F34E0BBFD934651EAD6C3DC5D8
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchGreeting01.Default__MonarchGreeting01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Monarch/Default/MonarchGreeting01.Default__MonarchGreeting01_C.SessionData.Lines(0).Lines
 msgctxt ",FB6284F34E0BBFD934651EAD6C3DC5D8"
 msgid "Oh, hello!"
-msgstr ""
+msgstr "¡Oh, hola!"
 
 #. Key:	FB857A0E425DC310680C179A127076D3
 #. SourceLocation:	/Game/Dialogue/Mirru/SexScenes/MirruSnatchF.Default__MirruSnatchF_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Mirru/SexScenes/MirruSnatchF.Default__MirruSnatchF_C.SessionData.Lines(3).Lines
 msgctxt ",FB857A0E425DC310680C179A127076D3"
 msgid "Ahh... it feels so good! I am going to cum."
-msgstr "Ahh ... ¡se siente tan bien! Me voy a correr."
+msgstr "¡Ahh... se siente tan bien! Me voy a correr."
 
 #. Key:	FB8D2D144CB9249F47237B94F66E71F1
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(6).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(6).Lines
 msgctxt ",FB8D2D144CB9249F47237B94F66E71F1"
 msgid "Why I drink it and use it to make magic treats of course! I ain't a wee lass mind you--I drink lots o' the stuff! Also, me treats are famous world wide!"
-msgstr ""
+msgstr "¡Poh qué la bebo y la uso para haceh deliciah mágicah, poh zupuehto! No zoy una moza pequeñita sabeh: ¡bebo mushah cosah! ¡Ademáh, mih deliciah son famozah en to' el mundo!"
 
 #. Key:	FBA6175C45D9F4E3E3CD7F85021561C6
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_Pregnancy.Default__FaleneDefault01_Pregnancy_C.SessionData.Lines(0).Lines
@@ -13619,42 +13705,42 @@ msgstr "A pesar de más de 4,000 años atravesando el Vacío, todavía tengo que
 #: /Game/Dialogue/Autumn/Default/DryadCherryHelp.Default__DryadCherryHelp_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",FBC59E69493451F2A30A66818584F9BC"
 msgid "Ohhh how I've waited for this."
-msgstr ""
+msgstr "Ohhh, cómo he esperado esto."
 
 #. Key:	FBDDB80F480F00F6DF7E1BA03EC927F6
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowTaskFullfilled2.Default__WidowTaskFullfilled2_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Widow/Default/WidowTaskFullfilled2.Default__WidowTaskFullfilled2_C.SessionData.Lines(2).Lines
 msgctxt ",FBDDB80F480F00F6DF7E1BA03EC927F6"
 msgid "Always she crawls to me, begging me to suck her juicy nethers and breasts... and I gladly oblige."
-msgstr ""
+msgstr "Siempre se arrastra hacia mí, suplicándome que le chupe sus jugosos bajos y pechos... y yo la complazco con mucho gusto."
 
 #. Key:	FBE363A241E1A6C5172380A2F5CAFD27
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleGreeting01.Default__KybeleGreeting01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Kybele/Default/KybeleGreeting01.Default__KybeleGreeting01_C.SessionData.Lines(1).Lines
 msgctxt ",FBE363A241E1A6C5172380A2F5CAFD27"
 msgid "I see that look in your eye, you wish to use the denizens of Virgin Breaks for your own pleasure."
-msgstr ""
+msgstr "Veo esa mirada en tus ojos, deseas usar a los habitantes de Rupturas Vírgenes para tu propio placer."
 
 #. Key:	FBF536C949746784E2045981A88739F6
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaHadSex02.Default__CamillaHadSex02_C.SessionData.LinesToMale(0).LinesToMale
 #: /Game/Dialogue/Camilla/Default/CamillaHadSex02.Default__CamillaHadSex02_C.SessionData.LinesToMale(0).LinesToMale
 msgctxt ",FBF536C949746784E2045981A88739F6"
 msgid "Wow human, you must have been desperate to give this nugget your love."
-msgstr ""
+msgstr "Guau, humano, debes haber estado desesperado por darle a esta pepita tu amor."
 
 #. Key:	FC2E4BC244CE7A4471B402A207DCB5C4
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03.Default__FernDefault03_C.SessionData.LinesToFuta(0).LinesToFuta
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03.Default__FernDefault03_C.SessionData.LinesToFuta(0).LinesToFuta
 msgctxt ",FC2E4BC244CE7A4471B402A207DCB5C4"
 msgid "Oh Master, you have fed me well."
-msgstr "Oh Maestra, me has alimentado bien."
+msgstr "Oh, Master, me has alimentado bien."
 
 #. Key:	FC6A48C641C7797ED1492DB62B0AC386
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R07_RL.Default__CamillaDefault01_R07_RL_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R07_RL.Default__CamillaDefault01_R07_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",FC6A48C641C7797ED1492DB62B0AC386"
 msgid "Mmm Amber's tits..."
-msgstr "Mmm las tetas de Amber..."
+msgstr "Mmm, las tetas de Amber..."
 
 #. Key:	FCA66F654F21F79586D7899A9C2CADC5
 #. SourceLocation:	/Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToFemale(3).LinesToFemale
@@ -13668,49 +13754,50 @@ msgstr "*Sorbe* *Lame*"
 #: /Game/Dialogue/Romy/Default/RomyGreeting01.Default__RomyGreeting01_C.SessionData.Lines(1).Lines
 msgctxt ",FCD1F71F4D144F31FDAB9F89767AC8E7"
 msgid "Yes it sounds so sweet, it is the sound of human desire. Ahhh... it grows louder as your gaze turns upon my breasts."
-msgstr "Sí, suena tan dulce, es el sonido del deseo humano. Ahhh ... se hace más fuerte cuando tu mirada se vuelve hacia mis senos."
+msgstr "Sí, suena tan dulce, es el sonido del deseo humano. Ahhh... se hace más fuerte cuando tu mirada se vuelve hacia mis pechos."
 
 #. Key:	FCEBBA094930884E07B0A38C1FC062B8
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchHadSex01.Default__MonarchHadSex01_C.SessionData.LinesToFemale(2).LinesToFemale
 #: /Game/Dialogue/Monarch/Default/MonarchHadSex01.Default__MonarchHadSex01_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",FCEBBA094930884E07B0A38C1FC062B8"
 msgid "I hope my toy made you feel good. Maybe... w-w-we can do it again?"
-msgstr ""
+msgstr "Espero que mi juguete te haya hecho sentir bien. ¿Tal vez... p-p-podemos hacerlo de nuevo?"
 
 #. Key:	FCFE3B3D4F76E0D8BBC19BBF1F504CC6
 #. SourceLocation:	/Game/Dialogue/Yasmine/Default/YasmineAwake.Default__YasmineAwake_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Yasmine/Default/YasmineAwake.Default__YasmineAwake_C.SessionData.Lines(1).Lines
 msgctxt ",FCFE3B3D4F76E0D8BBC19BBF1F504CC6"
 msgid "It happens every time I open, you think I would have learned by now."
-msgstr ""
+msgstr "Sucede cada vez que me abro, crees que ya lo habría aprendido."
 
 #. Key:	FD102648460B4847C187CA85C454705B
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeMoreHoney.Default__BeeMoreHoney_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/QueenBee/Default/BeeMoreHoney.Default__BeeMoreHoney_C.SessionData.Lines(1).Lines
 msgctxt ",FD102648460B4847C187CA85C454705B"
 msgid "Kneel and suck human. Engorge yourself on my honey, for it pleases me greatly."
-msgstr ""
+msgstr "Arrodíllate y chupa humano. Atibórrate de mi miel, porque me complace inmensamente."
 
 #. Key:	FD257CB04C6B3AB420244298D2C33047
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(14 - Value).TraitIcons.DisplayName
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(14 - Value).TraitIcons.DisplayName
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(14 -
+#: Value).TraitIcons.DisplayName
 msgctxt ",FD257CB04C6B3AB420244298D2C33047"
 msgid "Hornball"
-msgstr "Pervertida/o"
+msgstr "Pervertido"
 
 #. Key:	FD45A2EF441A8E608939FF9788710118
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadHaveKeystone2.Default__DryadHaveKeystone2_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Autumn/Default/DryadHaveKeystone2.Default__DryadHaveKeystone2_C.SessionData.Lines(2).Lines
 msgctxt ",FD45A2EF441A8E608939FF9788710118"
 msgid "There, they will no longer block your path."
-msgstr ""
+msgstr "Allí, ellas ya no bloquearán tu camino."
 
 #. Key:	FD4609F340081E569544E6914EAA6434
 #. SourceLocation:	/Game/Dialogue/Yasmine/Default/YasmineDefault02.Default__YasmineDefault02_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Yasmine/Default/YasmineDefault02.Default__YasmineDefault02_C.SessionData.Lines(0).Lines
 msgctxt ",FD4609F340081E569544E6914EAA6434"
 msgid "..."
-msgstr ""
+msgstr "..."
 
 #. Key:	FD467EAE4829745CF23D4BA9D511E423
 #. SourceLocation:	/Game/Dialogue/Mirru/SexScenes/MirruSnatchF.Default__MirruSnatchF_C.SessionData.Lines(2).Lines
@@ -13731,147 +13818,149 @@ msgstr "¡La hinchazón del vientre representa el progreso del recién nacido ha
 #: /Game/Dialogue/Fesssi/Default/FesssiHowLong.Default__FesssiHowLong_C.SessionData.Lines(9).Lines
 msgctxt ",FD60314C4ADEEDC7A454ECA6AA29E42A"
 msgid "A lamia's body is very sensitive in certain places, and if massaged correctly can induce a nice orgasm."
-msgstr ""
+msgstr "El cuerpo de una lamia es muy sensible en ciertos lugares y, si se masajea correctamente, puede inducir un orgasmo agradable."
 
 #. Key:	FD6F8B5B4B3A96B1EC5B4D838FCA8599
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToFemale(7).LinesToFemale
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToFemale(7).LinesToFemale
 msgctxt ",FD6F8B5B4B3A96B1EC5B4D838FCA8599"
 msgid "Believe it or not, I used to be bigger, but I lost a large chunk of myself and it floated away..."
-msgstr ""
+msgstr "Lo creas o no, solía ser más grande, pero perdí una gran parte de mí misma y se alejó flotando..."
 
 #. Key:	FD8011CC4C321FCEC4C41F88F97FDCD1
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TravelShrines(3 - Value).TravelShrines.ShrineName
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TravelShrines(3 - Value).TravelShrines.ShrineName
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TravelShrines(3 -
+#: Value).TravelShrines.ShrineName
 msgctxt ",FD8011CC4C321FCEC4C41F88F97FDCD1"
 msgid "Moaning Crag"
-msgstr "Peñasco Gimiente"
+msgstr "Risco Gimiente"
 
 #. Key:	FD905EC14D8B8AC5E3D8D28AB7280C39
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid_RL.Default__NeelaDefault01_YourVoid_RL_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid_RL.Default__NeelaDefault01_YourVoid_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",FD905EC14D8B8AC5E3D8D28AB7280C39"
 msgid "Experience this human!"
-msgstr ""
+msgstr "¡Experimentar este humano!"
 
 #. Key:	FD996BF544296A6A4A54CE82ABF12183
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernGreeting02.Default__FernGreeting02_C.SessionData.LinesToFuta(2).LinesToFuta
 #: /Game/Dialogue/Fern/DefaultP2/FernGreeting02.Default__FernGreeting02_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",FD996BF544296A6A4A54CE82ABF12183"
 msgid "I am a growing Alraune, perhaps you have fluids to spare?"
-msgstr "Soy una Mandrágora en crecimiento, ¿quizás tengas líquidos de sobra?"
+msgstr "Soy una alraune en crecimiento, ¿tal vez te sobran fluidos?"
 
 #. Key:	FDB79BD24E2E79AD2A532E8378563FD0
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault02.Default__CamillaDefault02_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaDefault02.Default__CamillaDefault02_C.SessionData.Lines(4).Lines
 msgctxt ",FDB79BD24E2E79AD2A532E8378563FD0"
 msgid "Not to eat me, it did other things to my little body... it felt amazing actually."
-msgstr ""
+msgstr "No comerme, le hizo otras cosas a mi cuerpecito... en realidad se sintió increíble."
 
 #. Key:	FDBDE7714A97FE255B38A0BACEC479DB
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(7 - Value).TraitIcons.DisplayName
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(7 - Value).TraitIcons.DisplayName
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(7 -
+#: Value).TraitIcons.DisplayName
 msgctxt ",FDBDE7714A97FE255B38A0BACEC479DB"
 msgid "Tiny Size"
-msgstr "Tamaño minúsculo"
+msgstr "Tamaño Menudo"
 
 #. Key:	FDF3D1784F3939583D52ADB0231DF337
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchQueen.Default__MonarchQueen_C.SessionData.Lines(6).Lines
 #: /Game/Dialogue/Monarch/Default/MonarchQueen.Default__MonarchQueen_C.SessionData.Lines(6).Lines
 msgctxt ",FDF3D1784F3939583D52ADB0231DF337"
 msgid "Legends say beautiful angels fly around its spires."
-msgstr ""
+msgstr "Las leyendas dicen que los hermosos ángeles vuelan alrededor de sus agujas."
 
 #. Key:	FDF4297C47FFAC2C90A1C8A5AC503A21
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadTaskFulfilled.Default__DryadTaskFulfilled_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Autumn/Default/DryadTaskFulfilled.Default__DryadTaskFulfilled_C.SessionData.Lines(1).Lines
 msgctxt ",FDF4297C47FFAC2C90A1C8A5AC503A21"
 msgid "She knows how to please, and her delicious honey has increased my fruit production."
-msgstr ""
+msgstr "Ella sabe complacer y su deliciosa miel ha aumentado mi producción de frutas."
 
 #. Key:	FE11832245764B482A5550B347EB143E
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(25).LinesToMale
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(25).LinesToMale
 msgctxt ",FE11832245764B482A5550B347EB143E"
 msgid "However, some might be more playful about it and surprise you!"
-msgstr "Sin embargo, ¡algunos podrían ser más juguetones al respecto y sorprenderte!"
+msgstr "¡Sin embargo, algunos podrían ser más juguetones y sorprenderte!"
 
 #. Key:	FE30CC0F4EC31063CA576A8A6CF941F5
 #. SourceLocation:	/Game/Dialogue/Yasmine/Default/YasmineHadSex01.Default__YasmineHadSex01_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Yasmine/Default/YasmineHadSex01.Default__YasmineHadSex01_C.SessionData.Lines(2).Lines
 msgctxt ",FE30CC0F4EC31063CA576A8A6CF941F5"
 msgid "Let us spend the day together, for here in the warmth of this water we can sing again for hours."
-msgstr ""
+msgstr "Pasemos el día juntos, porque aquí, en el calor de esta agua, podemos cantar de nuevo durante horas."
 
 #. Key:	FE908E8B4214DDCF1709D284DCA9D0E1
 #. SourceLocation:	/Game/Dialogue/Cassie/SexScenes/CassieButterButtF.Default__CassieButterButtF_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Cassie/SexScenes/CassieButterButtF.Default__CassieButterButtF_C.SessionData.Lines(1).Lines
 msgctxt ",FE908E8B4214DDCF1709D284DCA9D0E1"
 msgid "*Purr*"
-msgstr "*Ronroneo*"
+msgstr "*Ronronea*"
 
 #. Key:	FE9D2CEF44200883BEC34F94279CA502
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcGreeting01.Default__OrcGreeting01_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcGreeting01.Default__OrcGreeting01_C.SessionData.Lines(2).Lines
 msgctxt ",FE9D2CEF44200883BEC34F94279CA502"
 msgid "My tribe very horny, need elves for breeding."
-msgstr ""
+msgstr "Mi tribu muy cachonda, necesito elfos para reproducirnos."
 
 #. Key:	FEB03B36414C543E3D3737B9AB198545
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimePlay1.Default__MegaSlimePlay1_C.SessionData.LinesToFemale(2).LinesToFemale
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePlay1.Default__MegaSlimePlay1_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",FEB03B36414C543E3D3737B9AB198545"
 msgid "*Yawn* Might need a nap after we make love again."
-msgstr ""
+msgstr "*Bosteza* Puede que necesite una siesta después de que hagamos el amor de nuevo."
 
 #. Key:	FEB3BE874AC81C2B63FD03953371A656
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeVerySad.Default__MegaSlimeVerySad_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeVerySad.Default__MegaSlimeVerySad_C.SessionData.Lines(2).Lines
 msgctxt ",FEB3BE874AC81C2B63FD03953371A656"
 msgid "Who would... after years of loneliness... *sniff*"
-msgstr ""
+msgstr "¿Quién... después de años de soledad... *olfatea*"
 
 #. Key:	FEE6416B44C40270EC8167ADD51EA060
 #. SourceLocation:	/Game/Dialogue/Mirru/SexScenes/MirruKrakVag.Default__MirruKrakVag_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Mirru/SexScenes/MirruKrakVag.Default__MirruKrakVag_C.SessionData.Lines(0).Lines
 msgctxt ",FEE6416B44C40270EC8167ADD51EA060"
 msgid "Ohhh human yes... my soft fleshy groin awaits you."
-msgstr "Ohhh humana sí ... mi suave y carnosa ingle te espera."
+msgstr "Ohhh, humano, sí... mi suave y carnosa ingle te espera."
 
 #. Key:	FEEAD6AA4B91EE463E366FBDCB397167
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_AboutKrakens.Default__MirruDefault01_AboutKrakens_C.SessionData.Lines(8).Lines
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_AboutKrakens.Default__MirruDefault01_AboutKrakens_C.SessionData.Lines(8).Lines
 msgctxt ",FEEAD6AA4B91EE463E366FBDCB397167"
 msgid "Even a drylander such as yourself can probably guess what purpose my two front tentacles serve."
-msgstr "Incluso alguien de secano como tú probablemente pueda adivinar para qué sirven mis dos tentáculos delanteros."
+msgstr "Incluso alguien de suelo firme como tú probablemente pueda adivinar para qué sirven mis dos tentáculos delanteros."
 
 #. Key:	FF0D5A0E4AD29A5B9CCF59942CB94FFA
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_RaiseTraitLvl.Default__EmissaryDefault01_RaiseTraitLvl_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_RaiseTraitLvl.Default__EmissaryDefault01_RaiseTraitLvl_C.SessionData.Lines(0).Lines
 msgctxt ",FF0D5A0E4AD29A5B9CCF59942CB94FFA"
 msgid "Seeketh thou a higher quality breeding stock I sense."
-msgstr "Busca un ganado reproductor de mayor calidad, presiento."
+msgstr "Presiento que buscas un ganado reproductor de mayor calidad."
 
 #. Key:	FF2AAC0145D999DF7D9EE5BBF54B6B50
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFuta(8).LinesToFuta
 #: /Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFuta(8).LinesToFuta
 msgctxt ",FF2AAC0145D999DF7D9EE5BBF54B6B50"
 msgid "That must have been you, perhaps you should go and talk to her."
-msgstr ""
+msgstr "Debes haber sido tú, quizás deberías ir a hablar con ella."
 
 #. Key:	FF350C0E49A57126AB07218CBF432744
 #. SourceLocation:	/Game/UI/TaskDescriptions.TaskDescriptions.TextEntries(9).TextEntries
 #: /Game/UI/TaskDescriptions.TaskDescriptions.TextEntries(9).TextEntries
 msgctxt ",FF350C0E49A57126AB07218CBF432744"
 msgid "The Void gets dull when you have wandered it for countless millennia, and it's been awhile since I wrapped my body around a helpless mate. Could you make me a new toy to squeeze?  -Neela"
-msgstr ""
+msgstr "El Vacío se vuelve aburrido cuando lo has vagado durante incontables milenios, y ha pasado un tiempo desde que envolví mi cuerpo alrededor de un compañero indefenso. ¿Podrías hacerme un juguete nuevo para exprimir? -Neela"
 
 #. Key:	FF56CAFF482C5F43FF4C419DCB359C8A
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R06.Default__CamillaDefault01_R06_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R06.Default__CamillaDefault01_R06_C.SessionData.Lines(0).Lines
 msgctxt ",FF56CAFF482C5F43FF4C419DCB359C8A"
 msgid "Mean human! Girthy little lumps have feelings too!"
-msgstr "¡Humana mala! ¡ Los pequeño bultos circunscritos también tienen sentimientos!"
+msgstr "¡Humano mezquino! ¡ Los pequeño bultos orondos también tienen sentimientos!"
 
 #. Key:	FF5A245B4A28E802C1A30CAC4B4DE4E5
 #. SourceLocation:	/Game/Characters/Procedural/Variants/Seraphim/Harvest/SeraphimHarvest.Default__SeraphimHarvest_C.Harvest.Description
@@ -13885,21 +13974,22 @@ msgstr "Fluidos corporales de Serafín."
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(5).LinesToMale
 msgctxt ",FFA17F124A05F93244CA07860B63DEA2"
 msgid "Oh silly me, I never introduced myself."
-msgstr "Oh tonta de mí, nunca me presenté."
+msgstr "Oh, tonta de mí, nunca me presenté."
 
 #. Key:	FFEB9256402DB5ADDFEED38770F40285
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(24 - Value).TraitIcons.HelpText
-#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(24 - Value).TraitIcons.HelpText
+#: /Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(24 -
+#: Value).TraitIcons.HelpText
 msgctxt ",FFEB9256402DB5ADDFEED38770F40285"
 msgid "Busty: Inherited very large breasts."
-msgstr "Tetona: Heredó unos senos muy grandes."
+msgstr "Tetona: heredó unos pechos muy grandes."
 
 #. Key:	FFF6AE0C41E39194F413A28DAC8CD9F5
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiAreYouOk.Default__FesssiAreYouOk_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiAreYouOk.Default__FesssiAreYouOk_C.SessionData.Lines(1).Lines
 msgctxt ",FFF6AE0C41E39194F413A28DAC8CD9F5"
 msgid "Give into your desires human. I know you want to mate with all of thisss."
-msgstr ""
+msgstr "Cede a tus deseos humanos. Sé que quieres emparejarte con todo esssto."
 
 #. Key:	SpiritFormActivate
 #. SourceLocation:	Source/Radiant/Public/Characters/SexyBreederCharacter.cpp:200
@@ -13927,21 +14017,21 @@ msgstr "No hay suficiente espíritu."
 #: Source/Radiant/Public/Characters/Breeder/SexyBreederController.cpp:784
 msgctxt "ASexyBreederController,NoKeystones"
 msgid "A keystone is required."
-msgstr ""
+msgstr "Se requiere una piedra-llave."
 
 #. Key:	IncestDisabledMessage
 #. SourceLocation:	Source/Radiant/Public/Game/Monsters/SexyBreedingSystem.cpp:399
 #: Source/Radiant/Public/Game/Monsters/SexyBreedingSystem.cpp:399
 msgctxt "ASexyBreedingSystem,IncestDisabledMessage"
 msgid "Incest is not allowed."
-msgstr ""
+msgstr "No se permite el incesto."
 
 #. Key:	IncestMessage
 #. SourceLocation:	Source/Radiant/Public/Game/Monsters/SexyBreedingSystem.cpp:451
 #: Source/Radiant/Public/Game/Monsters/SexyBreedingSystem.cpp:451
 msgctxt "ASexyBreedingSystem,IncestMessage"
 msgid "This might not turn out well..."
-msgstr "Esto podría acabar mal..."
+msgstr "Puede que esto no salga bien..."
 
 #. Key:	ReleasedOffspring
 #. SourceLocation:	Source/Radiant/Public/Game/Monsters/SexyBreedingSystem.cpp:679
@@ -13955,56 +14045,56 @@ msgstr "Descendencia liberada en la naturaleza."
 #: Source/Radiant/Public/Characters/SexyCharacterSystem.cpp:2134
 msgctxt "ASexyCharacterSystem,BadSettingsMessage"
 msgid "Both female hominal and exotic variants are disabled, default will be used."
-msgstr "Tanto las variantes humanoides como las exóticas están deshabilitadas, se usarán las de por defecto."
+msgstr "Tanto las variantes femeninas humanoides como las exóticas están deshabilitadas, se utilizarán las predeterminadas."
 
 #. Key:	SaveBreeder
 #. SourceLocation:	Source/Radiant/Public/Characters/SexyCharacterSystem.cpp:3220
 #: Source/Radiant/Public/Characters/SexyCharacterSystem.cpp:3220
 msgctxt "ASexyCharacterSystem,SaveBreeder"
 msgid "Appearance has been saved."
-msgstr ""
+msgstr "La apariencia se ha guardado."
 
 #. Key:	SpiritForm
 #. SourceLocation:	Source/Radiant/Public/Characters/SexyCharacterSystem.cpp:3236
 #: Source/Radiant/Public/Characters/SexyCharacterSystem.cpp:3236
 msgctxt "ASexyCharacterSystem,SpiritForm"
 msgid "Spirit form has been saved."
-msgstr "Forma espiritual se ha guardado."
+msgstr "La forma espiritual ha sido guardada."
 
 #. Key:	EndlessDaze
 #. SourceLocation:	Source/Radiant/Public/World/SexyDazeSystem.cpp:124
 #: Source/Radiant/Public/World/SexyDazeSystem.cpp:124
 msgctxt "ASexyDazeSystem,EndlessDaze"
 msgid "{0} has lost conciousness..."
-msgstr ""
+msgstr "{0} ha perdido el conocimiento..."
 
 #. Key:	ReaperToll
 #. SourceLocation:	Source/Radiant/Public/World/SexyDazeSystem.cpp:155
 #: Source/Radiant/Public/World/SexyDazeSystem.cpp:155
 msgctxt "ASexyDazeSystem,ReaperToll"
 msgid "The Reaper will have her toll..."
-msgstr ""
+msgstr "La Segadora tendrá su peaje..."
 
 #. Key:	NoFuta
 #. SourceLocation:	Source/Radiant/Public/Game/Monsters/SexyMonsterSystem.cpp:875
 #: Source/Radiant/Public/Game/Monsters/SexyMonsterSystem.cpp:875
 msgctxt "ASexyDialogueSystem,NoFuta"
 msgid "Futa is disabled."
-msgstr "Futas están deshabilitadas."
+msgstr "Las futas están deshabilitadas."
 
 #. Key:	PostBreedingTask
 #. SourceLocation:	Source/Radiant/Public/Characters/Dialogue/SexyDialogueSystem.cpp:357
 #: Source/Radiant/Public/Characters/Dialogue/SexyDialogueSystem.cpp:357
 msgctxt "ASexyDialogueSystem,PostBreedingTask"
 msgid "A special breeding task has been added."
-msgstr ""
+msgstr "Se ha añadido una tarea de reproducción especial."
 
 #. Key:	SpiritForm
 #. SourceLocation:	Source/Radiant/Public/Game/SexyGameMode.cpp:361
 #: Source/Radiant/Public/Game/SexyGameMode.cpp:361
 msgctxt "ASexyGameMode,SpiritForm"
 msgid "Spirit form has been unlocked."
-msgstr "Forma espiritual ha sido desbloqueada."
+msgstr "La forma espiritual ha sido desbloqueada."
 
 #. Key:	MoreFavor
 #. SourceLocation:	Source/Radiant/Public/Economy/SexyMerchantSystem.cpp:471
@@ -14025,7 +14115,7 @@ msgstr "Se requiere Lujúria."
 #: Source/Radiant/Public/Game/Monsters/SexyMonsterSystem.cpp:1394
 msgctxt "ASexyMonsterSystem,FernThanks"
 msgid "Fern gave {0} 150 shiny."
-msgstr "Helecho dio a {0} 150 brillantes."
+msgstr "Fern dio a {0} 150 brillantes."
 
 #. Key:	LearnedPosition
 #. SourceLocation:	Source/Radiant/Public/Game/Monsters/SexyMonsterSystem.cpp:1456
@@ -14053,7 +14143,7 @@ msgstr "Escena futa omitida, posición sexual aprendida."
 #: Source/Radiant/Public/World/SexyOverworldInterface.cpp:263
 msgctxt "ASexyOverworldInterface,Breaks"
 msgid "Virgin Breaks"
-msgstr "Acantilados Vírgenes"
+msgstr "Rupturas Vírgenes"
 
 #. Key:	Cavern
 #. SourceLocation:	Source/Radiant/Public/World/SexyOverworldInterface.cpp:279
@@ -14067,28 +14157,28 @@ msgstr "Reliquias Amorosas"
 #: Source/Radiant/Public/World/SexyOverworldInterface.cpp:271
 msgctxt "ASexyOverworldInterface,ClimaxPeak"
 msgid "Climax Peak"
-msgstr "Pico de Climax"
+msgstr "Cumbre del Clímax"
 
 #. Key:	Cove
 #. SourceLocation:	Source/Radiant/Public/World/SexyOverworldInterface.cpp:247
 #: Source/Radiant/Public/World/SexyOverworldInterface.cpp:247
 msgctxt "ASexyOverworldInterface,Cove"
 msgid "Cove of Rapture"
-msgstr "Ensenada del Rapto"
+msgstr "Ensenada del Éxtasis"
 
 #. Key:	Crag
 #. SourceLocation:	Source/Radiant/Public/World/SexyOverworldInterface.cpp:287
 #: Source/Radiant/Public/World/SexyOverworldInterface.cpp:287
 msgctxt "ASexyOverworldInterface,Crag"
 msgid "Moaning Crag"
-msgstr "Peñasco Gimiente"
+msgstr "Risco Gimiente"
 
 #. Key:	Garden
 #. SourceLocation:	Source/Radiant/Public/World/SexyOverworldInterface.cpp:223
 #: Source/Radiant/Public/World/SexyOverworldInterface.cpp:223
 msgctxt "ASexyOverworldInterface,Garden"
 msgid "Hivelands"
-msgstr "Colmenas"
+msgstr "Tierras-Colmena"
 
 #. Key:	Glade
 #. SourceLocation:	Source/Radiant/Public/World/SexyOverworldInterface.cpp:255
@@ -14109,7 +14199,7 @@ msgstr "Municipio de Hedon"
 #: Source/Radiant/Public/World/SexyOverworldInterface.cpp:207
 msgctxt "ASexyOverworldInterface,Homestead"
 msgid "Homestead"
-msgstr "Caserío"
+msgstr "Granja"
 
 #. Key:	Jungle
 #. SourceLocation:	Source/Radiant/Public/World/SexyOverworldInterface.cpp:231
@@ -14137,7 +14227,7 @@ msgstr "Pastos del Placer"
 #: Source/Radiant/Public/World/SexyOverworldInterface.cpp:239
 msgctxt "ASexyOverworldInterface,Sands"
 msgid "Lewd Desert"
-msgstr ""
+msgstr "Desierto Lascivo"
 
 #. Key:	BoringCum
 #. SourceLocation:	Source/Radiant/Public/Game/Monsters/SexyRoamingSystem.cpp:903
@@ -14151,28 +14241,28 @@ msgstr "Ella quería más..."
 #: Source/Radiant/Public/Game/Monsters/SexyRoamingSystem.cpp:903
 msgctxt "ASexyRoamingSystem,BreederBoringCum"
 msgid "The wild one wanted more..."
-msgstr "El/La salvaje quería más..."
+msgstr "El silvestre quería más..."
 
 #. Key:	BreederClimaxedFirst
 #. SourceLocation:	Source/Radiant/Public/Game/Monsters/SexyRoamingSystem.cpp:909
 #: Source/Radiant/Public/Game/Monsters/SexyRoamingSystem.cpp:909
 msgctxt "ASexyRoamingSystem,BreederClimaxedFirst"
 msgid "{0} has climaxed first..."
-msgstr "{0} ha llegado al clímax primero..."
+msgstr "{0} alcanzó el clímax primero..."
 
 #. Key:	BreederLikedCum
 #. SourceLocation:	Source/Radiant/Public/Game/Monsters/SexyRoamingSystem.cpp:896
 #: Source/Radiant/Public/Game/Monsters/SexyRoamingSystem.cpp:896
 msgctxt "ASexyRoamingSystem,BreederLikedCum"
 msgid "The wild one is pleased!"
-msgstr "¡El/La salvaje está contento/a!"
+msgstr "¡El silvestre está complacido!"
 
 #. Key:	CatchSuccess
 #. SourceLocation:	Source/Radiant/Public/Game/Monsters/SexyRoamingSystem.cpp:1115
 #: Source/Radiant/Public/Game/Monsters/SexyRoamingSystem.cpp:1115
 msgctxt "ASexyRoamingSystem,CatchSuccess"
 msgid "The wild one has been captured."
-msgstr "El/La salvaje ha sido capturado/a."
+msgstr "El silvestre ha sido capturado."
 
 #. Key:	LikedCum
 #. SourceLocation:	Source/Radiant/Public/Game/Monsters/SexyRoamingSystem.cpp:897
@@ -14186,7 +14276,7 @@ msgstr "¡A ella le encanta cómo sabe {0}!"
 #: Source/Radiant/Public/Game/Monsters/SexyRoamingSystem.cpp:745
 msgctxt "ASexyRoamingSystem,RBJStart"
 msgid "Spontaneous Blow Job!"
-msgstr "¡Mamada espontánea!"
+msgstr "¡Mamada Espontánea!"
 
 #. Key:	SurpriseSexStart
 #. SourceLocation:	Source/Radiant/Public/Game/Monsters/SexyRoamingSystem.cpp:745
@@ -14200,7 +14290,7 @@ msgstr "¡Sexo Sorpresa!"
 #: Source/Radiant/Public/Game/Monsters/SexyRoamingSystem.cpp:909
 msgctxt "ASexyRoamingSystem,SurpriseSexSuccess"
 msgid "The wild one has climaxed first!"
-msgstr "¡El/La salvaje ha llegado al clímax primero!"
+msgstr "¡El silvestre alcanzó el clímax primero!"
 
 #. Key:	SameShrine
 #. SourceLocation:	Source/Radiant/Public/World/Travel/SexyTravelSystem.cpp:162
@@ -14214,237 +14304,245 @@ msgstr "Ya estas aquí."
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:656
 msgctxt "ASexyWorldSystem,DMMilkMateTask"
 msgid "Quench my thirst for creamy Bovaur breast milk, and perhaps it will restore my energy."
-msgstr ""
+msgstr "Apaga mi sed en la cremosa leche materna de bovaur, y tal vez me devuelva la energía."
 
 #. Key:	DMMilkTaskReward
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:655
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:655
 msgctxt "ASexyWorldSystem,DMMilkTaskReward"
 msgid "The Dragon Matriarch wishes to speak with you."
-msgstr ""
+msgstr "La Matriarca Dragón desea hablar contigo."
 
 #. Key:	DMMilkTitle
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:654
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:654
 msgctxt "ASexyWorldSystem,DMMilkTitle"
 msgid "Milk for the Matriarch"
-msgstr ""
+msgstr "Leche para la Matriarca"
 
 #. Key:	DragonSemenMateTask
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:599
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:599
 msgctxt "ASexyWorldSystem,DragonSemenMateTask"
 msgid "I require dragon semen in order to make the flowers grow in the Hivelands."
-msgstr ""
+msgstr "Necesito semen de dragón para hacer crecer las flores en las Tierras-Colmena."
 
 #. Key:	DragonSemenTaskReward
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:598
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:598
 msgctxt "ASexyWorldSystem,DragonSemenTaskReward"
 msgid "The Queen Bee wishes to speak with you."
-msgstr ""
+msgstr "La Abeja Reina desea hablar contigo."
 
 #. Key:	DragonSemenTitle
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:597
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:597
 msgctxt "ASexyWorldSystem,DragonSemenTitle"
 msgid "Semen Flowers"
-msgstr ""
+msgstr "Flores de Semen"
 
 #. Key:	DryadMateTask
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:645
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:645
 msgctxt "ASexyWorldSystem,DryadMateTask"
 msgid "If you would, breed me a lusty little honey bee. She can \"pollinate\" me all day, and I can produce more bosom cherries for my adorable cows."
-msgstr ""
+msgstr "Si quieres, críame una pequeña abeja de la miel lujuriosa. Ella puede \"polinizarme\" todo el día y yo puedo producir más cerezas para mis adorables vacas."
 
 #. Key:	DryadMateTaskReward
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:643
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:643
 msgctxt "ASexyWorldSystem,DryadMateTaskReward"
 msgid "Autumn wishes to speak with you."
-msgstr ""
+msgstr "Autumn desea hablar contigo."
 
 #. Key:	DryadMateTitle
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:642
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:642
 msgctxt "ASexyWorldSystem,DryadMateTitle"
 msgid "Autumn's Honey Bee"
-msgstr ""
+msgstr "Abeja de la Miel de Autumn"
 
 #. Key:	FessiTitanTask
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:682
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:682
 msgctxt "ASexyWorldSystem,FessiTitanTask"
 msgid "Sexy human, my goddess hindquarters have rendered me sssstuck. Breed me a strong Titan capable of freeing me from my cave. Hiss!"
-msgstr ""
+msgstr "Sexy humano, mis cuartos traseros de diosa me han dejado atasssscada. Críame un titán fuerte capaz de liberarme de mi cueva. ¡Sss!"
 
 #. Key:	FesssiTitan
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:679
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:679
 msgctxt "ASexyWorldSystem,FesssiTitan"
 msgid "Fat Ass Fesssi's Titan"
-msgstr ""
+msgstr "Titán de Fesssi Culo Gordo"
 
 #. Key:	FesssiTitanTaskReward
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:680
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:680
 msgctxt "ASexyWorldSystem,FesssiTitanTaskReward"
 msgid "Fesssi wishes to speak with you."
-msgstr ""
+msgstr "Fesssi desea hablar contigo."
 
 #. Key:	KybeleMateTaskF
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:508
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:508
 msgctxt "ASexyWorldSystem,KybeleMateTaskF"
 msgid "Bring to me a Vulwarg with a large soft ass! I wish feel her cushion as I thrust my cock deep and plant my seed in her body."
-msgstr ""
+msgstr "¡Tráeme una vulwarg con un culo grande y suave! Deseo sentir su cojín mientras empujo mi polla profundamente y planto mi semilla en su cuerpo."
 
 #. Key:	KybeleMateTaskReward
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:504
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:504
 msgctxt "ASexyWorldSystem,KybeleMateTaskReward"
 msgid "Kybele wishes to speak with you."
-msgstr ""
+msgstr "Kybele desea hablar contigo."
 
 #. Key:	KybeleMateTaskT
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:512
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:512
 msgctxt "ASexyWorldSystem,KybeleMateTaskT"
 msgid "Bring to me a Vulwarg with massive muscles! I wish feel like I'm being mounted by a mighty stallion."
-msgstr ""
+msgstr "¡Tráeme un vulwarg con músculos inmensos! Ojalá me sintiera como si me estuviera montando un poderoso semental."
 
 #. Key:	KybeleMateTitle
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:503
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:503
 msgctxt "ASexyWorldSystem,KybeleMateTitle"
 msgid "Kybele's Mighty Mate"
-msgstr ""
+msgstr "La Poderosa Pareja de Kybele"
 
 #. Key:	MilkFluid
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:424
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:424
 msgctxt "ASexyWorldSystem,MilkFluid"
 msgid "Milk"
-msgstr ""
+msgstr "Leche"
 
 #. Key:	MonarchMateTask
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:587
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:587
 msgctxt "ASexyWorldSystem,MonarchMateTask"
 msgid "Uh... please b-b-breed me an adorable Foxen that is fast enough to collect nectar for me. Thank you!"
-msgstr ""
+msgstr "Uh... por favor c-c-críame un adorable foxen que sea lo suficientemente rápido como para recolectar néctar para mí. ¡Gracias!"
 
 #. Key:	MonarchMateTaskReward
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:585
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:585
 msgctxt "ASexyWorldSystem,MonarchMateTaskReward"
 msgid "Monarch wishes to speak with you."
-msgstr ""
+msgstr "Monarch desea hablar contigo."
 
 #. Key:	MonarchMateTitle
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:584
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:584
 msgctxt "ASexyWorldSystem,MonarchMateTitle"
 msgid "Monarch's Swift Helper"
-msgstr ""
+msgstr "Ayudante Veloz de Monarch"
 
 #. Key:	NotEnoughMilk
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:796
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:796
 msgctxt "ASexyWorldSystem,NotEnoughMilk"
 msgid "More milk is required."
-msgstr ""
+msgstr "Se requiere más leche."
 
 #. Key:	NotEnoughSemen
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:804
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:804
 msgctxt "ASexyWorldSystem,NotEnoughSemen"
 msgid "More semen is required."
-msgstr ""
+msgstr "Se requiere más semen."
 
 #. Key:	OrcMate
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:730
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:730
 msgctxt "ASexyWorldSystem,OrcMate"
 msgid "Toy for the Tribe"
-msgstr ""
+msgstr "Juguete para la Tribu"
 
 #. Key:	OrcMateTask
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:733
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:733
 msgctxt "ASexyWorldSystem,OrcMateTask"
 msgid "Grrr! Breed us a fertile female! We want strong offspring."
-msgstr ""
+msgstr "¡Grrr! ¡Críanos una hembra fértil! Queremos descendencia fuerte."
 
 #. Key:	OrcMateTaskReward
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:731
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:731
 msgctxt "ASexyWorldSystem,OrcMateTaskReward"
 msgid "Chieftain Xena wishes to speak with you."
-msgstr ""
+msgstr "La Chieftain Xena desea hablar contigo."
 
 #. Key:	PetraMate
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:753
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:753
 msgctxt "ASexyWorldSystem,PetraMate"
 msgid "Practice Dragon"
-msgstr ""
+msgstr "Dragón de Práctica"
 
 #. Key:	PetraMateTask
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:756
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:756
 msgctxt "ASexyWorldSystem,PetraMateTask"
 msgid "Pawsmaati gave me the task of practicing her lesson with a \"winged mountain maiden\"!"
-msgstr ""
+msgstr "¡Pawsmaati me dio la tarea de practicar su lección con una \"doncella de la montaña alada\"!"
 
 #. Key:	PetraMateTaskReward
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:754
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:754
 msgctxt "ASexyWorldSystem,PetraMateTaskReward"
 msgid "Petra wishes to speak with you."
-msgstr ""
+msgstr "Petra desea hablar contigo."
 
 #. Key:	SemenFluid
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:411
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:411
 msgctxt "ASexyWorldSystem,SemenFluid"
 msgid "Semen"
-msgstr ""
+msgstr "Semen"
 
 #. Key:	TaskFullfilled
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:869
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:869
 msgctxt "ASexyWorldSystem,TaskFullfilled"
 msgid "Task fulfilled."
-msgstr ""
+msgstr "Tarea cumplida."
 
 #. Key:	TaskRefresh
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:264
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:264
 msgctxt "ASexyWorldSystem,TaskRefresh"
 msgid "New breeding requests have arrived."
-msgstr "Nuevas solicitudes de cría han llegado."
+msgstr "Han llegado nuevas solicitudes de reproducción."
 
 #. Key:	TraitRequirement
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:460
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:460
 msgctxt "ASexyWorldSystem,TraitRequirement"
-msgid "{0}\n{1}\n{2}"
+msgid ""
+"{0}\n"
+"{1}\n"
+"{2}"
 msgstr ""
 
 #. Key:	TraitRequirementFluid
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:427
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:427
 msgctxt "ASexyWorldSystem,TraitRequirementFluid"
-msgid "{0} {1}\n{2}ml\n"
+msgid ""
+"{0} {1}\n"
+"{2}ml\n"
 msgstr ""
 
 #. Key:	TraitRequirementStat
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:456
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:456
 msgctxt "ASexyWorldSystem,TraitRequirementStat"
-msgid "{0}\n{1}\n{2}{3}"
+msgid ""
+"{0}\n"
+"{1}\n"
+"{2}{3}"
 msgstr ""
 
 #. Key:	WidowElf
@@ -14452,21 +14550,21 @@ msgstr ""
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:707
 msgctxt "ASexyWorldSystem,WidowElf"
 msgid "Widow's Juicy Elf"
-msgstr ""
+msgstr "Elfa Jugosa de Widow"
 
 #. Key:	WidowElfTask
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:710
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:710
 msgctxt "ASexyWorldSystem,WidowElfTask"
 msgid "This lonely spider wishes for her own personal elf, both as a mate and a tasty morsel."
-msgstr ""
+msgstr "Esta araña solitaria desea tener su propia elfa personal, tanto como compañera como como un sabroso bocado."
 
 #. Key:	WidowElfTaskReward
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:708
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:708
 msgctxt "ASexyWorldSystem,WidowElfTaskReward"
 msgid "Widow wishes to speak with you."
-msgstr ""
+msgstr "Widow desea hablar contigo."
 
 #. Key:	Activate
 #. SourceLocation:	Source/Radiant/Public/Characters/SexyBreederCharacter.cpp:139
@@ -14487,7 +14585,7 @@ msgstr "Descripción"
 #: Source/Radiant/Public/UI/Components/SexyBarnActionDetails.cpp:33
 msgctxt "BarnActionDetails,HarvestDesc"
 msgid "Select an action and then press Start."
-msgstr "Seleccione una acción y luego presione Inicio."
+msgstr "Selecciona una acción y luego presiona Inicio."
 
 #. Key:	AdvanceButtonTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:108
@@ -14508,7 +14606,7 @@ msgstr "Omitir"
 #: Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:101
 msgctxt "BreedingSession,BreedButtonTooltip"
 msgid "Skip the rest of the scene, offspring may still be produced."
-msgstr "Omitir el resto de la escena, descendencia aún puede ser producida."
+msgstr "Omitir el resto de la escena, la descendencia aún puede ser producida."
 
 #. Key:	DebugTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:186
@@ -14529,21 +14627,21 @@ msgstr "Barriga"
 #: Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:296
 msgctxt "BreedingSession,IKDick"
 msgid "Dick"
-msgstr "Polla"
+msgstr "Pene"
 
 #. Key:	IKDickSpline
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:308
 #: Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:308
 msgctxt "BreedingSession,IKDickSpline"
 msgid "P,L,S C,T,V"
-msgstr "P,L,S C,T,V"
+msgstr ""
 
 #. Key:	IKGiver
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:209
 #: Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:209
 msgctxt "BreedingSession,IKGiver"
 msgid "Giver"
-msgstr "Dador/a"
+msgstr "Donante"
 
 #. Key:	IKHips
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:350
@@ -14557,21 +14655,21 @@ msgstr "Caderas"
 #: Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:265
 msgctxt "BreedingSession,IKLHand"
 msgid "Hand L"
-msgstr "Mano L"
+msgstr "Mano Izq"
 
 #. Key:	IKLHandTarget
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:277
 #: Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:277
 msgctxt "BreedingSession,IKLHandTarget"
 msgid "Arm PV L"
-msgstr "Bravo PV L"
+msgstr "Brazo PV Izq"
 
 #. Key:	IKLLeg
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:419
 #: Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:419
 msgctxt "BreedingSession,IKLLeg"
 msgid "Leg L"
-msgstr "Pierna L"
+msgstr "Pierna Izq"
 
 #. Key:	IKReceiver
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:209
@@ -14585,21 +14683,21 @@ msgstr "Receptora"
 #: Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:241
 msgctxt "BreedingSession,IKRHand"
 msgid "Hand R"
-msgstr "Mano R"
+msgstr "Mano Dcha"
 
 #. Key:	IKRHandTarget
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:253
 #: Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:253
 msgctxt "BreedingSession,IKRHandTarget"
 msgid "Arm PV R"
-msgstr "Brazo PV R"
+msgstr "Brazo PV Dcho"
 
 #. Key:	IKRLeg
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:407
 #: Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:407
 msgctxt "BreedingSession,IKRLeg"
 msgid "Leg R"
-msgstr "Pierna R"
+msgstr "Pierna Dcha"
 
 #. Key:	IKRoot
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:222
@@ -14634,7 +14732,7 @@ msgstr "Sostén"
 #: Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:179
 msgctxt "BreedingSession,SaveGiverTitle"
 msgid "Save Giver"
-msgstr "Guardar Dador/a"
+msgstr "Guardar Donante"
 
 #. Key:	SaveReceiverTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:193
@@ -14648,14 +14746,14 @@ msgstr "Guardar Receptora"
 #: Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:450
 msgctxt "BreedingSession,SemenPool"
 msgid "Semen Pool"
-msgstr "Piscina de Semen"
+msgstr "Reserva de Semen"
 
 #. Key:	SkipButtonTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:109
 #: Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:109
 msgctxt "BreedingSession,SkipButtonTooltip"
 msgid "Proceed to the next phase of this scene."
-msgstr "Pasa a la siguiente fase de esta escena."
+msgstr "Continúa con la siguiente fase de esta escena."
 
 #. Key:	SpeedTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:31
@@ -14676,14 +14774,14 @@ msgstr "Iniciar"
 #: Source/Radiant/Public/UI/Menus/SexyBreedingSetupMenu.cpp:76
 msgctxt "BreedingSetup,BreedButtonTooltip"
 msgid "Start a breeding scene with the currently selected mates and options."
-msgstr "Comience una escena de reproducción con los compañeros y opciones actualmente seleccionados."
+msgstr "Inicia una escena de reproducción con los compañeros y las opciones actualmente seleccionados."
 
 #. Key:	GiverWindowTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyBreedingSetupMenu.cpp:84
 #: Source/Radiant/Public/UI/Menus/SexyBreedingSetupMenu.cpp:84
 msgctxt "BreedingSetup,GiverWindowTitle"
 msgid "Select Giver"
-msgstr "Seleccionar Dador/a"
+msgstr "Seleccionar Donante"
 
 #. Key:	QuickButtonTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyBreedingSetupMenu.cpp:66
@@ -14697,7 +14795,7 @@ msgstr "Rápido"
 #: Source/Radiant/Public/UI/Menus/SexyBreedingSetupMenu.cpp:67
 msgctxt "BreedingSetup,QuickButtonTooltip"
 msgid "Breed this pair without starting a scene."
-msgstr "Reproducir este par sin comenzar una escena."
+msgstr "Reproducir esta pareja sin comenzar una escena."
 
 #. Key:	ReceiverWindowTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyBreedingSetupMenu.cpp:146
@@ -14718,21 +14816,21 @@ msgstr "Combinación de reproducción imposible."
 #: Source/Radiant/Public/Game/Monsters/SexyBreedingSystem.cpp:228
 msgctxt "BreedingSystem,NoFemaleGiver"
 msgid "Giver must be futa or male."
-msgstr "Dador/a debe ser futa o macho."
+msgstr "El donante debe ser futa o macho."
 
 #. Key:	NoGiver
 #. SourceLocation:	Source/Radiant/Public/Game/Monsters/SexyBreedingSystem.cpp:204
 #: Source/Radiant/Public/Game/Monsters/SexyBreedingSystem.cpp:204
 msgctxt "BreedingSystem,NoGiver"
 msgid "Giver must be selected."
-msgstr "Dador/a debe ser seleccionado/a."
+msgstr "El donante debe ser seleccionado."
 
 #. Key:	NoMaleReceiver
 #. SourceLocation:	Source/Radiant/Public/Game/Monsters/SexyBreedingSystem.cpp:223
 #: Source/Radiant/Public/Game/Monsters/SexyBreedingSystem.cpp:223
 msgctxt "BreedingSystem,NoMaleReceiver"
 msgid "Receiver must be female or futa."
-msgstr "Receptora debe ser hembra o futa."
+msgstr "La receptora debe ser hembra o futa."
 
 #. Key:	NoOffspring
 #. SourceLocation:	Source/Radiant/Public/Game/Monsters/SexyBreedingSystem.cpp:1019
@@ -14746,7 +14844,7 @@ msgstr "Sin descendencia esta vez..."
 #: Source/Radiant/Public/Game/Monsters/SexyBreedingSystem.cpp:209
 msgctxt "BreedingSystem,NoReceiver"
 msgid "Receiver must be selected."
-msgstr "Receptora debe ser seleccionada."
+msgstr "La receptora debe ser seleccionada."
 
 #. Key:	NoRoomOffspring
 #. SourceLocation:	Source/Radiant/Public/Game/Monsters/SexyBreedingSystem.cpp:1012
@@ -14774,7 +14872,7 @@ msgstr "Atractivo"
 #: Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:176
 msgctxt "CharacterDetails,AllureTooltip"
 msgid "Allure is a measure of the pheromones given off by this one."
-msgstr "El atractivo es una medida de las feromonas emitidas por éste/a."
+msgstr "El Atractivo es una medida de las feromonas emitidas por éste/a."
 
 #. Key:	Attributes
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:75
@@ -14795,7 +14893,7 @@ msgstr "Destreza"
 #: Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:192
 msgctxt "CharacterDetails,DexterityTooltip"
 msgid "Measures how quick and agile this one can be."
-msgstr "Mide cuán rápido y ágil puede ser este/a."
+msgstr "Mide cuán rápido y ágil puede ser este."
 
 #. Key:	Father
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:131
@@ -14809,7 +14907,7 @@ msgstr "Padre"
 #: Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:132
 msgctxt "CharacterDetails,FatherTooltip"
 msgid "The provider of the semen."
-msgstr "El/La proveedor/a del semen."
+msgstr "El proveedor del semen."
 
 #. Key:	Fertility
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:167
@@ -14823,7 +14921,7 @@ msgstr "Fertilidad"
 #: Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:168
 msgctxt "CharacterDetails,FertiliyTooltip"
 msgid "How likely it would be for this one to produce offspring."
-msgstr "Qué tan probable sería que este/a produjera descendencia."
+msgstr "Cuán probable sería que éste produjera descendencia."
 
 #. Key:	Level
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:151
@@ -14837,7 +14935,7 @@ msgstr "Nivel"
 #: Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:152
 msgctxt "CharacterDetails,LevelTooltip"
 msgid "Level represents how much power this one has absorbed through sexual activity."
-msgstr "El Nivel representa la cantidad de poder que este ha absorbido a través de actividades sexuales."
+msgstr "El Nivel representa cuánto poder ha absorbido este a través de la actividad sexual."
 
 #. Key:	Lifeforce
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:45
@@ -14851,7 +14949,7 @@ msgstr "Espíritu"
 #: Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:46
 msgctxt "CharacterDetails,LifeforceTooltip"
 msgid "Spirit energy. Used to transform into your spirit form."
-msgstr "Energía del Espíritu. Usada para transformarte en tu forma espiritual."
+msgstr "Energía espiritual. Se usa para transformarse en tu forma espiritual."
 
 #. Key:	Loyalty
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:52
@@ -14865,7 +14963,7 @@ msgstr "Lealtad"
 #: Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:53
 msgctxt "CharacterDetails,LoyaltyTooltip"
 msgid "How happy this one is to stay on your ranch."
-msgstr "Qué feliz es este/a de estar en tu rancho."
+msgstr "Qué feliz es éste de quedarse en tu rancho."
 
 #. Key:	Lust
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:37
@@ -14879,7 +14977,7 @@ msgstr "Lujuria"
 #: Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:38
 msgctxt "CharacterDetails,LustTooltip"
 msgid "Represents how horny this one has become. When lust reaches zero, sexual activity and most actions cannot be performed."
-msgstr "Representa lo cachondo/a que se ha vuelto este/a. Cuando la lujuria llega a cero, la actividad sexual y la mayoría de las acciones no se pueden realizar."
+msgstr "Representa lo cachondo que se ha vuelto este. Cuando la lujuria llega a cero, la actividad sexual y la mayoría de las acciones no se pueden realizar."
 
 #. Key:	Mother
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:123
@@ -14893,7 +14991,7 @@ msgstr "Madre"
 #: Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:124
 msgctxt "CharacterDetails,MotherTooltip"
 msgid "The female who summoned this one into the world."
-msgstr "La hembra que convocó a este/a al mundo."
+msgstr "La hembra que convocó a este al mundo."
 
 #. Key:	Pregnancy
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:66
@@ -14906,8 +15004,12 @@ msgstr "Embarazada"
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:67
 #: Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:67
 msgctxt "CharacterDetails,PregnancyTooltip"
-msgid "Progress toward summoning offspring.\nMilk production is doubled during pregnancy."
-msgstr "Progreso hacia la invocación de la descendencia.\nLa producción de leche se duplica durante el embarazo."
+msgid ""
+"Progress toward summoning offspring.\n"
+"Milk production is doubled during pregnancy."
+msgstr ""
+"Progreso hacia la invocación de la descendencia.\n"
+"La producción de leche se duplica durante el embarazo."
 
 #. Key:	Procreators
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:111
@@ -14928,7 +15030,7 @@ msgstr "Raza"
 #: Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:88
 msgctxt "CharacterDetails,RaceTooltip"
 msgid "The race this one belongs to."
-msgstr "La raza a la que este/a pertenece."
+msgstr "La raza a la que este pertenece."
 
 #. Key:	Sex
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:103
@@ -14942,7 +15044,7 @@ msgstr "Sexo"
 #: Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:104
 msgctxt "CharacterDetails,SexTooltip"
 msgid "What genetalia this one was born with."
-msgstr "Con qué genitales nació este/a."
+msgstr "Con qué genitales nació este."
 
 #. Key:	Stats
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:139
@@ -14963,7 +15065,7 @@ msgstr "Fuerza"
 #: Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:160
 msgctxt "CharacterDetails,StrengthTooltip"
 msgid "The physical strength of this one."
-msgstr "La fuerza física de este/a."
+msgstr "La fuerza física de este."
 
 #. Key:	Traits
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:207
@@ -14984,7 +15086,7 @@ msgstr "Valor"
 #: Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:200
 msgctxt "CharacterDetails,ValueTooltip"
 msgid "The net worth of this one, a result of stats and the rarity of its variant."
-msgstr "El valor neto de este/a, resultado de las estadísticas y la rareza de su variante."
+msgstr "El valor neto de este, resultado de las estadísticas y la rareza de su variante."
 
 #. Key:	Variant
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:95
@@ -14998,7 +15100,7 @@ msgstr "Variante"
 #: Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:96
 msgctxt "CharacterDetails,VariantTooltip"
 msgid "The morphology within this one's race."
-msgstr "La morfología dentro de la raza de este/a."
+msgstr "La morfología dentro de la raza de este."
 
 #. Key:	Willpower
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:183
@@ -15012,7 +15114,7 @@ msgstr "Fuerza de Voluntad"
 #: Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:184
 msgctxt "CharacterDetails,WillpowerTooltip"
 msgid "Willpower measures the ability of this one to control their lust."
-msgstr "La Fuerza de Voluntad mide la capacidad de éste/a para controlar su lujuria."
+msgstr "La Fuerza de Voluntad mide la capacidad de éste para controlar su lujuria."
 
 #. Key:	XP
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:59
@@ -15061,7 +15163,7 @@ msgstr "Atrás"
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:99
 msgctxt "CharacterEditor,BackButtonTooltip"
 msgid "Return to the previous screen."
-msgstr "Vuelve a la pantalla anterior."
+msgstr "Regresar a la pantalla anterior."
 
 #. Key:	BellyShape
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:351
@@ -15110,7 +15212,7 @@ msgstr "Calzado"
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:345
 msgctxt "CharacterEditor,BreastsShape"
 msgid "Breasts"
-msgstr "Senos"
+msgstr "Pechos"
 
 #. Key:	ButtShape
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:369
@@ -15130,8 +15232,12 @@ msgstr "Cancelar"
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:247
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:247
 msgctxt "CharacterEditor,ChangeSexTooltip"
-msgid "Change this character's sex.\nWARNING: This will overwrite the current appearance."
-msgstr "Cambia el sexo de este personaje.\nADVERTENCIA: Esto sobrescribirá la apariencia actual."
+msgid ""
+"Change this character's sex.\n"
+"WARNING: This will overwrite the current appearance."
+msgstr ""
+"Cambia el sexo de este personaje.\n"
+"ADVERTENCIA: Esto sobrescribirá la apariencia actual."
 
 #. Key:	ChooseAnimationTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:287
@@ -15159,14 +15265,18 @@ msgstr "Detalles"
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:519
 msgctxt "CharacterEditor,EditTraits"
 msgid "Traits and States"
-msgstr ""
+msgstr "Rasgos y Estados"
 
 #. Key:	ExoticTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:232
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:232
 msgctxt "CharacterEditor,ExoticTooltip"
-msgid "Give this character its exotic trait if one exists.\nWARNING: This will overwrite the current appearance."
-msgstr "Dale a este personaje su rasgo exótico si existe.\nADVERTENCIA: Esto sobrescribirá la apariencia actual."
+msgid ""
+"Give this character its exotic trait if one exists.\n"
+"WARNING: This will overwrite the current appearance."
+msgstr ""
+"Dale a este personaje su rasgo exótico si existe.\n"
+"ADVERTENCIA: Esto sobrescribirá la apariencia actual."
 
 #. Key:	EyebrowMaterial
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:402
@@ -15187,14 +15297,14 @@ msgstr "Ojos"
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:390
 msgctxt "CharacterEditor,FaceMaterial"
 msgid "Face"
-msgstr "Cara"
+msgstr "Rostro"
 
 #. Key:	FaceShape
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:327
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:327
 msgctxt "CharacterEditor,FaceShape"
 msgid "Face"
-msgstr "Cara"
+msgstr "Rostro"
 
 #. Key:	FullBodyShape
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:333
@@ -15243,14 +15353,18 @@ msgstr "Genitales"
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:438
 msgctxt "CharacterEditor,HairMaterial"
 msgid "Hair"
-msgstr "Pelo"
+msgstr "Cabello"
 
 #. Key:	HominalTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:224
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:224
 msgctxt "CharacterEditor,HominalTooltip"
-msgid "Give this character its hominal trait if one exists.\nWARNING: This will overwrite the current appearance."
-msgstr "Dale a este personaje su rasgo humanoide si existe.\nADVERTENCIA: Esto sobrescribirá la apariencia actual."
+msgid ""
+"Give this character its hominal trait if one exists.\n"
+"WARNING: This will overwrite the current appearance."
+msgstr ""
+"Dale a este personaje su rasgo humanoide si existe.\n"
+"ADVERTENCIA: Esto sobrescribirá la apariencia actual."
 
 #. Key:	LeaveButton
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:126
@@ -15264,14 +15378,18 @@ msgstr "Salir"
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:127
 msgctxt "CharacterEditor,LeaveButtonTooltip"
 msgid "Exit the editor. Unsaved changes will be lost."
-msgstr ""
+msgstr "Sal del editor. Los cambios no guardados se perderán."
 
 #. Key:	LoadUsrPresetTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:175
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:175
 msgctxt "CharacterEditor,LoadUsrPresetTooltip"
-msgid "Load a saved preset.\nWARNING: This will overwrite the current appearance."
-msgstr "Carga un preajuste guardado.\nADVERTENCIA: Esto sobrescribirá la apariencia actual."
+msgid ""
+"Load a saved preset.\n"
+"WARNING: This will overwrite the current appearance."
+msgstr ""
+"Cargar un preajuste guardado.\n"
+"ADVERTENCIA: Esto sobrescribirá la apariencia actual."
 
 #. Key:	LowerBodyShape
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:357
@@ -15326,15 +15444,19 @@ msgstr "Pezones"
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:201
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:201
 msgctxt "CharacterEditor,PasteTooltip"
-msgid "Paste copied data.\nWARNING: This will overwrite the selected category, and might look terrible on different variants."
+msgid ""
+"Paste copied data.\n"
+"WARNING: This will overwrite the selected category, and might look terrible on different variants."
 msgstr ""
+"Pega los datos copiados.\n"
+"ADVERTENCIA: Esto sobrescribirá la categoría seleccionada y podría verse terrible en diferentes variantes."
 
 #. Key:	PresetFlags
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:513
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:513
 msgctxt "CharacterEditor,PresetFlags"
 msgid "Flags"
-msgstr ""
+msgstr "Banderas"
 
 #. Key:	PresetNameTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:527
@@ -15355,7 +15477,7 @@ msgstr "Renombrar a este personaje."
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:155
 msgctxt "CharacterEditor,SaveBreederTooltip"
 msgid "Save current appearance."
-msgstr ""
+msgstr "Guardar apariencia actual."
 
 #. Key:	SaveButton
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:557
@@ -15376,7 +15498,7 @@ msgstr "Guardar la apariencia actual como un preajuste."
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:163
 msgctxt "CharacterEditor,SaveSpiritTooltip"
 msgid "Save this as your spirit form."
-msgstr "Guarda esta como tu forma espiritual."
+msgstr "Guardar esta como tu forma espiritual."
 
 #. Key:	ShapeWindowTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:320
@@ -15411,14 +15533,14 @@ msgstr "Alternar la vinculación de valores similares o reflejados."
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:272
 msgctxt "CharacterEditor,ToggleUnderwearTooltip"
 msgid "Toggle only underwear."
-msgstr "Alternar sólo la ropa interior."
+msgstr "Alternar sólo la Ropa Interior."
 
 #. Key:	ToolsTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:302
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:302
 msgctxt "CharacterEditor,ToolsTooltip"
 msgid "Various editor functions."
-msgstr ""
+msgstr "Varias funciones del editor."
 
 #. Key:	UnderwearGroup
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:474
@@ -15432,21 +15554,25 @@ msgstr "Ropa Interior"
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:339
 msgctxt "CharacterEditor,UpperBodyShape"
 msgid "Upper Body"
-msgstr "Parte Superior del Cuerpo"
+msgstr "Cuerpo Superior"
 
 #. Key:	UpperClothing
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:462
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:462
 msgctxt "CharacterEditor,UpperClothing"
 msgid "Upper Clothing"
-msgstr "Ropa de la Parte Superior"
+msgstr "Ropa Superior"
 
 #. Key:	VariantTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:216
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:216
 msgctxt "CharacterEditor,VariantTooltip"
-msgid "Change this character's variant.\nWARNING: This will overwrite the current appearance."
-msgstr "Cambia la variante de este personaje.\nADVERTENCIA: Esto sobrescribirá la apariencia actual."
+msgid ""
+"Change this character's variant.\n"
+"WARNING: This will overwrite the current appearance."
+msgstr ""
+"Cambia la variante de este personaje.\n"
+"ADVERTENCIA: Esto sobrescribirá la apariencia actual."
 
 #. Key:	ErrorSavingPreset
 #. SourceLocation:	Source/Radiant/Public/Characters/SexyCharacterSystem.cpp:3579
@@ -15467,7 +15593,7 @@ msgstr "Preajuste guardado con éxito."
 #: Source/Radiant/Public/UI/Components/SexyComponentModifier.cpp:35
 msgctxt "ComponentModifier,DecrementTooltip"
 msgid "Previous component."
-msgstr "Componente anterior."
+msgstr "Anterior componente."
 
 #. Key:	IncrementTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyComponentModifier.cpp:56
@@ -15509,7 +15635,7 @@ msgstr "¿Salir al Escritorio?"
 #: Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:127
 msgctxt "ConfirmationBox,FulfillConfirm"
 msgid "The selected Nephelym will be given away."
-msgstr "El/La Nephelym seleccionado/a será regalado/a."
+msgstr "Se regalará el Nephelym seleccionado."
 
 #. Key:	FulfillConfirmTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:126
@@ -15523,7 +15649,7 @@ msgstr "¿Cumplir Tarea?"
 #: Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:132
 msgctxt "ConfirmationBox,FulfillFluidConfirm"
 msgid "Fluids will be removed from your inventory."
-msgstr ""
+msgstr "Los fluidos se eliminarán de su inventario."
 
 #. Key:	NewGameConfirm
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:97
@@ -15558,84 +15684,84 @@ msgstr "¿Sobrescribir Juego Guardado?"
 #: Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:152
 msgctxt "ConfirmationBox,PresetAttachmentConfirm"
 msgid "All presets for this variant will have their attachment colors replaced, this cannot be undone."
-msgstr ""
+msgstr "Todos los ajustes preestablecidos para esta variante tendrán sus colores adjuntos reemplazados, esto no se puede deshacer."
 
 #. Key:	PresetAttachmentTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:146
 #: Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:146
 msgctxt "ConfirmationBox,PresetAttachmentTitle"
 msgid "Propagate Attachment Color?"
-msgstr ""
+msgstr "¿Propagar el Color del Accesorio?"
 
 #. Key:	PresetFurConfirm
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:147
 #: Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:147
 msgctxt "ConfirmationBox,PresetFurConfirm"
 msgid "All presets for this variant will have their fur colors replaced, this cannot be undone."
-msgstr ""
+msgstr "Todos los ajustes preestablecidos para esta variante tendrán sus colores de pelaje reemplazados, esto no se puede deshacer."
 
 #. Key:	PresetFurTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:151
 #: Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:151
 msgctxt "ConfirmationBox,PresetFurTitle"
 msgid "Propagate Fur Color?"
-msgstr ""
+msgstr "¿Propagar el Color del Pelaje?"
 
 #. Key:	PresetHairConfirm
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:162
 #: Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:162
 msgctxt "ConfirmationBox,PresetHairConfirm"
 msgid "All presets for this variant will have their hair colors replaced, this cannot be undone."
-msgstr ""
+msgstr "Todos los ajustes preestablecidos para esta variante tendrán sus colores de cabello reemplazados, esto no se puede deshacer."
 
 #. Key:	PresetOverwriteConfirm
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:137
 #: Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:137
 msgctxt "ConfirmationBox,PresetOverwriteConfirm"
 msgid "Preset data will be overwritten with defaults, this cannot be undone."
-msgstr ""
+msgstr "Los datos preestablecidos se sobrescribirán con los valores predeterminados, esto no se puede deshacer."
 
 #. Key:	PresetOverwriteTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:136
 #: Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:136
 msgctxt "ConfirmationBox,PresetOverwriteTitle"
 msgid "Overwrite Preset Shape?"
-msgstr ""
+msgstr "¿Sobrescribir la Forma Preestablecida?"
 
 #. Key:	PresetPropagateConfirm
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:142
 #: Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:142
 msgctxt "ConfirmationBox,PresetPropagateConfirm"
 msgid "All presets for this variant will be overwritten with the current body shape, this cannot be undone."
-msgstr ""
+msgstr "Todos los ajustes preestablecidos para esta variante se sobrescribirán con la forma del cuerpo actual, esto no se puede deshacer."
 
 #. Key:	PresetPropagateTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:141
 #: Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:141
 msgctxt "ConfirmationBox,PresetPropagateTitle"
 msgid "Propagate Preset Shape?"
-msgstr ""
+msgstr "¿Propagar Forma Preestablecida?"
 
 #. Key:	PresetSkinConfirm
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:172
 #: Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:172
 msgctxt "ConfirmationBox,PresetSkinConfirm"
 msgid "All presets for this variant will have their skin colors replaced, this cannot be undone."
-msgstr ""
+msgstr "Todos los ajustes preestablecidos para esta variante tendrán sus colores de piel reemplazados, esto no se puede deshacer."
 
 #. Key:	PresetSkinTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:166
 #: Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:166
 msgctxt "ConfirmationBox,PresetSkinTitle"
 msgid "Propagate Skin Color?"
-msgstr ""
+msgstr "¿Propagar el Color de la Piel?"
 
 #. Key:	PresetTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:161
 #: Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:161
 msgctxt "ConfirmationBox,PresetTitle"
 msgid "Propagate Hair Color?"
-msgstr ""
+msgstr "¿Propagar el Color del Cabello?"
 
 #. Key:	ReleaseConfirm
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:122
@@ -15649,14 +15775,14 @@ msgstr "Dejará permanentemente su rancho y se divertirá una vez más."
 #: Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:121
 msgctxt "ConfirmationBox,ReleaseConfirmTitle"
 msgid "Release this Nephelym?"
-msgstr "¿Liberar este/a Nephelym?"
+msgstr "¿Liberar este Nephelym?"
 
 #. Key:	ReturnMainConfirm
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:112
 #: Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:112
 msgctxt "ConfirmationBox,ReturnMainConfirm"
 msgid "All progress since the last save will be lost."
-msgstr "Todo el progreso desde el último guardado se perderá."
+msgstr "Se perderá todo el progreso desde la última vez que se guardó."
 
 #. Key:	ReturnMainConfirmTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:111
@@ -15691,7 +15817,7 @@ msgstr "Confirmar"
 #: Source/Radiant/Public/UI/Menus/SexyTradeMenu.cpp:329
 msgctxt "ConfirmTradeBox,BatheMonsterMessage"
 msgid "Bathing will remove the grungy trait."
-msgstr "Bañarse eliminará el rasgo sucio."
+msgstr "Bañarse eliminará el rasgo Sucio."
 
 #. Key:	BuyUpgradeMessage
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyTradeMenu.cpp:317
@@ -15782,7 +15908,7 @@ msgstr "Nulo"
 #: Source/Radiant/Public/UI/Components/SexyHarvestContainerGrid.cpp:25
 msgctxt "HarvestGrid,NotInterested"
 msgid "This merchant does not deal in petty fluids."
-msgstr "Esta comerciante no trata con líquidos menores."
+msgstr "Esta comerciante no trata con fluidos menores."
 
 #. Key:	BuyMilkTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyHarvestWidget.cpp:423
@@ -15803,14 +15929,14 @@ msgstr "Comprar semen."
 #: Source/Radiant/Public/UI/Components/SexyHarvestWidget.cpp:250
 msgctxt "HarvestWidget,MaxMilk"
 msgid "4000 ml"
-msgstr "4000 ml"
+msgstr ""
 
 #. Key:	MaxSemen
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyHarvestWidget.cpp:155
 #: Source/Radiant/Public/UI/Components/SexyHarvestWidget.cpp:155
 msgctxt "HarvestWidget,MaxSemen"
 msgid "1500 ml"
-msgstr "1500 ml"
+msgstr ""
 
 #. Key:	Milk
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyHarvestWidget.cpp:220
@@ -15824,7 +15950,7 @@ msgstr "Leche"
 #: Source/Radiant/Public/UI/Components/SexyHarvestWidget.cpp:238
 msgctxt "HarvestWidget,MilkML"
 msgid "355 ml"
-msgstr "355 ml"
+msgstr ""
 
 #. Key:	PriceML
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyHarvestWidget.cpp:170
@@ -15859,56 +15985,56 @@ msgstr "Semen"
 #: Source/Radiant/Public/UI/Components/SexyHarvestWidget.cpp:143
 msgctxt "HarvestWidget,SemenML"
 msgid "118 ml"
-msgstr "118 ml"
+msgstr ""
 
 #. Key:	UseMilkTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyHarvestWidget.cpp:419
 #: Source/Radiant/Public/UI/Components/SexyHarvestWidget.cpp:419
 msgctxt "HarvestWidget,UseMilkTooltip"
 msgid "Use 15 ml of milk in attempt to stimulate this wild Nephelym."
-msgstr "Usar 15 ml de leche en un intento de estimular este/a Nephelym salvaje."
+msgstr "Usar 15 ml de leche en un intento de estimular este Nephelym silvestre."
 
 #. Key:	UseSemenTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyHarvestWidget.cpp:404
 #: Source/Radiant/Public/UI/Components/SexyHarvestWidget.cpp:404
 msgctxt "HarvestWidget,UseSemenTooltip"
 msgid "Use 5 ml of semen in attempt to stimulate this wild Nephelym."
-msgstr "Usar 5 ml de semen en un intento de estimular este/a Nephelym salvaje."
+msgstr "Usar 5 ml de semen en un intento de estimular este Nephelym silvestre."
 
 #. Key:	P
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyIKModifier.cpp:156
 #: Source/Radiant/Public/UI/Components/SexyIKModifier.cpp:156
 msgctxt "IKModifier,P"
 msgid "P"
-msgstr "P"
+msgstr ""
 
 #. Key:	R
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyIKModifier.cpp:136
 #: Source/Radiant/Public/UI/Components/SexyIKModifier.cpp:136
 msgctxt "IKModifier,R"
 msgid "R"
-msgstr "R"
+msgstr ""
 
 #. Key:	X
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyIKModifier.cpp:66
 #: Source/Radiant/Public/UI/Components/SexyIKModifier.cpp:66
 msgctxt "IKModifier,X"
 msgid "X"
-msgstr "X"
+msgstr ""
 
 #. Key:	Y
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyIKModifier.cpp:86
 #: Source/Radiant/Public/UI/Components/SexyIKModifier.cpp:86
 msgctxt "IKModifier,Y"
 msgid "Y"
-msgstr "Y"
+msgstr ""
 
 #. Key:	Z
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyIKModifier.cpp:105
 #: Source/Radiant/Public/UI/Components/SexyIKModifier.cpp:105
 msgctxt "IKModifier,Z"
 msgid "Z"
-msgstr "Z"
+msgstr ""
 
 #. Key:	Allure
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyItemDetails.cpp:18
@@ -15922,7 +16048,7 @@ msgstr "Atractivo"
 #: Source/Radiant/Public/UI/Components/SexyItemDetails.cpp:18
 msgctxt "ItemDetails,AllureTooltip"
 msgid "Allure will change by this modifier when this item is used."
-msgstr "Atractivo cambiará con este modificador cuando se use este item."
+msgstr "El Atractivo cambiará con este modificador cuando se use este artículo."
 
 #. Key:	Description
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyItemDetails.cpp:20
@@ -15943,7 +16069,7 @@ msgstr "Destreza"
 #: Source/Radiant/Public/UI/Components/SexyItemDetails.cpp:19
 msgctxt "ItemDetails,DexterityTooltip"
 msgid "Dexterity will change by this modifier when this item is used."
-msgstr "Destreza cambiará con este modificador cuando se use este item."
+msgstr "La Destreza cambiará con este modificador cuando se use este artículo."
 
 #. Key:	Fertility
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyItemDetails.cpp:18
@@ -15957,7 +16083,7 @@ msgstr "Fertilidad"
 #: Source/Radiant/Public/UI/Components/SexyItemDetails.cpp:18
 msgctxt "ItemDetails,FertilityTooltip"
 msgid "Fertility will change by this modifier when this item is used."
-msgstr "Fertilidad cambiará con este modificador cuando se use este item."
+msgstr "La Fertilidad cambiará con este modificador cuando se use este artículo."
 
 #. Key:	Level
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyItemDetails.cpp:17
@@ -15971,7 +16097,7 @@ msgstr "Nivel"
 #: Source/Radiant/Public/UI/Components/SexyItemDetails.cpp:17
 msgctxt "ItemDetails,LevelTooltip"
 msgid "Level will change by this modifier when this item is used."
-msgstr "Nivel cambiará con este modificador cuando se use este item."
+msgstr "El Nivel cambiará con este modificador cuando se use este artículo."
 
 #. Key:	Loyalty
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyItemDetails.cpp:17
@@ -15985,7 +16111,7 @@ msgstr "Lealtad"
 #: Source/Radiant/Public/UI/Components/SexyItemDetails.cpp:17
 msgctxt "ItemDetails,LoyaltyTooltip"
 msgid "Loyalty will change by this modifier when this item is used."
-msgstr "Lealtad cambiará con este modificador cuando se use este item."
+msgstr "La Lealtad cambiará con este modificador cuando se use este artículo."
 
 #. Key:	Modifiers
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyItemDetails.cpp:16
@@ -15999,7 +16125,7 @@ msgstr "Modificadores"
 #: Source/Radiant/Public/UI/Components/SexyItemDetails.cpp:16
 msgctxt "ItemDetails,Name"
 msgid "Item"
-msgstr "Articulo"
+msgstr "Artículo"
 
 #. Key:	Strength
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyItemDetails.cpp:17
@@ -16013,7 +16139,7 @@ msgstr "Fuerza"
 #: Source/Radiant/Public/UI/Components/SexyItemDetails.cpp:17
 msgctxt "ItemDetails,StrengthTooltip"
 msgid "Strength will change by this modifier when this item is used."
-msgstr "Fuerza cambiará con este modificador cuando se use este item."
+msgstr "La Fuerza cambiará con este modificador cuando se use este artículo."
 
 #. Key:	Type
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyItemDetails.cpp:16
@@ -16034,7 +16160,7 @@ msgstr "Valor"
 #: Source/Radiant/Public/UI/Components/SexyItemDetails.cpp:19
 msgctxt "ItemDetails,ValueTooltip"
 msgid "Value will change by this modifier when this item is used."
-msgstr "Valor cambiará con este modificador cuando se use este item."
+msgstr "El Valor cambiará con este modificador cuando se use este artículo."
 
 #. Key:	Willpower
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyItemDetails.cpp:18
@@ -16048,14 +16174,14 @@ msgstr "Fuerza de Voluntad"
 #: Source/Radiant/Public/UI/Components/SexyItemDetails.cpp:18
 msgctxt "ItemDetails,WillpowerTooltip"
 msgid "Willpower will change by this modifier when this item is used."
-msgstr "Fuerza de Voluntad cambiará con este modificador cuando se use este item."
+msgstr "La Fuerza de Voluntad cambiará con este modificador cuando se use este artículo."
 
 #. Key:	NotEnoughFluid
 #. SourceLocation:	Source/Radiant/Public/Items/SexyItemSystem.cpp:194
 #: Source/Radiant/Public/Items/SexyItemSystem.cpp:194
 msgctxt "ItemSystem,NotEnoughFluid"
 msgid "Not enough fluid."
-msgstr "No hay suficiente líquido."
+msgstr "No hay suficiente fluido."
 
 #. Key:	Action
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:188
@@ -16069,7 +16195,7 @@ msgstr "Acción"
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:193
 msgctxt "Keybinds,Back"
 msgid "Back"
-msgstr "Espalda"
+msgstr "Atrás"
 
 #. Key:	Crouch
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:153
@@ -16083,7 +16209,7 @@ msgstr "Agacharse"
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:209
 msgctxt "Keybinds,GalleryMenu"
 msgid "Toggle Gallery"
-msgstr "Alternar Galería"
+msgstr "Alternar a la Galería"
 
 #. Key:	Jump
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:149
@@ -16097,7 +16223,7 @@ msgstr "Saltar"
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:174
 msgctxt "Keybinds,Look"
 msgid "Camera Look"
-msgstr "Vista de Cámara"
+msgstr "Vista de la Cámara"
 
 #. Key:	MoveBackward
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:137
@@ -16111,7 +16237,7 @@ msgstr "Mover hacia Atrás"
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:133
 msgctxt "Keybinds,MoveForward"
 msgid "Move Forward"
-msgstr "Mover hacia Delante"
+msgstr "Mover hacia Adelante"
 
 #. Key:	MoveLeft
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:145
@@ -16132,7 +16258,7 @@ msgstr "Mover hacia la Derecha"
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:181
 msgctxt "Keybinds,Pan"
 msgid "Pan"
-msgstr "Panoramica"
+msgstr "Panorámica"
 
 #. Key:	Rotate
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:184
@@ -16146,7 +16272,7 @@ msgstr "Rotar"
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:160
 msgctxt "Keybinds,SingleTapDodge"
 msgid "One Tap Dodge"
-msgstr "Esquivar de un Toque"
+msgstr "Esquivar con un Toque"
 
 #. Key:	Slide
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:157
@@ -16328,7 +16454,7 @@ msgstr "Realiza la acción seleccionada sin comenzar una escena."
 #: Source/Radiant/Public/UI/Components/SexyMateSizeChart.cpp:33
 msgctxt "MateSizeChart,Giver"
 msgid "Giver"
-msgstr "Dador/a"
+msgstr "Donante"
 
 #. Key:	Receiver
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyMateSizeChart.cpp:22
@@ -16377,28 +16503,28 @@ msgstr "Aceptar"
 #: Source/Radiant/Public/UI/Menus/SexyOffspringMenu.cpp:54
 msgctxt "Offspring,AcceptButtonTitleTooltip"
 msgid "Keep this offspring and add it to your ranch."
-msgstr "Quedarte con este/a descendiente y agrégalo/a a tu rancho."
+msgstr "Quedarte con este descendiente y agrégalo a tu rancho."
 
 #. Key:	BackButtonTitleTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyOffspringMenu.cpp:63
 #: Source/Radiant/Public/UI/Menus/SexyOffspringMenu.cpp:63
 msgctxt "Offspring,BackButtonTitleTooltip"
 msgid "Return to the gallery."
-msgstr ""
+msgstr "Regresar a la galería."
 
 #. Key:	BackTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyOffspringMenu.cpp:62
 #: Source/Radiant/Public/UI/Menus/SexyOffspringMenu.cpp:62
 msgctxt "Offspring,BackTitle"
 msgid "Back"
-msgstr ""
+msgstr "Atrás"
 
 #. Key:	ReceiverWindowTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyOffspringMenu.cpp:71
 #: Source/Radiant/Public/UI/Menus/SexyOffspringMenu.cpp:71
 msgctxt "Offspring,ReceiverWindowTitle"
 msgid "Nephelym Offspring"
-msgstr "Descendiente de Nephelym"
+msgstr "Descendiente Nephelym"
 
 #. Key:	ReleaseButtonTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyOffspringMenu.cpp:34
@@ -16412,7 +16538,7 @@ msgstr "Liberar"
 #: Source/Radiant/Public/UI/Menus/SexyOffspringMenu.cpp:35
 msgctxt "Offspring,ReleaseButtonTooltip"
 msgid "Release this offspring into the wild."
-msgstr "Libera a este/a descendiente en la naturaleza."
+msgstr "Liberar este descendiente en la naturaleza."
 
 #. Key:	RenameButton
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyOffspringMenu.cpp:43
@@ -16426,28 +16552,28 @@ msgstr "Renombrar"
 #: Source/Radiant/Public/UI/Menus/SexyOffspringMenu.cpp:44
 msgctxt "Offspring,RenameButtonTooltip"
 msgid "Rename this offspring before adding it to your ranch."
-msgstr "Cambiar el nombre de este/a descendiente antes de agregarlo/a a tu rancho."
+msgstr "Cambiar el nombre de este descendiente antes de agregarlo a tu rancho."
 
 #. Key:	Female
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:442
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:442
 msgctxt "Radiant,Female"
 msgid "Female"
-msgstr ""
+msgstr "Hembra"
 
 #. Key:	Futa
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:446
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:446
 msgctxt "Radiant,Futa"
 msgid "Futa"
-msgstr ""
+msgstr "Futa"
 
 #. Key:	Male
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:450
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:450
 msgctxt "Radiant,Male"
 msgid "Male"
-msgstr ""
+msgstr "Macho"
 
 #. Key:	NullText
 #. SourceLocation:	Source/Radiant/Public/Data/SexyData.h:2848
@@ -16489,7 +16615,7 @@ msgstr "Renombrar"
 #: Source/Radiant/Public/UI/Components/SexyResourceList.cpp:1097
 msgctxt "ResourceList,ActionEditBreeder"
 msgid "Edit Appearance"
-msgstr ""
+msgstr "Editar Apariencia"
 
 #. Key:	ActionGiveFavorite
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyResourceList.cpp:1134
@@ -16510,14 +16636,14 @@ msgstr "Cosechar Leche"
 #: Source/Radiant/Public/UI/Components/SexyResourceList.cpp:1116
 msgctxt "ResourceList,ActionHarvestMilkAssist"
 msgid "Harvest Milk (Fern)"
-msgstr "Cosechar Leche (Helecho)"
+msgstr "Cosechar Leche (Fern)"
 
 #. Key:	ActionHarvestMilkAssist2
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyResourceList.cpp:1122
 #: Source/Radiant/Public/UI/Components/SexyResourceList.cpp:1122
 msgctxt "ResourceList,ActionHarvestMilkAssist2"
 msgid "Harvest Milk (Blossom)"
-msgstr "Cosechar Leche (Flor)"
+msgstr "Cosechar Leche (Blossom)"
 
 #. Key:	ActionHarvestSemen
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyResourceList.cpp:1108
@@ -16538,42 +16664,42 @@ msgstr "Capturar Semen"
 #: Source/Radiant/Public/UI/Components/SexyResourceList.cpp:1114
 msgctxt "ResourceList,ActionHarvestSemenAssist"
 msgid "Harvest Semen (Fern)"
-msgstr "Cosechar Semen (Helecho)"
+msgstr "Cosechar Semen (Fern)"
 
 #. Key:	ActionHarvestSemenAssist2
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyResourceList.cpp:1115
 #: Source/Radiant/Public/UI/Components/SexyResourceList.cpp:1115
 msgctxt "ResourceList,ActionHarvestSemenAssist2"
 msgid "Capture Semen (Fern)"
-msgstr "Capturar Semen (Helecho)"
+msgstr "Capturar Semen (Fern)"
 
 #. Key:	ActionHarvestSemenAssist3
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyResourceList.cpp:1120
 #: Source/Radiant/Public/UI/Components/SexyResourceList.cpp:1120
 msgctxt "ResourceList,ActionHarvestSemenAssist3"
 msgid "Harvest Semen (Blossom)"
-msgstr "Cosechar Semen (Flor)"
+msgstr "Cosechar Semen (Blossom)"
 
 #. Key:	ActionHarvestSemenAssist4
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyResourceList.cpp:1121
 #: Source/Radiant/Public/UI/Components/SexyResourceList.cpp:1121
 msgctxt "ResourceList,ActionHarvestSemenAssist4"
 msgid "Capture Semen (Blossom)"
-msgstr "Capturar Semen (Flor)"
+msgstr "Capturar Semen (Blossom)"
 
 #. Key:	ActionRBJ
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyResourceList.cpp:1231
 #: Source/Radiant/Public/UI/Components/SexyResourceList.cpp:1231
 msgctxt "ResourceList,ActionRBJ"
 msgid "Spontaneous Blow Job"
-msgstr ""
+msgstr "Mamada Espontánea"
 
 #. Key:	ActionRelease
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyResourceList.cpp:1124
 #: Source/Radiant/Public/UI/Components/SexyResourceList.cpp:1124
 msgctxt "ResourceList,ActionRelease"
 msgid "Release into the Wild"
-msgstr "Soltar en la naturaleza"
+msgstr "Liberar en la Naturaleza"
 
 #. Key:	ActionRename
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyResourceList.cpp:1105
@@ -16657,14 +16783,14 @@ msgstr "Reproducción Automática de Diálogo"
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:119
 msgctxt "SettingsMenu,AutoplayDialogueHelp"
 msgid "Automatically cycle through lines of dialogue without having to press next."
-msgstr "Alterna automáticamente las líneas de diálogo sin tener que presionar siguiente."
+msgstr "Ciclo automático a través de las líneas de diálogo sin tener que presionar siguiente."
 
 #. Key:	BulgeHelp
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:116
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:116
 msgctxt "SettingsMenu,BulgeHelp"
 msgid "Large dicks will slightly bulge the receiver's groin and belly area."
-msgstr ""
+msgstr "Los penes grandes abultan ligeramente la ingle y el área del vientre de la receptora."
 
 #. Key:	CameraControls
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:243
@@ -16734,14 +16860,14 @@ msgstr "Inflación por Semen"
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:116
 msgctxt "SettingsMenu,DickBulge"
 msgid "Dick Bulge"
-msgstr ""
+msgstr "Bulto del Pene"
 
 #. Key:	DickSheath
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:435
 #: Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:435
 msgctxt "SettingsMenu,DickSheath"
 msgid "Dick Seam Blend"
-msgstr ""
+msgstr "Mezcla de la Juntura del Pene"
 
 #. Key:	EffectsVolume
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:516
@@ -16776,7 +16902,7 @@ msgstr "Futanari"
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:107
 msgctxt "SettingsMenu,FutanariHelp"
 msgid "Female Nephelym and NPCs can have a fully functional dick."
-msgstr "Las hembras Nephelym y NPCs pueden tener una polla completamente funcional."
+msgstr "Las hembras Nephelym y NPCs pueden tener un pene completamente funcional."
 
 #. Key:	GameplayTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:69
@@ -16804,7 +16930,7 @@ msgstr "Hembras Humanoides"
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:105
 msgctxt "SettingsMenu,HominalFemalesHelp"
 msgid "Female and futa Nephelym can have a trait that alters their appearance to be more human than monster."
-msgstr "Hembras y Futas Nephelym pueden tener un rasgo que altera su apariencia para ser más humana que monstruo."
+msgstr "Las hembras y las futas Nephelym pueden tener un rasgo que altera su apariencia para ser más humana que monstruo."
 
 #. Key:	KeyBinds
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:326
@@ -16846,21 +16972,21 @@ msgstr "Con la excepción del criador masculino, todos los Nephelym machos será
 #: Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:492
 msgctxt "SettingsMenu,MasterVolume"
 msgid "Master"
-msgstr "Maestro"
+msgstr "Master"
 
 #. Key:	MixHelp
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:112
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:112
 msgctxt "SettingsMenu,MixHelp"
 msgid "Offspring colors will be blended from parents."
-msgstr ""
+msgstr "Los colores de la descendencia se mezclarán de los padres."
 
 #. Key:	MixOffspring
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:112
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:112
 msgctxt "SettingsMenu,MixOffspring"
 msgid "Blend Offspring Colors"
-msgstr ""
+msgstr "Mezclar Colores en los Descendientes"
 
 #. Key:	MusicVolume
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:564
@@ -16881,7 +17007,7 @@ msgstr "Configuraciones"
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:123
 msgctxt "SettingsMenu,PhysHelp"
 msgid "Simulate Breeder's jiggly bits, disable for performance gain. Restart required for full effect."
-msgstr "Simula el zangoloteo en las partes de el/la Criador/a, desactívalo para aumentar el rendimiento. Reinicio requerido para un efecto completo."
+msgstr "Simula las partes temblorosas del criador, desactívalo para aumentar el rendimiento. Es necesario reiniciar para un efecto completo."
 
 #. Key:	PhysicsTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:451
@@ -16909,7 +17035,7 @@ msgstr "Embarazo"
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:110
 msgctxt "SettingsMenu,PregnancyHelp"
 msgid "Female Nephelym will take 5 days to summon their offspring, and the belly will morph to reflect this."
-msgstr ""
+msgstr "La hembra Nephelym tardará 3 días en convocar a su descendencia, y el vientre se transformará para reflejar esto."
 
 #. Key:	Quality
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:417
@@ -16944,7 +17070,7 @@ msgstr "Pantalla"
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:113
 msgctxt "SettingsMenu,SurpriseHelp"
 msgid "Allow consensual surprise sex."
-msgstr "Permitir el sexo consensual sorpresa."
+msgstr "Permitir sexo sorpresa consensuado."
 
 #. Key:	SurpriseSex
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:113
@@ -16972,7 +17098,7 @@ msgstr "Cada raza tiene colores únicos para sus fluidos corporales. Si está de
 #: Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:141
 msgctxt "SettingsMenu,UITitle"
 msgid "UI"
-msgstr "UI"
+msgstr ""
 
 #. Key:	VocalsVolume
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:540
@@ -17007,28 +17133,28 @@ msgstr "Aprenderás esta posición sexual."
 #: Source/Radiant/Public/UI/Menus/SexyBreedingSetupMenu.cpp:139
 msgctxt "SSexyBreedingSetupMenu,CollapseGStats"
 msgid "Hide detailed stats for selected giver."
-msgstr "Ocultar estadísticas detalladas para el/la dador/a seleccionado/a."
+msgstr "Ocultar estadísticas detalladas del donante seleccionado."
 
 #. Key:	CollapseRStats
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyBreedingSetupMenu.cpp:201
 #: Source/Radiant/Public/UI/Menus/SexyBreedingSetupMenu.cpp:201
 msgctxt "SSexyBreedingSetupMenu,CollapseRStats"
 msgid "Hide detailed stats for selected receiver."
-msgstr "Ocultar estadísticas detalladas para la receptora seleccionada."
+msgstr "Ocultar estadísticas detalladas de la receptora seleccionada."
 
 #. Key:	ExpandGStats
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyBreedingSetupMenu.cpp:116
 #: Source/Radiant/Public/UI/Menus/SexyBreedingSetupMenu.cpp:116
 msgctxt "SSexyBreedingSetupMenu,ExpandGStats"
 msgid "View detailed stats for selected giver."
-msgstr "Ver estadísticas detalladas para el/la dador/a seleccionado/a."
+msgstr "Ver estadísticas detalladas del donante seleccionado."
 
 #. Key:	ExpandRStats
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyBreedingSetupMenu.cpp:178
 #: Source/Radiant/Public/UI/Menus/SexyBreedingSetupMenu.cpp:178
 msgctxt "SSexyBreedingSetupMenu,ExpandRStats"
 msgid "View detailed stats for selected receiver."
-msgstr "Ver estadísticas detalladas para la receptora seleccionada."
+msgstr "Ver estadísticas detalladas de la receptora seleccionada."
 
 #. Key:	SpiritForm
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:254
@@ -17056,7 +17182,7 @@ msgstr "Dale a este personaje su rasgo humanoide si existe."
 #: Source/Radiant/Public/UI/Components/SexyCharacterGalleryControls.cpp:57
 msgctxt "SSexyCharacterGalleryControls,UsrPresetTooltip"
 msgid "Load a preset for this character."
-msgstr "Carga un preajuste para este personaje."
+msgstr "Cargar un preajuste para este personaje."
 
 #. Key:	None
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyDropList.cpp:95
@@ -17084,21 +17210,21 @@ msgstr "Regresar al creador."
 #: Source/Radiant/Public/UI/Menus/SexyGalleryMenu.cpp:96
 msgctxt "SSexyGalleryMenu,GiverWindowTitle"
 msgid "Select Giver"
-msgstr "Seleccionar Dador/a"
+msgstr "Seleccionar Donante"
 
 #. Key:	OffspringButtonTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyGalleryMenu.cpp:87
 #: Source/Radiant/Public/UI/Menus/SexyGalleryMenu.cpp:87
 msgctxt "SSexyGalleryMenu,OffspringButtonTitle"
 msgid "Make Offspring"
-msgstr ""
+msgstr "Hacer Descendiente"
 
 #. Key:	OffspringButtonTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyGalleryMenu.cpp:88
 #: Source/Radiant/Public/UI/Menus/SexyGalleryMenu.cpp:88
 msgctxt "SSexyGalleryMenu,OffspringButtonTooltip"
 msgid "See what the selected mates would produce."
-msgstr ""
+msgstr "Ver lo que producirían los compañeros seleccionados."
 
 #. Key:	ReceiverWindowTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyGalleryMenu.cpp:134
@@ -17119,7 +17245,7 @@ msgstr "Ver"
 #: Source/Radiant/Public/UI/Menus/SexyGalleryMenu.cpp:79
 msgctxt "SSexyGalleryMenu,ViewButtonTooltip"
 msgid "View the sex scene for the currently selected mates and options."
-msgstr "Ver la escena de sexo para los compañeros y opciones actualmente seleccionados."
+msgstr "Ver la escena de sexo de los compañeros y las opciones seleccionadas actualmente."
 
 #. Key:	ASOGMessage
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyGenericMenu.cpp:101
@@ -17133,14 +17259,14 @@ msgstr "Un agradecimiento especial a las siguientes personas:"
 #: Source/Radiant/Public/UI/Menus/SexyGenericMenu.cpp:86
 msgctxt "SSexyGenericMenu,ASOGWindowTitle"
 msgid "Ancient Stone of Glory"
-msgstr "Antigua Piedra de Gloria"
+msgstr "Antigua Piedra de la Gloria"
 
 #. Key:	DailyTasksTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyGenericMenu.cpp:146
 #: Source/Radiant/Public/UI/Menus/SexyGenericMenu.cpp:146
 msgctxt "SSexyGenericMenu,DailyTasksTitle"
 msgid "Daily"
-msgstr ""
+msgstr "Diario"
 
 #. Key:	FulfillButton
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyGenericMenu.cpp:219
@@ -17161,14 +17287,14 @@ msgstr "Acepta la recompensa por esta tarea."
 #: Source/Radiant/Public/UI/Menus/SexyGenericMenu.cpp:164
 msgctxt "SSexyGenericMenu,SpecialTasksTitle"
 msgid "Special Requests"
-msgstr ""
+msgstr "Solicitudes Especiales"
 
 #. Key:	TaskMonsterWindowTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyGenericMenu.cpp:230
 #: Source/Radiant/Public/UI/Menus/SexyGenericMenu.cpp:230
 msgctxt "SSexyGenericMenu,TaskMonsterWindowTitle"
 msgid "Select Nephelym to Fulfill Task"
-msgstr "Seleccione Nephelym para cumplir tarea"
+msgstr "Seleccionar Nephelym para Cumplir la Tarea"
 
 #. Key:	TaskWindowTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyGenericMenu.cpp:120
@@ -17196,21 +17322,21 @@ msgstr "Enlazar"
 #: Source/Radiant/Public/UI/Components/SexyKeyBind.cpp:56
 msgctxt "SSexyKeyBind,BindKey"
 msgid "Press Key"
-msgstr "Pulsa la Tecla"
+msgstr "Presiona la Tecla"
 
 #. Key:	CollapseStats
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyMonsterMenu.cpp:149
 #: Source/Radiant/Public/UI/Menus/SexyMonsterMenu.cpp:149
 msgctxt "SSexyMonsterMenu,CollapseStats"
 msgid "Hide detailed stats for selected Nephelym."
-msgstr "Ocultar estadísticas detalladas para el/la Nephelym seleccionado/a."
+msgstr "Ocultar estadísticas detalladas para el Nephelym seleccionado."
 
 #. Key:	ExpandStats
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyMonsterMenu.cpp:126
 #: Source/Radiant/Public/UI/Menus/SexyMonsterMenu.cpp:126
 msgctxt "SSexyMonsterMenu,ExpandStats"
 msgid "View detailed stats for selected Nephelym."
-msgstr "Ver estadísticas detalladas para el/la Nephelym seleccionado/a."
+msgstr "Ver estadísticas detalladas del Nephelym seleccionado."
 
 #. Key:	ManageWindowTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyRanchMenu.cpp:87
@@ -17266,7 +17392,7 @@ msgstr "Filtrar por estadísticas."
 #: Source/Radiant/Public/UI/Menus/SexyRoamerMenu.cpp:216
 msgctxt "SSexyRoamerMenu,Breeder"
 msgid "Breeder:"
-msgstr "Criador/a:"
+msgstr "Criador:"
 
 #. Key:	CatchButton
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyRoamerMenu.cpp:113
@@ -17280,21 +17406,21 @@ msgstr "Capturar"
 #: Source/Radiant/Public/UI/Menus/SexyRoamerMenu.cpp:114
 msgctxt "SSexyRoamerMenu,CatchButtonTooltip"
 msgid "Add this wild Nephelym to your collection."
-msgstr "Agrega este Nephelym salvaje a tu colección."
+msgstr "Agrega este Nephelym silvestre a tu colección."
 
 #. Key:	CollapseStats
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyRoamerMenu.cpp:161
 #: Source/Radiant/Public/UI/Menus/SexyRoamerMenu.cpp:161
 msgctxt "SSexyRoamerMenu,CollapseStats"
 msgid "Hide detailed stats for this wild Nephelym."
-msgstr "Ocultar estadísticas detalladas para este/a Nephelym salvaje."
+msgstr "Ocultar las estadísticas detalladas de este Nephelym silvestre."
 
 #. Key:	ExpandStats
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyRoamerMenu.cpp:140
 #: Source/Radiant/Public/UI/Menus/SexyRoamerMenu.cpp:140
 msgctxt "SSexyRoamerMenu,ExpandStats"
 msgid "View detailed stats for this wild Nephelym."
-msgstr "Ver estadísticas detalladas para este/a Nephelym salvaje."
+msgstr "Ver las estadísticas detalladas de este Nephelym silvestre."
 
 #. Key:	ItemWindowTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyRoamerMenu.cpp:252
@@ -17315,7 +17441,7 @@ msgstr "Salir"
 #: Source/Radiant/Public/UI/Menus/SexyRoamerMenu.cpp:71
 msgctxt "SSexyRoamerMenu,LeaveButtonTooltip"
 msgid "Leave this wild Nephelym alone."
-msgstr "Deja en paz este Nephelym salvaje."
+msgstr "Deja en paz a este Nephelym silvestre."
 
 #. Key:	Nephelym
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyRoamerMenu.cpp:196
@@ -17357,14 +17483,14 @@ msgstr "¡Sexo Sorpresa!"
 #: Source/Radiant/Public/UI/Menus/SexyRoamerMenu.cpp:344
 msgctxt "SSexyRoamerMenu,TaskRBJ"
 msgid "Let her work her wonder."
-msgstr "Déjala trabajar su maravilla."
+msgstr "Dejar trabajar su maravilla."
 
 #. Key:	CheatFavor
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:993
 #: Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:993
 msgctxt "SSexySettingsMenu,CheatFavor"
 msgid "Added 1,000 favor."
-msgstr "Se agregaron 1,000 de favor."
+msgstr "Se añadieron 1,000 de favor."
 
 #. Key:	CheatFluids
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:1040
@@ -17385,14 +17511,14 @@ msgstr "Todos tienen lujuria infinita."
 #: Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:988
 msgctxt "SSexySettingsMenu,CheatMoney"
 msgid "Added 1,000,000 orgasium."
-msgstr "Se agregaron 1,000,000 de orgasium."
+msgstr "Se añadieron 1,000,000 de orgasium."
 
 #. Key:	CheatRanch
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:1031
 #: Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:1031
 msgctxt "SSexySettingsMenu,CheatRanch"
 msgid "All barns added to ranch."
-msgstr "Todos los graneros agregados al rancho."
+msgstr "Todos los graneros añadidos al rancho."
 
 #. Key:	CheatRemove
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:983
@@ -17413,7 +17539,7 @@ msgstr "Ahora tienes espíritu infinito."
 #: Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:1045
 msgctxt "SSexySettingsMenu,CheatSurprise"
 msgid "You will always win surprise sex."
-msgstr "Siempre ganarás sexo sorpresa."
+msgstr "Siempre ganarás el sexo sorpresa."
 
 #. Key:	CheatTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:199
@@ -17441,7 +17567,7 @@ msgstr "Modo creador activado."
 #: Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:966
 msgctxt "SSexySettingsMenu,CreatorModeMainMenu"
 msgid "Use this code in the main menu."
-msgstr ""
+msgstr "Utiliza este código en el menú principal."
 
 #. Key:	DefaultKeyBinds
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:864
@@ -17490,28 +17616,28 @@ msgstr "Futas usan SS TG."
 #: Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:1088
 msgctxt "SSexySettingsMenu,ProudMother"
 msgid "Your mother would be so proud."
-msgstr ""
+msgstr "Tu madre estaría muy orgullosa."
 
 #. Key:	SizePairs
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexySexPositionDetails.cpp:35
 #: Source/Radiant/Public/UI/Components/SexySexPositionDetails.cpp:35
 msgctxt "SSexySexPositionDetails,SizePairs"
 msgid "Pairs with Scene"
-msgstr "Pares con Escena"
+msgstr "Parejas con Escena"
 
 #. Key:	DaysRemaining
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyTaskGridItem.cpp:231
 #: Source/Radiant/Public/UI/Components/SexyTaskGridItem.cpp:231
 msgctxt "SSexyTaskGridItem,DaysRemaining"
 msgid "Days remaining: {0}"
-msgstr ""
+msgstr "Días restantes: {0}"
 
 #. Key:	Reward
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyTaskGridItem.cpp:151
 #: Source/Radiant/Public/UI/Components/SexyTaskGridItem.cpp:151
 msgctxt "SSexyTaskGridItem,Reward"
 msgid "Reward:"
-msgstr ""
+msgstr "Recompensa:"
 
 #. Key:	FavorTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyTradeMenu.cpp:483
@@ -17553,14 +17679,14 @@ msgstr "Confirmar Venta"
 #: Source/Radiant/Public/UI/Menus/SexyTradeMenu.cpp:274
 msgctxt "SSexyTradeMenu,SellMonsterMessage"
 msgid "Ascend this one and gain favor?"
-msgstr "¿Ascender a este/a y ganar favor?"
+msgstr "¿Ascender a este y ganar favor?"
 
 #. Key:	Activate
 #. SourceLocation:	Source/Radiant/Public/Characters/SexyBreederCharacter.cpp:133
 #: Source/Radiant/Public/Characters/SexyBreederCharacter.cpp:133
 msgctxt "TaskBoard,Activate"
 msgid "Check Breeding Tasks"
-msgstr "Verificar Tareas de Cría"
+msgstr "Verificar Tareas de Reproducción"
 
 #. Key:	BuyFunds
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyTradeMenu.cpp:39
@@ -17623,7 +17749,7 @@ msgstr "Activar"
 #: Source/Radiant/Public/UI/SexyInterface.cpp:386
 msgctxt "WorldAction,ActivateDazeShrine"
 msgid "Commune with the Reaper"
-msgstr ""
+msgstr "Comunión con la Segadora"
 
 #. Key:	BreedingSetupAction
 #. SourceLocation:	Source/Radiant/Public/UI/SexyInterface.cpp:370
@@ -17644,7 +17770,7 @@ msgstr "Interactuar"
 #: Source/Radiant/Public/UI/SexyInterface.cpp:366
 msgctxt "WorldAction,ManageRanch"
 msgid "Manage Ranch"
-msgstr "Administrar Rancho"
+msgstr "Gestiona el Rancho"
 
 #. Key:	TalkAction
 #. SourceLocation:	Source/Radiant/Public/UI/SexyInterface.cpp:374
@@ -17659,4 +17785,3 @@ msgstr "Hablar"
 msgctxt "WorldAction,TraverseAction"
 msgid "Traverse Portal"
 msgstr "Atravesar el Portal"
-

--- a/spanish.po
+++ b/spanish.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Radiant\n"
 "POT-Creation-Date: 2021-06-14 02:04\n"
-"PO-Revision-Date: 2021-12-13 19:14+0100\n"
+"PO-Revision-Date: 2022-01-15 01:01+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: es_ES\n"
@@ -19,7 +19,7 @@ msgstr ""
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03_R02.Default__FernDefault03_R02_C.SessionData.Lines(1).Lines
 msgctxt ",0009BEE346934010A7F79C8CF23B20D5"
 msgid "This is my final form, and it feels so amazing. I smell beautiful too!"
-msgstr "Esta es mi forma final y se siente increíble. ¡También huelo hermoso!"
+msgstr "Esta es mi forma final y se siente increíble. ¡También huelo delicioso!"
 
 #. Key:	00164C5345E544D784CC289035CEF701
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimePlay_RL.Default__MegaSlimePlay_RL_C.ResponseData(0).ResponseData.BreederPrompt
@@ -202,14 +202,14 @@ msgstr "Mi nombre es Falene, la especialista de @MONSTER_RACE@ líder en todo @W
 #: /Game/Dialogue/Fern/Default/FernDefault01_RL_T.Default__FernDefault01_RL_T_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",03C3FCAE4B8424BCF5F580BC933E08E8"
 msgid "Why did you call me master?"
-msgstr "¿Por qué me llamaste, Master?"
+msgstr "¿Por qué me llamaste Master?"
 
 #. Key:	03FDE484412EB5432BA89A9FF52176AD
 #. SourceLocation:	/Game/Dialogue/Cassie/SexScenes/CassieSplintersT.Default__CassieSplintersT_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Cassie/SexScenes/CassieSplintersT.Default__CassieSplintersT_C.SessionData.Lines(3).Lines
 msgctxt ",03FDE484412EB5432BA89A9FF52176AD"
 msgid "Meow! It feels so good! I'm going to get kitty cum all over myself!"
-msgstr "¡Miau! ¡Se siente tan bien! ¡Voy a hacer que la gatita se corra por todas partes!"
+msgstr "¡Miau! ¡Se siente tan bien! ¡Voy a hacer que el gatito se corra por todas partes!"
 
 #. Key:	0417FF204F76BA02C95525915D7673A9
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowKeystone.Default__WidowKeystone_C.SessionData.Lines(1).Lines
@@ -272,14 +272,14 @@ msgstr "Avísame si quieres nuevos edificios para tus @MONSTER_RACE@ silvestres.
 #: /Game/Dialogue/Cassie/Default/CassieDungeon.Default__CassieDungeon_C.SessionData.Lines(4).Lines
 msgctxt ",051883BC403A71EC7220ACAE27A63552"
 msgid "That old rusty set of gears above the town entrance probably controls a pulley system."
-msgstr "Ese viejo y oxidado juego de engranajes sobre la entrada de la ciudad probablemente controla un sistema de poleas."
+msgstr "Ese viejo y oxidado juego de engranajes sobre la entrada del pueblo probablemente controla un sistema de poleas."
 
 #. Key:	0522652344116C917836F4A1A78C8815
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R07.Default__CamillaDefault01_R07_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R07.Default__CamillaDefault01_R07_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",0522652344116C917836F4A1A78C8815"
 msgid "Don't waste your beautiful tall body on me human. Just wait for Falene to come back, or go suck on Amber's tits."
-msgstr "No desperdicies tu hermoso y alto cuerpo en mi humana. Solo espera a que vuelva Falene o ve a chupar las tetas de Amber."
+msgstr "No desperdicies tu hermoso y alto cuerpo en mi, humana. Solo espera a que vuelva Falene o ve a chupar las tetas de Amber."
 
 #. Key:	052657834F6DBDBBC49BDAADA6E5E88A
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_RL.Default__NeelaDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
@@ -300,7 +300,7 @@ msgstr "¡Alégrate, las flores han vuelto!"
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_FutaBalls.Default__CamillaDefault01_FutaBalls_C.SessionData.Lines(0).Lines
 msgctxt ",0559493D46F48B86A2683FB3AC087112"
 msgid "Sugar walls before balls!"
-msgstr "¡Azúcar en gotas antes que pelotas!"
+msgstr "¡Coños con mango, sin pelotas colgando!"
 
 #. Key:	056C9C1748701D33A4113FB426A3981C
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraGetKeystone.Default__PetraGetKeystone_C.SessionData.Lines(1).Lines
@@ -356,7 +356,7 @@ msgstr "¡Fern ayuda a Mastah! ¡Fern recolecta fluidossss para ti!"
 #: /Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(8).Lines
 msgctxt ",06F45D04453307E37897C89FC16861F0"
 msgid "Well, I'm sure you best be get'n off!"
-msgstr "Bueno, ¡ehtoy segura de que eh mejoh que te vayah!"
+msgstr "Bueno, ¡ehtoy zegura de que eh mejoh que te vayah!"
 
 #. Key:	070169104C3375DAB052E18982B50AE4
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(3).LinesToMale
@@ -398,7 +398,7 @@ msgstr "Cosecha"
 #: /Game/Dialogue/Fern/Default/FernDefault01.Default__FernDefault01_C.SessionData.Lines(0).Lines
 msgctxt ",07F233504BDA1232640FB1846CBFE868"
 msgid "Mastah! Fern love you."
-msgstr "¡Mastah! Fern te ama."
+msgstr "¡Mastah! Fern te quiere."
 
 #. Key:	07F5EE754EC13715610F3E8746D2A3D2
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_AboutLamias.Default__NeelaDefault01_AboutLamias_C.SessionData.Lines(0).Lines
@@ -419,7 +419,7 @@ msgstr "¡Puedes tener mi semen!"
 #: /Game/Dialogue/OrcChief/Default/OrcDefault03_RL.Default__OrcDefault03_RL_C.ResponseData(4).ResponseData.BreederPrompt
 msgctxt ",085EF70E45D784AFAEFB07BC461A23D9"
 msgid "Are all orcs as brash and dumb as you?"
-msgstr "¿Todos los orcos son tan impetuosos y tontos como tú?"
+msgstr "¿Todos los orcos son tan temerarios y tontos como tú?"
 
 #. Key:	08A1991945921B46D9EF9A94894EF846
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeDefault01.Default__BeeDefault01_C.SessionData.LinesToMale(0).LinesToMale
@@ -454,7 +454,7 @@ msgstr "Créeme, humano, he dado a luz a muchos descendientes."
 #: /Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon2.Default__AmberMaeLockedDungeon2_C.SessionData.Lines(1).Lines
 msgctxt ",093760FD4181D0AA284C4D96884A3801"
 msgid "Took me love for milk too far, 'an the 'ol bovaur genes kicked in."
-msgstr "Me llevó el amor por la leshe demasiado lejoh, y loh geneh de loh viejoh bovaur entraron en arsión."
+msgstr "Me llevó mi amor por la leshe demasiado lejoh, y loh viejoh geneh bovaur entraron en arsión."
 
 #. Key:	094AB3854E6DACE10C94B28ADCB83FE0
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaFaleneWeek.Default__CamillaFaleneWeek_C.SessionData.Lines(2).Lines
@@ -503,7 +503,7 @@ msgstr "Cuando Pawsmaati finalmente desató su río de semen, entré en un estad
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePlay1.Default__MegaSlimePlay1_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",0A6CE0B4469F4068DE66F4AB8EC4EDA9"
 msgid "I think... you might be my best friend of all time."
-msgstr "Creo que... podrías ser mi mejor amiga de todos los tiempos."
+msgstr "Creo que... podrías ser mi mejor amigui de todos los tiempos."
 
 #. Key:	0AA608164C47369E28D0C6BFDB27289A
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_AboutKrakens.Default__MirruDefault01_AboutKrakens_C.SessionData.Lines(0).Lines
@@ -517,7 +517,7 @@ msgstr "¡Somos la raza más noble, poderosa y temida bajo las olas!"
 #: /Game/Dialogue/DragonMatriarch/Default/DMClimaxPeak.Default__DMClimaxPeak_C.SessionData.Lines(3).Lines
 msgctxt ",0B1F283F4C4E0D0752DF53AB312D45F9"
 msgid "I've heard about fertile Bovaur roaming in the south which produce vast quantities of breast milk."
-msgstr "He oído hablar de los fértiles bovaur que deambulan por el sur y producen grandes cantidades de leche materna."
+msgstr "He oído hablar de los fértiles bovaur que deambulan por el sur y producen vastas cantidades de leche materna."
 
 #. Key:	0B2CFD3342EAE68FB552BF9F7876374B
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaHadSex01.Default__NeelaHadSex01_C.SessionData.Lines(2).Lines
@@ -545,14 +545,14 @@ msgstr "Tu tribu orca apesta."
 #: /Game/Dialogue/Romy/Default/RomyHadSex01.Default__RomyHadSex01_C.SessionData.Lines(2).Lines
 msgctxt ",0B796FF84644C0154CA874BFDFA16D50"
 msgid "Let us spend the day together, for here in the warmth of this water we can sing again for hours."
-msgstr "Pasemos el día juntos, porque aquí, en el calor de esta agua, podemos cantar de nuevo durante horas."
+msgstr "Pasemos el día juntos, porque aquí, en el calor de estas aguas, podemos cantar de nuevo durante horas."
 
 #. Key:	0BB0A695454FD69DAA129F82F023EB23
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",0BB0A695454FD69DAA129F82F023EB23"
 msgid "A human! A super cute human, this is my lucky day. I've been waiting for this phenomenon for... huh. Well as long as I can remember!"
-msgstr "¡Una humana! Una humana super linda, este es mi día de suerte. He estado esperando este fenómeno desde... eh. Bueno, ¡desde que puedo recordar!"
+msgstr "¡Una humana! Una humana super linda... este es mi día de suerte. He estado esperando este fenómeno desde... eh. Bueno, ¡desde que puedo recordar!"
 
 #. Key:	0BBD00B64AD7488CC6A8008C2BAF8B41
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.VulwargKennel.ManageActionMessage
@@ -671,7 +671,7 @@ msgstr "Gestiona tus Titanes"
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeVerySad2.Default__MegaSlimeVerySad2_C.SessionData.Lines(0).Lines
 msgctxt ",0DF191BF45A432F3BF190CAA63DF44DA"
 msgid "*Continued sobbing*"
-msgstr "*Sollozos contínuos*"
+msgstr "*Sollozos continuos*"
 
 #. Key:	0DFBAC884A0E11B073E5269E92E6DC30
 #. SourceLocation:	/Game/Breeding/Positions/Doggy.Default__Doggy_C.SessionData.PositionName
@@ -700,7 +700,7 @@ msgstr "Ninfómano"
 #: /Game/Dialogue/Parvati/Default/ParvatiHadSex01.Default__ParvatiHadSex01_C.SessionData.Lines(3).Lines
 msgctxt ",0E3AF3704D88CDB26D17458852A1792E"
 msgid "Using our bodies in ways all too perverse."
-msgstr "Usando nuestros cuerpos de formas demasiado perversas."
+msgstr "Usando nuestros cuerpos de formas todas de un modo muy perverso."
 
 #. Key:	0E4B3CBA440B587A805453A5FAC01859
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDungeon2.Default__CassieDungeon2_C.SessionData.Lines(1).Lines
@@ -820,7 +820,7 @@ msgstr "Ahhhh..."
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFuta(30).LinesToFuta
 msgctxt ",1019EEE14B67704DE6DE0B9FD7D0D596"
 msgid "If you want to learn about how to catch @MONSTER_RACE@, head to the town located up the plateau ahead and speak to my assistant Camilla. You can't miss her... actually wait you might, she's so tiny and cute hehehe."
-msgstr "Si quieres aprender cómo atrapar @MONSTER_RACE@, dirígete a la ciudad ubicada en la meseta más adelante y habla con mi asistente Camilla. No puedes fallarle... en realidad, espera, es posible, es tan pequeña y linda jejeje."
+msgstr "Si quieres aprender cómo atrapar @MONSTER_RACE@, dirígete al pueblo ubicado en la meseta más adelante y habla con mi asistente Camilla. No puedes fallarle... en realidad, espera, es posible, es tan pequeña y linda jejeje."
 
 #. Key:	106EA6A747A0901892BD12A925DA79A5
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy_RL_F.Default__MirruDefault01_BodySexToy_RL_F_C.ResponseData(0).ResponseData.BreederPrompt
@@ -890,7 +890,7 @@ msgstr "Quiero chupártela..."
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_AboutKrakens.Default__MirruDefault01_AboutKrakens_C.SessionData.Lines(3).Lines
 msgctxt ",115E28B04787E362B52C17AF826B86A5"
 msgid "You must understand human, our large fleshy bodies pulse with lust and are difficult to satisfy."
-msgstr "Debes entender humano, nuestros grandes cuerpos carnosos palpitan con lujuria y son difíciles de satisfacer."
+msgstr "Debes entenderlo humano, nuestros grandes cuerpos carnosos palpitan con lujuria y son difíciles de satisfacer."
 
 #. Key:	1187860A495AEE8B52286F8DA6A1DF53
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01_RL_F.Default__FernDefault01_RL_F_C.ResponseData(1).ResponseData.BreederPrompt
@@ -953,7 +953,7 @@ msgstr "Deslízate aquí conmigo, mi cuerpo es sedoso y lleno de dulce néctar. 
 #: /Game/Dialogue/Fern/Default/FernDefault01_RL_F.Default__FernDefault01_RL_F_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",123F93684828FFF522F86B84110A5712"
 msgid "Why did you call me master?"
-msgstr "¿Por qué me llamaste, Master?"
+msgstr "¿Por qué me llamaste Master?"
 
 #. Key:	1240C441425085EA27ECBDBABB3C00AF
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R04.Default__FaleneDefault01_R04_C.SessionData.Lines(14).Lines
@@ -982,7 +982,7 @@ msgstr "Tantas astillas en mi espalda, ¡pero valió la pena!"
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(12).LinesToFemale
 msgctxt ",129E92F14686D57C52A26598C5257AF6"
 msgid "You have a beautiful set of fertile hips and breasts... you will make a great mate!"
-msgstr "Tienes un hermoso conjunto de caderas y pechos fértiles... ¡serás una gran pareja!"
+msgstr "Tienes un hermoso conjunto de fértiles caderas y pechos... ¡serás una gran compañera!"
 
 #. Key:	12AF2DD443EFD1CDF7E19291D7E49384
 #. SourceLocation:	/Game/Ranch/Upgrades/ThriaeHive.Default__ThriaeHive_C.Upgrade.Description
@@ -1094,7 +1094,7 @@ msgstr "Tú eres... el que complació a madre Fern."
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_FloatRhyme.Default__ParvatiDefault01_FloatRhyme_C.SessionData.Lines(3).Lines
 msgctxt ",1494AA5040692D75A2E458AE890541FA"
 msgid "Allow me to show you what She shared, if I may."
-msgstr "Permíteme mostrarte lo que Ella compartió, si me permites."
+msgstr "Si me permites, déjame mostrarte lo que Ella ha compartido."
 
 #. Key:	1495FB154E5C773C51452295CAF9F467
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R02.Default__FaleneDefault01_R02_C.SessionData.Lines(10).Lines
@@ -1108,7 +1108,7 @@ msgstr "Somos tan felices cuando los humanos nos aman y satisfacen nuestros dese
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_Teach.Default__ParvatiDefault01_Teach_C.SessionData.LinesToFuta(0).LinesToFuta
 msgctxt ",14E2045C4451D2597C51F4AAF56AE3B7"
 msgid "Remove your garments, for you must be nude."
-msgstr "Quítate tus prendas, debes estar desnuda."
+msgstr "Quítate tus prendas, debes estar en pelota picada."
 
 #. Key:	14F5C7E34772BFD4F5E7039EF72ACF9E
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaGreeting01.Default__NeelaGreeting01_C.SessionData.Lines(1).Lines
@@ -1122,7 +1122,7 @@ msgstr "A través de todos mis largos años y viajes interminables, nunca pensé
 #: /Game/Dialogue/Fesssi/Default/FesssiCave.Default__FesssiCave_C.SessionData.Lines(5).Lines
 msgctxt ",1558B86B4DAABB7D51D53FB9D3508EBD"
 msgid "The surface is boring and full of self-righteous angels and simpletons. Hiss!"
-msgstr "La superficie es aburrida y está llena de ángeles farisaicos y simplones. ¡Ssss!"
+msgstr "La superficie es aburrida y está llena de ángeles santurrones y simplones. ¡Ssss!"
 
 #. Key:	158D44FA46C00C7898EF1C99A9A99EA7
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_Leylanna.Default__EmissaryDefault01_Leylanna_C.SessionData.Lines(7).Lines
@@ -1164,7 +1164,7 @@ msgstr "¡Sss!"
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_FloatRhyme.Default__ParvatiDefault01_FloatRhyme_C.SessionData.Lines(8).Lines
 msgctxt ",169058BF4DE41C3E4D03D0ABE7BC7F77"
 msgid "We can make love, for it is lonely at times."
-msgstr "Podemos hacer el amor, porque a veces nos sentimos solos."
+msgstr "Podemos hacer el amor, porque solitario a veces es sentido."
 
 #. Key:	16E336BD48B5FD77EAAE96BC1BAAF7D4
 #. SourceLocation:	/Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToMale(2).LinesToMale
@@ -1206,7 +1206,7 @@ msgstr "En realidad, eso no sería útil ahora que lo pienso, pero de todos modo
 #: /Game/Dialogue/OrcChief/Default/OrcAkabekoCheck.Default__OrcAkabekoCheck_C.SessionData.Lines(0).Lines
 msgctxt ",176F7A314E26B5F6293327AB991F4EAA"
 msgid "*Snarl* Glorious!"
-msgstr "*Gruñe* ¡Glorioso!"
+msgstr "*Gruñe* ¡Gloriosa!"
 
 #. Key:	17A76DB943E2CB6F9ACC2A823244D892
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMMuchEnergy.Default__DMMuchEnergy_C.SessionData.LinesToFemale(1).LinesToFemale
@@ -1227,14 +1227,14 @@ msgstr "Ha pasado tanto tiempo desde que probé el semen caliente."
 #: /Game/Dialogue/DragonMatriarch/Default/DMDefault_RL3.Default__DMDefault_RL3_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",186FDC7F49586189532EC29D0F8296D3"
 msgid "It's presently grasslands and trees..."
-msgstr "Actualmente son pastizales y árboles..."
+msgstr "Actualmente son praderas y árboles..."
 
 #. Key:	18CAD01243ECA034DDADA1A0880C715D
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_Forgot.Default__ParvatiDefault01_Forgot_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_Forgot.Default__ParvatiDefault01_Forgot_C.SessionData.Lines(2).Lines
 msgctxt ",18CAD01243ECA034DDADA1A0880C715D"
 msgid "You are in the presence of Pawsmaati, and I am kind."
-msgstr "Estás en presencia de Pawsmaati, y soy bondadosa."
+msgstr "Estás en presencia de Pawsmaati, y soy benevolente."
 
 #. Key:	18D7599649118CDCF2E1C78FFB34E034
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_ChangeSpiritForm.Default__LeylannaDefault01_ChangeSpiritForm_C.SessionData.Lines(0).Lines
@@ -1277,7 +1277,7 @@ msgstr "Qué he hecho..."
 #: /Game/Dialogue/AmberMae/Default/AmberMaeDefault01.Default__AmberMaeDefault01_C.SessionData.Lines(0).Lines
 msgctxt ",19A2E9D044587CE3E0AC5B8D366B6974"
 msgid "Have ye come back to feel 'mai jugs?"
-msgstr "¿Hah vuerto pa sentih mih cántaroh de leshe?"
+msgstr "¿Hah vuerto pa' sentih mih cántaroh de leshe?"
 
 #. Key:	19AB0BB8417E1310F35D1D922EF9CFD5
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadFatAssLamia.Default__DryadFatAssLamia_C.SessionData.Lines(5).Lines
@@ -1312,21 +1312,21 @@ msgstr "Pronto mi colección de néctar estará completa y podré regresar a las
 #: /Game/Dialogue/AmberMae/SexScenes/AmberMilkyF.Default__AmberMilkyF_C.SessionData.Lines(4).Lines
 msgctxt ",1A66A5974B5893066D25B7A93AD8BA38"
 msgid "Does it taste good?"
-msgstr "¿Sabe bien?"
+msgstr "¿Zabe bieh?"
 
 #. Key:	1A7572BD4073E9E25BE3D1889A08E000
 #. SourceLocation:	/Game/Dialogue/Cassie/SexScenes/CassieButterButtF.Default__CassieButterButtF_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Cassie/SexScenes/CassieButterButtF.Default__CassieButterButtF_C.SessionData.Lines(2).Lines
 msgctxt ",1A7572BD4073E9E25BE3D1889A08E000"
 msgid "Experience my amazing butter stick human! Ahhhh..."
-msgstr "¡Experimenta mi increíble barra de mantequilla humano! Ahhhh..."
+msgstr "¡Experimenta mi increíble barra de mantequilla, humana! Ahhhh..."
 
 #. Key:	1A7B16814705FD34BE5FF69AB7855D7B
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiGreeting01.Default__ParvatiGreeting01_C.SessionData.LinesToFuta(3).LinesToFuta
 #: /Game/Dialogue/Parvati/Default/ParvatiGreeting01.Default__ParvatiGreeting01_C.SessionData.LinesToFuta(3).LinesToFuta
 msgctxt ",1A7B16814705FD34BE5FF69AB7855D7B"
 msgid "You seek to learn a new way to use a pleasure hole."
-msgstr "Buscas aprender una nueva forma de usar un agujero del placer."
+msgstr "Buscas aprender una nueva forma de usar un agujero afectivo."
 
 #. Key:	1AF544224BFAECD89C2CE99B8EE6EB2D
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_Formuria.Default__MirruDefault01_Formuria_C.SessionData.Lines(4).Lines
@@ -1340,7 +1340,7 @@ msgstr "Es costumbre que las futuras reinas peregrinen a tierra firme y..."
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(30).LinesToFemale
 msgctxt ",1B5A3D3E4B34533CC5E7E599C01B1A38"
 msgid "If you want to learn about how to catch @MONSTER_RACE@, head to the town located up the plateau ahead and speak to my assistant Camilla. You can't miss her... actually wait you might, she's so tiny and cute hehehe."
-msgstr "Si quieres aprender cómo atrapar @MONSTER_RACE@, dirígete a la ciudad ubicada en la meseta más adelante y habla con mi asistente Camilla. No puedes fallarle... en realidad, espera, es posible, es tan pequeña y linda jejeje."
+msgstr "Si quieres aprender cómo atrapar @MONSTER_RACE@, dirígete al pueblo ubicado en la meseta más adelante y habla con mi asistente Camilla. No puedes fallarle... en realidad, espera, es posible, es tan pequeña y linda jejeje."
 
 #. Key:	1B9EA938413881EEDE041F85884A4BC3
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_RL.Default__FaleneDefault01_RL_C.ResponseData(8).ResponseData.BreederPrompt
@@ -1361,7 +1361,7 @@ msgstr "Ahora... ahhh... ohhh..."
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_Teach.Default__ParvatiDefault01_Teach_C.SessionData.Lines(1).Lines
 msgctxt ",1BD44FF4429194137A0C4CAF227F2CA1"
 msgid "Contemplate for moment while I apply some lube."
-msgstr "Contempla por un momento mientras aplico un poco de lubricante."
+msgstr "Contempla por un momento mientras la dejo bien lubricada."
 
 #. Key:	1BE1CDD644277334F98620A99521B9DC
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_HowToSpiritForm_RL_F.Default__LeylannaDefault01_HowToSpiritForm_RL_F_C.ResponseData(1).ResponseData.BreederPrompt
@@ -1417,7 +1417,7 @@ msgstr "Luego se aparearon con las criaturas naturales del mundo. Sí... lo prim
 #: /Game/Dialogue/Leylanna/Default/LeylannaDefault01_RechargeSpiritForm.Default__LeylannaDefault01_RechargeSpiritForm_C.SessionData.Lines(2).Lines
 msgctxt ",1C9CDC1147105A3D3F0A43BB6C94695C"
 msgid "Alternatively, you can recharge your spirit form partially by engaging in sex with blessed ones."
-msgstr "Alternativamente, puedes recargar tu forma espiritual parcialmente al tener sexo con los bendecidos."
+msgstr "Alternativamente, puedes recargar tu forma espiritual parcialmente al tener sexo con bendecidos."
 
 #. Key:	1CB51DBE4D43642F605E479B59AC73A0
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.EM_HedonDungeonSwitch.Message
@@ -1501,7 +1501,7 @@ msgstr "Lamentablemente, ya no puedo ayudarte a recolectar fluidos de @MONSTER_R
 #: /Game/Dialogue/Kybele/Default/KybeleDragonMatriarch.Default__KybeleDragonMatriarch_C.SessionData.Lines(4).Lines
 msgctxt ",1D9FC9EA4EBB827C25C418BF316240BB"
 msgid "This lust is driving me mad human! You have no idea."
-msgstr "¡Esta lujuria me está volviendo loca humano! No tienes idea."
+msgstr "¡Esta lujuria me está volviendo loca, humano! No tienes idea."
 
 #. Key:	1DA742CA40AC6A3A7EC5B6834EEA93B8
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_AboutMusic.Default__RomyDefault01_AboutMusic_C.SessionData.Lines(2).Lines
@@ -1522,7 +1522,7 @@ msgstr "¡Bebihte musho para una mosa pequeñita!"
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_Teach.Default__ParvatiDefault01_Teach_C.SessionData.Lines(5).Lines
 msgctxt ",1E0C491A43E8C2F67FA568B20B5A6743"
 msgid "Pay close attention to my form, and learn you should."
-msgstr "Presta mucha atención a mi forma, y aprende lo que debas."
+msgstr "Presta mucha atención a mi forma, y aprende lo esencial."
 
 #. Key:	1E23F2524EB7DC68DC07EC92E709C65F
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernGreeting03.Default__FernGreeting03_C.SessionData.LinesToFuta(4).LinesToFuta
@@ -1550,7 +1550,7 @@ msgstr "¡Tanto placer! Ahhh..."
 #: /Game/Dialogue/Emissary/Default/EmissaryGreeting01.Default__EmissaryGreeting01_C.SessionData.Lines(5).Lines
 msgctxt ",1E80A3A048E90BE3C26622BC4F2230F7"
 msgid "Bring them to me so that the Goddess can be reunited with her children. You shall be rewarded with the crystalized cum of the Goddess Herself."
-msgstr "Tráemelos para que la Diosa pueda reunirse con sus hijos. Serás recompensado con el semen cristalizado de la propia Diosa."
+msgstr "Tráemelos para que la Diosa pueda reunirse con sus hijos. Serás recompensado con el semen cristalizado de la mismísima Diosa."
 
 #. Key:	1E9E8C004AF398F32ECD97B66BFC3438
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01_RL_M.Default__FernDefault01_RL_M_C.ResponseData(2).ResponseData.BreederPrompt
@@ -1564,7 +1564,7 @@ msgstr "¿Qué puedes hacer?"
 #: /Game/Dialogue/Cassie/Default/CassieHadSex01.Default__CassieHadSex01_C.SessionData.LinesToFemale(5).LinesToFemale
 msgctxt ",1EB41EAD40088E3874A4E0A7F3C437DC"
 msgid "I need to release again already... you humans have it so easy."
-msgstr "Necesito descargar otra vez de nuevo... vosotros los humanos lo tenéis muy fácil."
+msgstr "Necesito descargar de nuevo ya... vosotros los humanos lo tenéis muy fácil."
 
 #. Key:	1EB7986D40F6A7B90EB5ADB781104A11
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_RL.Default__LeylannaDefault01_RL_C.ResponseData(6).ResponseData.BreederPrompt
@@ -1599,7 +1599,7 @@ msgstr "Mis chicas ya están trabajando duro para cosecharlas."
 #: /Game/Dialogue/Monarch/Default/MonarchHaveKeystone2.Default__MonarchHaveKeystone2_C.SessionData.Lines(2).Lines
 msgctxt ",1EC6ED68400A0EEDE25F8BA9CAB37F8E"
 msgid "T-t-thank you human!"
-msgstr "¡G-g-gracias humano!"
+msgstr "¡G-g-gracias, humano!"
 
 #. Key:	1EDF51EB413B2D360FB8C6B5AD2E62ED
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_Forgot_RL.Default__ParvatiDefault01_Forgot_RL_C.ResponseData(1).ResponseData.BreederPrompt
@@ -1627,7 +1627,7 @@ msgstr "¡Ah, que pareja tan gloriosa me has dado!"
 #: /Game/Dialogue/QueenBee/Default/BeeHaveKeystone.Default__BeeHaveKeystone_C.SessionData.Lines(7).Lines
 msgctxt ",1F39C5E04BCD3150F989F3994E948682"
 msgid "We shall continue to wait for our savior. Someone who is one with the soil itself, a true maiden of nature."
-msgstr "Seguiremos esperando a nuestro salvador. Alguien que es uno con el suelo mismo, una verdadera doncella de la naturaleza."
+msgstr "Seguiremos esperando a nuestro salvador. Alguien que es uno con el suelo mismo, un verdadero señor de la naturaleza."
 
 #. Key:	1F41165A452FBA12C2CF81A71C1DE5AC
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadFatAssLamia.Default__DryadFatAssLamia_C.SessionData.Lines(1).Lines
@@ -1691,7 +1691,7 @@ msgstr "Fern espera que esto complazca mucho a Mastah..."
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",20A752DD41AFEBDD2A4852BD029B894E"
 msgid "You have just become @WORLD_NAME@'s newest resident!"
-msgstr "¡Te acabas de convertir en el residente más nuevo de @WORLD_NAME@!"
+msgstr "¡Te acabas de convertir en la residente más nueva de @WORLD_NAME@!"
 
 #. Key:	20BEB0FA47066DBAB732F68642C6BAC3
 #. SourceLocation:	/Game/Breeding/Positions/Test5.Default__Test5_C.SessionData.PositionName
@@ -1839,7 +1839,7 @@ msgstr "Humano, mira lo sucio que te has vuelto. No, no, esto no servirá."
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03_R02.Default__FernDefault03_R02_C.SessionData.Lines(2).Lines
 msgctxt ",22721E7243A0F89426773BB6C47E987A"
 msgid "We can have a lot of fun with my flower body! I have wanted to make love with you Master..."
-msgstr "¡Podemos divertirnos mucho con mi cuerpo de flor! He querido hacer el amor contigo, Master..."
+msgstr "¡Podemos divertirnos mucho con mi cuerpo de flor! He estado queriendo hacer el amor contigo, Master..."
 
 #. Key:	22A642E14AB14A866F4A749782B623B0
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToFemale(3).LinesToFemale
@@ -1860,7 +1860,7 @@ msgstr "Gestiona tus Bovaurs"
 #: /Game/Dialogue/Leylanna/Default/LeylannaOldTempleDungeon1.Default__LeylannaOldTempleDungeon1_C.SessionData.Lines(0).Lines
 msgctxt ",233ACAAA4B9A80E38B57579ACF78F5DF"
 msgid "Sooooo very high human."
-msgstr "Taaaaan alto humano."
+msgstr "Asííííí muy alto, humano."
 
 #. Key:	2341F9304FDFA81B77486F840A0E749C
 #. SourceLocation:	/Game/Ranch/Upgrades/MuttHut.Default__MuttHut_C.Upgrade.Description
@@ -1881,14 +1881,14 @@ msgstr "Esto le permite capturar y almacenar todas las variantes de Silvanos."
 #: /Game/Dialogue/Fern/SexScenes/FernCum_01.Default__FernCum_01_C.SessionData.Lines(0).Lines
 msgctxt ",236BBFF14A62BA287C86179E8ACDDCA9"
 msgid "Mastah... your dick so big! Many fluids will it give me."
-msgstr "¡Mastah... tu pene es tan grande! Me dará muchos fluidos."
+msgstr "¡Mastah... tu pene tan grande! Me dará muchos fluidos."
 
 #. Key:	2373050C45C9AA9783D038B170402B88
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_R02_R01.Default__FernDefault02_R02_R01_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02_R02_R01.Default__FernDefault02_R02_R01_C.SessionData.Lines(2).Lines
 msgctxt ",2373050C45C9AA9783D038B170402B88"
 msgid "You could... always keep giving me your fluids. I will reward you with intense pleasure and that shiny stuff you like so much."
-msgstr "Podrías... siempre seguir dándome tus fluidos. Te recompensaré con un placer intenso y esas cosas brillantes que tanto te gustan."
+msgstr "Siempre... podrías seguir dándome tus fluidos. Te recompensaré con un placer intenso y esas cosas brillantes que tanto te gustan."
 
 #. Key:	239678F6481C22C297A01BAF6A94E397
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy_RL_T.Default__MirruDefault01_BodySexToy_RL_T_C.ResponseData(0).ResponseData.BreederPrompt
@@ -2008,7 +2008,7 @@ msgstr "Soy una doncella de guerra centauro bien entrenada, no tendrías ninguna
 #: /Game/Dialogue/Fesssi/Default/FesssiHadSex01.Default__FesssiHadSex01_C.SessionData.LinesToFuta(1).LinesToFuta
 msgctxt ",255D031B4240EE3EF4E557AE245DE751"
 msgid "I'm certain you found it quite pleasurable."
-msgstr "Estoy seguro de que te pareció bastante placentero."
+msgstr "Estoy segura de que te pareció bastante placentero."
 
 #. Key:	2562C2DF4A1E2558709AB9BF6D7F7974
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaHadSex01.Default__NeelaHadSex01_C.SessionData.Lines(3).Lines
@@ -2072,7 +2072,7 @@ msgstr "¡Haz lo que quieras conmigo!"
 #: /Game/Dialogue/Autumn/Default/DryadHadSex01.Default__DryadHadSex01_C.SessionData.Lines(2).Lines
 msgctxt ",26DAA5B74F8BBB68C15E26ADBB255431"
 msgid "It's true what they say about humans, you really can please us like nothing else."
-msgstr "Es cierto lo que dicen de los humanos, realmente puedes complacernos como nada más."
+msgstr "Es cierto lo que dicen de los humanos, realmente puedes complacernos como ningún otro."
 
 #. Key:	26DCB9EA476437386094CA87FFE3E422
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryBlessedInquiry01_R02.Default__EmissaryBlessedInquiry01_R02_C.SessionData.Lines(0).Lines
@@ -2107,7 +2107,7 @@ msgstr "Los Pastos del Placer ahora son accesibles."
 #: /Game/Dialogue/Blossom/Default/BlossomDefault01.Default__BlossomDefault01_C.SessionData.Lines(0).Lines
 msgctxt ",276B525843A991FAE2D5FAAE9243EFC9"
 msgid "Mastah! Blossom love you."
-msgstr "¡Mastah! Blossom te ama."
+msgstr "¡Mastah! Blossom te quiere."
 
 #. Key:	2792356C47CF43619493DA8F71F0D9A0
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(29).LinesToMale
@@ -2184,7 +2184,7 @@ msgstr "¡Oh, maldita sea, he dicho demasiado!"
 #: /Game/Dialogue/Fesssi/Default/FesssiHowLong.Default__FesssiHowLong_C.SessionData.Lines(10).Lines
 msgctxt ",293B31924F2C8CE36DB46AB48441D958"
 msgid "They found every way to make me climax, and it wassss glorious!"
-msgstr "Encontraron todassss lassss formassss de hacerme llegar al clímax, ¡y fue glorioso!"
+msgstr "Encontraron todas las formassss de hacerme llegar al clímax, ¡y fue glorioso!"
 
 #. Key:	29A421FC41D83A2B9DCC669ECA1F708D
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(34 - Value).TraitIcons.HelpText
@@ -2284,7 +2284,7 @@ msgstr "¿Puedo tener tu Keystone?"
 #: /Game/Dialogue/Romy/Default/RomyDefault01_YourMusic_RL.Default__RomyDefault01_YourMusic_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",2BCA631C4BEC509E1B1DAC824001A31A"
 msgid "Whoa, actually I'm tone-deaf."
-msgstr "Vaya, realmente estoy sorda."
+msgstr "Vaya, en realidad soy de oído duro."
 
 #. Key:	2BD0260D4AF5544E8E7FEE98A41B8289
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchDefault01.Default__MonarchDefault01_C.SessionData.LinesToFemale(3).LinesToFemale
@@ -2340,7 +2340,7 @@ msgstr "¡Nadie puede pasar!"
 #: /Game/Dialogue/Romy/Default/RomyDefault01_AboutMusic.Default__RomyDefault01_AboutMusic_C.SessionData.Lines(0).Lines
 msgctxt ",2CCE0ADD406CF961196E5BAEDA387652"
 msgid "Can you not hear it?"
-msgstr "¿No puedes oírlo?"
+msgstr "¿No puedes oírla?"
 
 #. Key:	2D2E42E44183AC98D3F98B8BCC03296A
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraAboutPawsmaati.Default__PetraAboutPawsmaati_C.SessionData.Lines(8).Lines
@@ -2354,7 +2354,7 @@ msgstr "Si deseas aprender nuevas formas de tener sexo, ve a visitar Pawmaati. �
 #: /Game/Dialogue/QueenBee/Default/BeeDefault01_RL.Default__BeeDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",2D3C1B2D468CB7B71E995CBC072D4767"
 msgid "Uh... no?"
-msgstr "Uh... ¿no?"
+msgstr "Eh... ¿no?"
 
 #. Key:	2D40A8404D1D3D0D2D24B49349427E5A
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernGreeting03.Default__FernGreeting03_C.SessionData.LinesToFemale(3).LinesToFemale
@@ -2389,7 +2389,7 @@ msgstr "Con frecuencia debo cambiar mis prendas inferiores ya que mi vagina siem
 #: /Game/Dialogue/Fern/SexScenes/FernMilk_01.Default__FernMilk_01_C.SessionData.Lines(4).Lines
 msgctxt ",2DC7EABB434FE7136DE3498D19A6B8B9"
 msgid "Give Fern all milky... hiss! Grow faster with more milky."
-msgstr "Dale a Fern toda lo lechoso... ¡Sss! Crezco más rápido con más lechoso."
+msgstr "Dale a Fern todo lo lechoso... ¡Sss! Crezco más rápido con más lechoso."
 
 #. Key:	2DF7474B4ED132A075973ABFA667399C
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_RL.Default__RomyDefault01_RL_C.ResponseData(4).ResponseData.BreederPrompt
@@ -2410,7 +2410,7 @@ msgstr "¿Quizás mis pezones?"
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R04.Default__FaleneDefault01_R04_C.SessionData.Lines(0).Lines
 msgctxt ",2E18B0B24CC860D3136F0CA493EDDD3B"
 msgid "Ohhh... that's going to be tough to talk about without cumming right here..."
-msgstr "Ohhh ... será difícil hablar de eso sin correrte aquí mismo..."
+msgstr "Ohhh... será difícil hablar de eso sin correrme aquí mismo..."
 
 #. Key:	2E25C7F94C5F91F1328BC39C52574333
 #. SourceLocation:	/Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToMale(1).LinesToMale
@@ -2459,7 +2459,7 @@ msgstr "Pronto Ella se dio cuenta de que faltaba algo, ya que la luz no tenía n
 #: /Game/Dialogue/Fern/Default/FernDefault01_R04.Default__FernDefault01_R04_C.SessionData.Lines(1).Lines
 msgctxt ",2E926B8847D675F1C4CAAFAC2732930B"
 msgid "Fern need human milk to grow into big Alraune! Hissss, Fern suck nipples now!"
-msgstr "¡Fern necesita leche humana para convertirse en una gran alraune! ¡Sssss, Fern ahora chupa pezones!"
+msgstr "¡Fern necesita leche humana para convertirse en gran alraune! ¡Sssss, Fern ahora chupa pezones!"
 
 #. Key:	2EDA99CC46CBEB3206A527B95F55FAB9
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMDefault01.Default__DMDefault01_C.SessionData.Lines(1).Lines
@@ -2494,7 +2494,7 @@ msgstr "El poder de una dríada alcanza su cumbre en el momento del orgasmo."
 #: /Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(4).Lines
 msgctxt ",2F5513164D00080A441C1292E501C786"
 msgid "If ye have @MONSTER_RACE@ milk to sell, or if ye want te buy some then I'm yer gal!"
-msgstr "Si tieneh leshe de @MONSTER_RACE@ pa' vendeh, o si quiereh comprah un poco, en ese caso ¡soy tu shica!"
+msgstr "Si tieneh leshe de @MONSTER_RACE@ pa' vendeh, o si quiereh comprah argo, en ese caso ¡soy tu shica!"
 
 #. Key:	2F7D02EE4B2C5C30E72919BE9D83BD1F
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleDragonMatriarch.Default__KybeleDragonMatriarch_C.SessionData.Lines(5).Lines
@@ -2508,14 +2508,14 @@ msgstr "Como recompensa, la Matriarca Dragón me prometió la oportunidad de apa
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(2).Lines
 msgctxt ",2F988E7B4E35BA65FB81488EC3339C51"
 msgid "First, She made love with Herself to bring forth light and the Seraphim, my kin, were born."
-msgstr "Primero, Ella hizo el amor con Ella misma para dar a luz y las serafines, mis parientes, nacieron."
+msgstr "Primero, Ella hizo el amor con Ella misma para traer a luz y los serafines, mis parientes, nacieron."
 
 #. Key:	2FA4621047A86335175276AF22BFDE52
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon2.Default__AmberMaeLockedDungeon2_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon2.Default__AmberMaeLockedDungeon2_C.SessionData.Lines(0).Lines
 msgctxt ",2FA4621047A86335175276AF22BFDE52"
 msgid "If ye think I'm a big cow today, 'mai goodness was I larger in me younger days!"
-msgstr "Si piensah que soy una vaca grande hoy, ¡santo cielo, era máh grande en mi juventuh!"
+msgstr "Si piensah que soy una vaca grande hoy, ¡santo cielo, era máh grande en mih díah de juventuh!"
 
 #. Key:	2FA59C8A48A63BD0FE6D0289A8AF9587
 #. SourceLocation:	/Game/Dialogue/Yasmine/Default/YasmineDefault02_RL.Default__YasmineDefault02_RL_C.ResponseData(0).ResponseData.BreederPrompt
@@ -2585,14 +2585,14 @@ msgstr "El material en el agua siempre está frío... oh, el limo que podría ha
 #: /Game/Dialogue/Kybele/Default/KybeleRideYou_RL_T.Default__KybeleRideYou_RL_T_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",308B8DB245EC118210674A84BB3AFDC3"
 msgid "Aww what an adorable titty pony."
-msgstr "Amm, que adorable poni tetudita."
+msgstr "Amm, que adorable poni tetuda."
 
 #. Key:	3092F47E411D4A54A80D53BAF9BCBC3F
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToFuta(5).LinesToFuta
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToFuta(5).LinesToFuta
 msgctxt ",3092F47E411D4A54A80D53BAF9BCBC3F"
 msgid "It's a nutritious aphrodisiac, a very powerful one so be careful!"
-msgstr "Es un afrodisíaco nutritivo, uno muy poderoso, ¡así que ten cuidado!"
+msgstr "Es un afrodisíaco nutritivo, ¡uno muy poderoso, así que ten cuidado!"
 
 #. Key:	30940E7C46EDA0BA71E783B92668ECFD
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernHadSex01.Default__FernHadSex01_C.SessionData.Lines(0).Lines
@@ -2669,14 +2669,14 @@ msgstr "No, no disfruto estando aquí todo el día usando este ridículo casco."
 #: /Game/Dialogue/Cassie/SexScenes/CassieSplintersT.Default__CassieSplintersT_C.SessionData.Lines(6).Lines
 msgctxt ",322489D0449B3ABC5F1D12BCD6CAD220"
 msgid "Ouch, I'm getting splinters in my back! Ohhh... worth it."
-msgstr "¡Ay, se me está astillando la espalda! Ohhh... vale la pena."
+msgstr "¡Ay, se me clavan astillas en mi espalda! Ohhh... vale la pena."
 
 #. Key:	323DCA0444372E8B59354A9FC665147D
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchGreeting01.Default__MonarchGreeting01_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Monarch/Default/MonarchGreeting01.Default__MonarchGreeting01_C.SessionData.Lines(4).Lines
 msgctxt ",323DCA0444372E8B59354A9FC665147D"
 msgid "Uh, m-m-my name is Monarch."
-msgstr "Uh, m-m-mi nombre es Monarch."
+msgstr "Eh, m-m-mi nombre es Monarch."
 
 #. Key:	324ED3C844A0E2724766EB9155484064
 #. SourceLocation:	/Game/Dialogue/Neela/SexScenes/NeelaSnakeCuddleT.Default__NeelaSnakeCuddleT_C.SessionData.Lines(1).Lines
@@ -2690,7 +2690,7 @@ msgstr "Te sientes tan bien humano... ahhhh."
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_Forgot.Default__ParvatiDefault01_Forgot_C.SessionData.Lines(4).Lines
 msgctxt ",325B057D42B7367B320C54941EEE0BA6"
 msgid "I will show again how to move your body beyond all measure."
-msgstr "Te mostraré de nuevo cómo mover tu cuerpo más allá de todo límite."
+msgstr "Te mostraré de nuevo cómo tu cuerpo más allá de todo límite mover."
 
 #. Key:	32E74CA64F7C6339A9D526A19496DD86
 #. SourceLocation:	/Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToFemale(0).LinesToFemale
@@ -2718,7 +2718,7 @@ msgstr "Ha sioh un plaseh conoserte @BREEDER_NAME@..."
 #: /Game/Dialogue/Cassie/Default/CassieGreeting01.Default__CassieGreeting01_C.SessionData.Lines(5).Lines
 msgctxt ",335AC6B54A917B8EBB17218E2A338F3C"
 msgid "Name's Cassie, I'm the architect in town."
-msgstr "Me llamo Cassie, soy la arquitecta de la ciudad."
+msgstr "Me llamo Cassie, soy la arquitecta del pueblo."
 
 #. Key:	33869B7A401E77AD997246A9AFD3C136
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcGreeting01.Default__OrcGreeting01_C.SessionData.Lines(3).Lines
@@ -2795,7 +2795,7 @@ msgstr "Monarch está satisfecha."
 #: /Game/Dialogue/Cassie/Default/CassieDefault01_Meow_ButterStick.Default__CassieDefault01_Meow_ButterStick_C.SessionData.Lines(0).Lines
 msgctxt ",34C104D84D1D1734B9408FA6B2BDA125"
 msgid "Awww... meow... Cassie is sad now."
-msgstr "Ammm… miau... Cassie esta triste ahora."
+msgstr "Ammm... miau... Cassie esta triste ahora."
 
 #. Key:	350B5B304D18A9FD50E44AA8A979877B
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMSoBeIt.Default__DMSoBeIt_C.SessionData.Lines(0).Lines
@@ -2837,21 +2837,21 @@ msgstr "Si tuviera que pasar el resto de la eternidad en un lugar, no querría q
 #: /Game/Dialogue/Kybele/Default/KybeleTittyPony_T.Default__KybeleTittyPony_T_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",35908AA04644610D46AB42B909BDD768"
 msgid "That's it human, you have annoyed me long enough. Bend over and prepare to be stuffed with my fat spear!"
-msgstr "Eso es humana, me has molestado lo suficiente. ¡Inclínate y prepárate para ser llenada con mi gorda lanza!"
+msgstr "Eso es humana, me has molestado lo suficiente. ¡Inclínate y prepárate para ser rellenada con mi gorda lanza!"
 
 #. Key:	35B0312145CDC987463545B35DBCF219
 #. SourceLocation:	/Game/Dialogue/Mirru/SexScenes/MirruSnatchT.Default__MirruSnatchT_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Mirru/SexScenes/MirruSnatchT.Default__MirruSnatchT_C.SessionData.Lines(0).Lines
 msgctxt ",35B0312145CDC987463545B35DBCF219"
 msgid "Submit human... I cannot control my desires!"
-msgstr "Entrégate humano... ¡No puedo controlar mis deseos!"
+msgstr "Entrégate humano... ¡no puedo controlar mis deseos!"
 
 #. Key:	35BF63974E330C75B3359E8E1E99F0CB
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(11).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(11).Lines
 msgctxt ",35BF63974E330C75B3359E8E1E99F0CB"
 msgid "However the demons grew weary of being governed by archangels, and decided to revolt."
-msgstr "Sin embargo, los demonios se cansaron de ser gobernados por las arcángeles y decidieron rebelarse."
+msgstr "Sin embargo, los demonios se cansaron de ser gobernados por los arcángeles y decidieron sublevarse."
 
 #. Key:	35CF617940B0723BA4795CA4E3D0FA22
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_StartLoveMakingT.Default__LeylannaDefault01_StartLoveMakingT_C.SessionData.Lines(0).Lines
@@ -2998,7 +2998,7 @@ msgstr "¡Tendrás que pasar por encima mío!"
 #: /Game/Dialogue/Fesssi/Default/FesssiTaskFulfilled.Default__FesssiTaskFulfilled_C.SessionData.Lines(0).Lines
 msgctxt ",386696884552AA79E38A38B6CD4C33BA"
 msgid "Freedom! The fresh air feels sssso good. The titan you bred me was so strong, it had no trouble lifting my heavy body. It even smashed a few surrounding rocks too!"
-msgstr "¡Libertad! El aire fresco se siente muy bien. El titán que me criaste era tan fuerte que no tuvo problemas para levantar mi pesado cuerpo. ¡Incluso aplastó algunas rocas circundantes también!"
+msgstr "¡Libertad! El aire fressssco sienta tan bien. El titán que me criaste era tan fuerte que no tuvo problemas para levantar mi pesado cuerpo. ¡Incluso aplastó algunas rocas circundantes también!"
 
 #. Key:	3888188240872C25EF9A03B26842C93D
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraTaskFulfilled.Default__PetraTaskFulfilled_C.SessionData.Lines(0).Lines
@@ -3033,7 +3033,7 @@ msgstr "Decidí usar mi poder de dríada para producir fruta para ellas, y les e
 #: /Game/Dialogue/Kybele/Default/KybeleTittyPony.Default__KybeleTittyPony_C.SessionData.LinesToMale(1).LinesToMale
 msgctxt ",38F493C44D198004851E1399B9B3A835"
 msgid "It's been sometime since I have been mounted, so I might get rough!"
-msgstr "Ha pasado algún tiempo desde que me montaron, ¡así que podría ponerme dura!"
+msgstr "Ha pasado algún tiempo desde que me montaron, ¡así que podría ponerme brava!"
 
 #. Key:	391607BA4B3A996D1551BC9B7E71F385
 #. SourceLocation:	/Game/Characters/Procedural/Variants/Harpy/Harvest/HarpyHarvest.Default__HarpyHarvest_C.Harvest.RaceName
@@ -3054,7 +3054,7 @@ msgstr "*Chupa* *Chupa*"
 #: /Game/Dialogue/Parvati/Default/ParvatiGreeting01.Default__ParvatiGreeting01_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",396D6F1D4A5CDF3A44406A84BB8CE6D9"
 msgid "A human filled with lust comes before me, this I know."
-msgstr "Un humano lleno de lujuria viene ante mí, esto lo sé."
+msgstr "Esto lo sé, un humano lleno de lujuria ante mí ha de venir."
 
 #. Key:	397B4EDC415499258BF65B825D968230
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeDefault01_RL.Default__AmberMaeDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
@@ -3068,7 +3068,7 @@ msgstr "¿Qué sabes del antiguo templo?"
 #: /Game/Dialogue/AmberMae/Default/AmberMaeDefault01_Accent.Default__AmberMaeDefault01_Accent_C.SessionData.Lines(2).Lines
 msgctxt ",39BB76F04901D85036C696B74CA537B3"
 msgid "She can get mighty cold though, ye best fatten up on 'mai milk if yer head'n that way!"
-msgstr "Aunque puede enfriahse musho, ¡será mejoh que engordeh con mi leshe si te encabezonah de esa manera!"
+msgstr "Aunque puede haseh mushísimo frío, ¡será mejoh que engordeh con mi leshe si vah poh eze camino!"
 
 #. Key:	39E4B8C74F24A77B88CFA89F73E896C7
 #. SourceLocation:	/Game/UI/TaskDescriptions.TaskDescriptions.TextEntries(2).TextEntries
@@ -3159,21 +3159,21 @@ msgstr "Fluidos corporales de Starfallen."
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03_R02.Default__FernDefault03_R02_C.SessionData.Lines(4).Lines
 msgctxt ",3B447AD04300826ECFC550A03A3AA0BC"
 msgid "My lower body is filled with nectar just waiting to surround your body as you cum again... and again."
-msgstr "La parte inferior de mi cuerpo está llena de néctar solo esperando a rodear tu cuerpo mientras te corres una... y otra vez."
+msgstr "La parte inferior de mi cuerpo está llena de néctar esperando a rodear tu cuerpo mientras te corres una... y otra vez."
 
 #. Key:	3B686C7E477142920CF64F8119EC7E6F
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_FloatRhyme.Default__ParvatiDefault01_FloatRhyme_C.SessionData.Lines(6).Lines
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_FloatRhyme.Default__ParvatiDefault01_FloatRhyme_C.SessionData.Lines(6).Lines
 msgctxt ",3B686C7E477142920CF64F8119EC7E6F"
 msgid "Give into your desires, it will not render you weak."
-msgstr "Cede a tus deseos, no te debilitará."
+msgstr "Cede a tus deseos, no te debilitarás."
 
 #. Key:	3B6C0A634B200C954436A296F4A9EFEE
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_HowToSpiritForm.Default__LeylannaDefault01_HowToSpiritForm_C.SessionData.LinesToMale(2).LinesToMale
 #: /Game/Dialogue/Leylanna/Default/LeylannaDefault01_HowToSpiritForm.Default__LeylannaDefault01_HowToSpiritForm_C.SessionData.LinesToMale(2).LinesToMale
 msgctxt ",3B6C0A634B200C954436A296F4A9EFEE"
 msgid "Catch a male Vulwarg if you have not done so, and then return to me. We will then make love and form a covenant."
-msgstr "Atrapa a un macho vulwarg si aún no lo has hecho, y luego vuelve a mí. Luego haremos el amor y formaremos un pacto."
+msgstr "Atrapa un macho vulwarg si aún no lo has hecho, y luego vuelve a mí. Luego haremos el amor y formaremos un pacto."
 
 #. Key:	3B7564A547A46D41C60CB999DCC9B845
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiHowLong.Default__FesssiHowLong_C.SessionData.Lines(4).Lines
@@ -3222,7 +3222,7 @@ msgstr "Colmena de Thriaes"
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePearl.Default__MegaSlimePearl_C.SessionData.Message
 msgctxt ",3C6678BF441FA4DC09CD16B12864C86C"
 msgid "Beautiful Pearl was given away."
-msgstr "Perla Preciosa fue regalada."
+msgstr "La Perla Preciosa fue regalada."
 
 #. Key:	3C6949B84E9BE02327C5408DC7F1D673
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadDefault01_RL.Default__DryadDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
@@ -3236,7 +3236,7 @@ msgstr "¡Puedo ayudarte a hacer una cereza!"
 #: /Game/Dialogue/Emissary/Default/EmissaryGreeting01.Default__EmissaryGreeting01_C.SessionData.Lines(7).Lines
 msgctxt ",3C944B624D25292479528987C3078CBF"
 msgid "For from Her and through Her and to Her are all things. To Her be glory forever."
-msgstr "Porque de Ella y a través de Ella y para Ella son todas las cosas. Para Ella sea la gloria para siempre."
+msgstr "Porque de Ella y a través de Ella y para Ella son todas las cosas. Para Ella sea para siempre la gloria."
 
 #. Key:	3C9BA6E04AC95F2B27A50B89FF127DCA
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowDefault01_RL.Default__WidowDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
@@ -3265,7 +3265,7 @@ msgstr "Ha pasado un tiempo, tal vez debería ir a ver cómo está."
 #: /Game/Dialogue/Kybele/Default/KybeleTittyPony.Default__KybeleTittyPony_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",3CD8374646422958F67B3F8F2C11622C"
 msgid "That should teach you to cross this titty po--I mean mighty centaur warmaiden, again!"
-msgstr "Eso debería enseñarte a cruzar esta poni tet-: ¡otra vez, me refiero a la poderosa doncella-guerrera centauro!"
+msgstr "Eso debería enseñarte a cruzarte con esta poni tet-: ¡otra vez, me refiero a la poderosa doncella-guerrera centauro!"
 
 #. Key:	3D4441784AF4D03AE277679928164F4E
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(21 - Value).TraitIcons.DisplayName
@@ -3280,7 +3280,7 @@ msgstr "Estoico"
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03_RL_F.Default__FernDefault03_RL_F_C.ResponseData(4).ResponseData.BreederPrompt
 msgctxt ",3D80ACD9492E522E22EE0EAAD298E834"
 msgid "I'm climbing in your flower."
-msgstr "Estoy trepando en tu flor."
+msgstr "Estoy trepando por tu flor."
 
 #. Key:	3D8EEBEC4ED68B55EF4D03AE26C8037C
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeDefault01_RL.Default__MegaSlimeDefault01_RL_C.ResponseData(4).ResponseData.BreederPrompt
@@ -3308,7 +3308,7 @@ msgstr "¿Puedo... usar mi juguete contigo?"
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeLikesPresent.Default__MegaSlimeLikesPresent_C.SessionData.Lines(1).Lines
 msgctxt ",3DE7C5E5483FE8321224F9A0BE1EE1E2"
 msgid "I will keep it forever as a token of our friendship!"
-msgstr "¡Lo guardaré para siempre como muestra de nuestra amistad!"
+msgstr "¡La guardaré para siempre como muestra de nuestra amistad!"
 
 #. Key:	3E483C5F491D4BAE82E56082A61D1FA0
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleTaskFulfilled.Default__KybeleTaskFulfilled_C.SessionData.LinesToFemale(5).LinesToFemale
@@ -3456,7 +3456,7 @@ msgstr "Está ante ti una emisaria de la Diosa, y tu arcángel sirviente. Deja q
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R03.Default__FaleneDefault01_R03_C.SessionData.Lines(12).Lines
 msgctxt ",4021F6674834D5C495A7E59231DB4FA4"
 msgid "If you aren't in the mood, you can also catch them by rubbing @MONSTER_RACE@ semen on their skin, or feeding them @MONSTER_RACE@ milk."
-msgstr "Si no está de humor, también puedes atraparlos frotando semen de @MONSTER_RACE@ en su piel o alimentándolos con leche de @MONSTER_RACE@."
+msgstr "Si no estás de humor, también puedes atraparlos frotando semen de @MONSTER_RACE@ en su piel o alimentándolos con leche de @MONSTER_RACE@."
 
 #. Key:	402496A44933EE13233F8E8A45D06E47
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchDefault01_RL.Default__MonarchDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
@@ -3491,7 +3491,7 @@ msgstr "¿Puedes ayudarme a conseguir esa Keystone?"
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeHadSex01.Default__MegaSlimeHadSex01_C.SessionData.LinesToFuta(3).LinesToFuta
 msgctxt ",40FFE44B48699F620EAC16A81249A058"
 msgid "You should stay down here and give me more! We can be friends forever."
-msgstr "¡Deberías quedarte aquí y darme más! Podemos ser amigos para siempre."
+msgstr "¡Deberías quedarte aquí abajo y darme más! Podemos ser amigos para siempre."
 
 #. Key:	410012DF43FE2AB2B4B74FA7EE1CB85E
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeDefault01.Default__AmberMaeDefault01_C.SessionData.Lines(1).Lines
@@ -3547,7 +3547,7 @@ msgstr "Según mis teorías, calculo que los @MONSTER_RACE@ son unas 18 veces m�
 #: /Game/Dialogue/QueenBee/Default/BeeDefault01.Default__BeeDefault01_C.SessionData.LinesToMale(2).LinesToMale
 msgctxt ",41B56BDE47DBF26EB76387BAB182E0D2"
 msgid "Is t-t-there something... you want human?"
-msgstr "¿Hay a-a-algo... que quieras humano?"
+msgstr "¿Hay a-a-algo... que quieras, humano?"
 
 #. Key:	41CE38AC413D8EA31A17AAA16825D852
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimePlay.Default__MegaSlimePlay_C.SessionData.LinesToFemale(1).LinesToFemale
@@ -3561,7 +3561,7 @@ msgstr "Te sentirás tan bien mientras inundo tu útero con mi limo..."
 #: /Game/Dialogue/AmberMae/Default/AmberMaeSuckJugs_Start.Default__AmberMaeSuckJugs_Start_C.SessionData.Lines(1).Lines
 msgctxt ",41D4E33A4F278EEAC8E03DBD1A9618E5"
 msgid "I'm get'n wet, milk me 'lil human! Drink it all!"
-msgstr "¡Me ehtoy mojando, ordéñame peke humano! ¡Bébela toa!"
+msgstr "¡Me ehtoy mojando, ordéñame peke humano! ¡Bébetela toa!"
 
 #. Key:	42094BD145964827266556B272FD2005
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernGreeting03.Default__FernGreeting03_C.SessionData.LinesToMale(4).LinesToMale
@@ -3617,7 +3617,7 @@ msgstr "Meh, soy una alquimista... ¡no creo en estas cosas! ¡Ve a hablar con l
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(5).Lines
 msgctxt ",431393014FD2AE0F14B10994F1A6E951"
 msgid "A force was needed to contrast the light, and so the Goddess gave into Her most lustful desires and birthed the darkness."
-msgstr "Se necesitó una fuerza para contrastar la luz, por lo que la Diosa cedió a Sus deseos más lujuriosos y dio a luz a la oscuridad."
+msgstr "Se necesitaba una fuerza para contrastar la luz, por lo que la Diosa cedió a Sus deseos más lujuriosos y dio a luz a la oscuridad."
 
 #. Key:	432AB6154EB0FCBABFD45A9F48D948F8
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcFixOwnGate.Default__OrcFixOwnGate_C.SessionData.LinesToFemale(3).LinesToFemale
@@ -3729,7 +3729,7 @@ msgstr "Mi gigante pero delicioso culo lleva mucho tiempo atrapado en esta cueva
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(8).Lines
 msgctxt ",44ABED7740DE9FD12170D8B548E87A78"
 msgid "She assigned each world a special Seraphim, an archangel, to guide the evolution of life."
-msgstr "Ella asignó a cada mundo una serafín especial, una arcángel, para guiar la evolución de la vida."
+msgstr "Ella asignó a cada mundo un serafín especial, un arcángel, para guiar la evolución de la vida."
 
 #. Key:	44BC09AE4BDFA439FBFD8BAABD7A96D0
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(25 - Value).TraitIcons.DisplayName
@@ -3751,7 +3751,7 @@ msgstr "Tal es para que Ella decida. Descansa, pues Ella es todopoderosa y amoro
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(19).LinesToFemale
 msgctxt ",44FB7A2943203A7912B1F5B22C5B6DCA"
 msgid "That makes your job a lot easier!"
-msgstr "¡Eso hace que tu trabajo sea mucho más fácil!"
+msgstr "¡Eso hace tu trabajo mucho más fácil!"
 
 #. Key:	451D045F4EC3DCF8BA7211AC97FF4D8A
 #. SourceLocation:	/Game/Characters/Procedural/Variants/Sylvan/Harvest/SylvanHarvest.Default__SylvanHarvest_C.Harvest.RaceName
@@ -3765,14 +3765,14 @@ msgstr "Silvano"
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFuta(12).LinesToFuta
 msgctxt ",451F078442E7E1029E8F99BF760B9E69"
 msgid "You have a beautiful set of fertile hips and breasts... and... ohhhh, a nice thick dick! You, my lovely futa, will make a great mate!"
-msgstr "Tienes un hermoso conjunto de caderas y pechos fértiles... y... ¡ohhhh, un buen y grueso pene! ¡Tú, mi adorable futa, serás una gran pareja!"
+msgstr "Tienes un hermoso conjunto de fértiles caderas y pechos... y... ¡ohhhh, un buen y grueso pene! ¡Tú, mi adorable futa, serás una gran compañera!"
 
 #. Key:	45593BFD42216BAC5309AAAB9A612E59
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiHadSex01.Default__FesssiHadSex01_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/Fesssi/Default/FesssiHadSex01.Default__FesssiHadSex01_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",45593BFD42216BAC5309AAAB9A612E59"
 msgid "Bring that human pussy back to me soon."
-msgstr "Tráeme ese coño humano pronto."
+msgstr "Tráeme ese coño humano de vuelta pronto."
 
 #. Key:	45B1E6E34C7DA1B37BDE04B204DC4C4B
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_RL.Default__MirruDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
@@ -3793,7 +3793,7 @@ msgstr "Gestiona tus Nekos"
 #: /Game/Dialogue/Kybele/Default/KybeleCentaur.Default__KybeleCentaur_C.SessionData.Lines(6).Lines
 msgctxt ",46018B7B49E8F91F3AB3B5A9002485B1"
 msgid "External \"help\" is required, and you are looking tasty at the moment."
-msgstr "Se requiere \"ayuda\" externa, y te ves delicioso en este momento."
+msgstr "Se requiere \"ayuda\" externa, y en este momento te ves delicioso."
 
 #. Key:	464B0F3B450345A0F3EA8E98C67A5248
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(6).LinesToMale
@@ -3828,7 +3828,7 @@ msgstr "¡Mira el tamaño de esa!"
 #: /Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon2.Default__AmberMaeLockedDungeon2_C.SessionData.Lines(3).Lines
 msgctxt ",46C09FA14157EC1F3D6608BB30F25A60"
 msgid "Them townsfolk loved playing with 'mai soft body... *sigh*"
-msgstr "A la gente der pueblo le encantaba jugah con mi zuave cuerpo... *suspira*"
+msgstr "A la gente der puerblo le encantaba jugah con mi zuave cuerpo... *suspira*"
 
 #. Key:	46D776EB4F6C6F71D802088F7C493A82
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToFuta(6).LinesToFuta
@@ -3849,7 +3849,7 @@ msgstr "Fluidos corporales de Silvano."
 #: /Game/Dialogue/Fesssi/Default/FesssiIdiots.Default__FesssiIdiots_C.SessionData.Lines(4).Lines
 msgctxt ",46E1708442BF3BDBC5C555BB87A184A4"
 msgid "Maybe a team of vulwarg males... no they would just want blow jobs and then run away."
-msgstr "Tal vez un equipo de machos vulwarg... no, solo querrían mamadas y luego escapar."
+msgstr "Tal vez un equipo de machos vulwarg... no, solo querrían mamadas y luego huirian."
 
 #. Key:	4713FDFD44B74E42186DE9AD0CAAEBC6
 #. SourceLocation:	/Game/Dialogue/Neela/SexScenes/NeelaSnakeCuddleF.Default__NeelaSnakeCuddleF_C.SessionData.Lines(3).Lines
@@ -3906,7 +3906,7 @@ msgstr "Estéril"
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_Forgot_RL.Default__ParvatiDefault01_Forgot_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",47E16E8D474D1F2D115C12A6DEB45E2B"
 msgid "Oh wait I haven't learned anything yet!!!!!"
-msgstr "¡¡¡¡¡Oh, espera, no he aprendido nada todavía!!!!!"
+msgstr "¡¡Oh, espera, aún no he aprendido nada!!"
 
 #. Key:	47F7DAF04C7F69F373B132BD8B955A76
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcFixOwnGate.Default__OrcFixOwnGate_C.SessionData.LinesToFemale(2).LinesToFemale
@@ -3984,7 +3984,7 @@ msgstr "No me acercaré a ese templo, probablemente intentarán convertirme o me
 #: /Game/Dialogue/Mirru/SexScenes/MirruKrakVag.Default__MirruKrakVag_C.SessionData.Lines(6).Lines
 msgctxt ",48F333E347A7091F18F946AADDC3C69D"
 msgid "Oh... you please this Kraken princess greatly human..."
-msgstr "Oh... complaces a esta princesa kraken enormemente humano..."
+msgstr "Oh... complaces a esta princesa kraken enormemente, humano..."
 
 #. Key:	4941188D4EE43A48ECE99F9361838C0C
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(4).LinesToMale
@@ -3998,7 +3998,7 @@ msgstr "¡Y yo soy una de ellos! ¡Una elfa pintada bendecida para ser exactas!"
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_Teach.Default__ParvatiDefault01_Teach_C.SessionData.Lines(0).Lines
 msgctxt ",4954D9E748572866289FA785934950B8"
 msgid "Remove your garments, for you must be nude."
-msgstr "Quítate tus prendas, debes estar desnudo."
+msgstr "Quítate tus prendas, debes estar en pelota picada."
 
 #. Key:	49C9E46943998C63648E12A033938266
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(9 - Value).TraitIcons.DisplayName
@@ -4069,7 +4069,7 @@ msgstr "¿Qué puedes hacer?"
 #: /Game/Dialogue/Parvati/Default/ParvatiGreeting01.Default__ParvatiGreeting01_C.SessionData.LinesToFemale(7).LinesToFemale
 msgctxt ",4ADC18CD4A8D1152D3ABF788E0A8ECCF"
 msgid "Just as water can take on any form."
-msgstr "Así como el agua puede adoptar cualquier forma."
+msgstr "Así como el agua cualquier forma puede adoptar."
 
 #. Key:	4AF4F6C44BC706495A6BC1910F5EB035
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaFaleneWeek.Default__CamillaFaleneWeek_C.SessionData.Lines(1).Lines
@@ -4090,7 +4090,7 @@ msgstr "¡Puedes tener mi leche materna!"
 #: /Game/Dialogue/Petra/Default/PetraGetKeystone.Default__PetraGetKeystone_C.SessionData.Lines(7).Lines
 msgctxt ",4B400F8545DB288AE092E39BA2CD24BF"
 msgid "If you can find me something that fits Pawsmaati's request, I will get that keystone for you."
-msgstr "Si puedes encontrarme algo que se ajuste a la petición de Pawsmaati, te conseguiré esa Keystone."
+msgstr "Si puedes encontrarme algo que se ajuste a la petición de Pawsmaati, conseguiré esa Keystone para ti."
 
 #. Key:	4B96D56447562EBC8748929A5D3B51FD
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernGreeting02.Default__FernGreeting02_C.SessionData.LinesToFuta(3).LinesToFuta
@@ -4153,7 +4153,7 @@ msgstr "Pero... estás atascada."
 #: /Game/Dialogue/Petra/Default/PetraPracticeMe.Default__PetraPracticeMe_C.SessionData.Lines(2).Lines
 msgctxt ",4CC5D673471A3B46D285D681BCAEC1A8"
 msgid "Ahhh... yes! Well what are you waiting for?"
-msgstr "Ahhh... ¡sí! ¿Bueno, qué estás esperando?"
+msgstr "Ahhh... ¡sí! ¿Bueno, a qué estás esperando?"
 
 #. Key:	4CEEC1684CDAEA938B302F89B5DCC6FD
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiCave.Default__FesssiCave_C.SessionData.Lines(2).Lines
@@ -4188,7 +4188,7 @@ msgstr "Nos encanta crear nuevos @MONSTER_RACE@, para que ellos también puedan 
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R07_RL.Default__CamillaDefault01_R07_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",4DE4EDAD457F0C2715629B82E07D5D91"
 msgid "Oh come here you lovable shortstack!"
-msgstr "¡Oh, ven aquí, adorable montoncito!"
+msgstr "¡Oh, ven aquí, adorable rechonchita!"
 
 #. Key:	4E12D93143928EAE2221E7A3621657C0
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R01.Default__FaleneDefault01_R01_C.SessionData.Lines(8).Lines
@@ -4202,7 +4202,7 @@ msgstr "Mi teoría es que cuando semen y óvulo @MONSTER_RACE@ se unen, fractura
 #: /Game/Dialogue/AmberMae/Default/AmberMaeDefault01_RL.Default__AmberMaeDefault01_RL_C.ResponseData(3).ResponseData.BreederPrompt
 msgctxt ",4E27E33747B868644B436C9F77707525"
 msgid "May I suck on your jugs?"
-msgstr "¿Puedo chupar tus cántaros de leche?"
+msgstr "¿Puedo chupar tus cántaros?"
 
 #. Key:	4E36B8A545FB7E25EE044C834B5EFC4D
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernHadSex02.Default__FernHadSex02_C.SessionData.Lines(0).Lines
@@ -4223,21 +4223,21 @@ msgstr "Recuéstate y relájate @BREEDER_NAME@..."
 #: /Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToMale(8).LinesToMale
 msgctxt ",4E52974540DE6960CB56CDB713C76A05"
 msgid "That must have been you, perhaps you should go and talk to her."
-msgstr "Debes haber sido tú, quizás deberías ir a hablar con ella."
+msgstr "Ese debes haber sido tú, quizás deberías ir a hablar con ella."
 
 #. Key:	4E5BBE2D466F692CEB63ACA293C411A8
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruHadSex01.Default__MirruHadSex01_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/Mirru/Default/MirruHadSex01.Default__MirruHadSex01_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",4E5BBE2D466F692CEB63ACA293C411A8"
 msgid "You have satisfied a kraken princess, and allowed me to release my lust."
-msgstr "Has satisfecho a una princesa kraken, y me has permitido liberar mi lujuria."
+msgstr "Has satisfecho a una princesa kraken, y me has permitido descargar mi lujuria."
 
 #. Key:	4E7910C949370E1A22F20886B7F19689
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryBlessedInquiry01_RL.Default__EmissaryBlessedInquiry01_RL_C.ResponseData(0).ResponseData.BreederPrompt
 #: /Game/Dialogue/Emissary/Default/EmissaryBlessedInquiry01_RL.Default__EmissaryBlessedInquiry01_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",4E7910C949370E1A22F20886B7F19689"
 msgid "Huh... that means you're just as horny then."
-msgstr "Huh... eso significa que eres igual de cachonda entonces."
+msgstr "Ajá... eso significa que eres igual de cachonda entonces."
 
 #. Key:	4E7998DA4738ECC33C9E7DA9B98FC68B
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_BatheAllDay.Default__RomyDefault01_BatheAllDay_C.SessionData.Lines(2).Lines
@@ -4258,7 +4258,7 @@ msgstr "Puedes meterme esa lengua..."
 #: /Game/Dialogue/Romy/Default/RomyDefault01_YourMusic.Default__RomyDefault01_YourMusic_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",4E899A5D4E84988C4EA22C94596B1177"
 msgid "Wave after wave of pleasure will engulf you, and the entire town will know your beautiful voice."
-msgstr "Ola tras ola de placer te envolverá, y toda la ciudad conocerá tu hermosa voz."
+msgstr "Ola tras ola de placer te envolverá, y todo el pueblo conocerá tu hermosa voz."
 
 #. Key:	4E9D03D24AE3DC71062DEA8716955966
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01_RL_T.Default__FernDefault01_RL_T_C.ResponseData(2).ResponseData.BreederPrompt
@@ -4293,7 +4293,7 @@ msgstr "*Chupa* *Lame*"
 #: /Game/Dialogue/Autumn/Default/DryadGreeting01.Default__DryadGreeting01_C.SessionData.Lines(1).Lines
 msgctxt ",4F3471C54B27DDD9BC7D5F8A12D1E871"
 msgid "Soft and plump, with many a bump."
-msgstr "Suave y regordeta, con muchas protuberancias."
+msgstr "Suave y regordeta, con muchos bultos."
 
 #. Key:	4F37D08C43E11EDF706D07998D86692F
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyHadSex01.Default__RomyHadSex01_C.SessionData.LinesGrungy(0).LinesGrungy
@@ -4328,7 +4328,7 @@ msgstr "Sí... tu nombre es @BREEDER_NAME@. ¡Los espíritus me lo han revelado!
 #: /Game/Dialogue/Widow/Default/WidowSpiders.Default__WidowSpiders_C.SessionData.Lines(1).Lines
 msgctxt ",4FA58F3643C40D88119D81857F7F6815"
 msgid "We are reclusive cavern dwellers, and once a home is found it's not uncommon for us to stay there for many years."
-msgstr "Somos solitarios habitantes de las cavernas, y una vez que se encuentra un hogar, no es raro que nos quedemos allí durante muchos años."
+msgstr "Somos solitarias habitantes de las cavernas, y una vez que se encuentra un hogar, no es raro que nos quedemos allí durante muchos años."
 
 #. Key:	4FC454FA455E4284639DF9A235A1B888
 #. SourceLocation:	/Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToFuta(4).LinesToFuta
@@ -4479,7 +4479,7 @@ msgstr "*Chupa* *Chupa*"
 #: /Game/Dialogue/Widow/Default/WidowTaskFullfilled2.Default__WidowTaskFullfilled2_C.SessionData.Lines(3).Lines
 msgctxt ",52FA782943DCF1904C31D0AD39452FE2"
 msgid "Please take the glowing rock on your way out. I feel the hunger creeping up, and my elf is looking full and ready."
-msgstr "Por favor, recoge la roca brillante al salir. Siento que el hambre aumenta y mi elfa parece llena y lista."
+msgstr "Por favor, recoge la roca brillante al salir. Siento que el hambre acecha y mi elfa parece llena y lista."
 
 #. Key:	53133AE5461CD4363425BC8B9E8327F4
 #. SourceLocation:	/Game/Dialogue/Emissary/SexScenes/EmissaryAngelGroinLove.Default__EmissaryAngelGroinLove_C.SessionData.LinesToFemale(0).LinesToFemale
@@ -4493,7 +4493,7 @@ msgstr "Deléitate humana, pues soy tu sirviente."
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_RL.Default__CamillaDefault01_RL_C.ResponseData(6).ResponseData.BreederPrompt
 msgctxt ",535696214ED031B7F34A458925D0CEA8"
 msgid "Falene brings you stuff?"
-msgstr "¿Falene te trae cosas?"
+msgstr "¿Falene te trae material?"
 
 #. Key:	537B245D4CBB8BD28882D3AB47480EA4
 #. SourceLocation:	/Game/Dialogue/Fern/SexScenes/FernCum_01.Default__FernCum_01_C.SessionData.Lines(1).Lines
@@ -4535,7 +4535,7 @@ msgstr "Fern espera que esto complazca mucho a Mastah..."
 #: /Game/Dialogue/AmberMae/Default/AmberMaeSuckJugs_Cancel.Default__AmberMaeSuckJugs_Cancel_C.SessionData.Lines(0).Lines
 msgctxt ",5477799C4F9B5398BECB918C51B6CC44"
 msgid "Forgive me if I was com'n on too strong! I hope I didn't offend ye..."
-msgstr "¡Perdóname si fui demasiao fuehte! Espero no habehte ofendio..."
+msgstr "¡Perdóname si fui demasiao bruhca! Espero no habehte ofendio..."
 
 #. Key:	5487409C445EEB5B2C699C8A5253DD30
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFemale(2).LinesToFemale
@@ -4549,7 +4549,7 @@ msgstr "¿Quizás te gustaría probar mi brillante coño de elfa?"
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeGreeting01.Default__MegaSlimeGreeting01_C.SessionData.Lines(3).Lines
 msgctxt ",5499C216450B8D38D1D5E48EAB4EAE1A"
 msgid "Do you want to meet my best friend?"
-msgstr "¿Quieres conocer a mi mejor amiga?"
+msgstr "¿Quieres conocer a mi mejor amigo?"
 
 #. Key:	54A656CF43AE3DD98B149D8CB0E836B1
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R02.Default__FaleneDefault01_R02_C.SessionData.Lines(4).Lines
@@ -4726,7 +4726,7 @@ msgstr "Quitaré el panal de miel del portón de las Tierras-Colmena."
 #: /Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon.Default__AmberMaeLockedDungeon_C.SessionData.Lines(5).Lines
 msgctxt ",5881DC0E4C70AE1F56EE70A7C1A4A78A"
 msgid "Yer ask'n the wrong lass though, I'm just a simple milkmaid."
-msgstr "Sin embargo, le preguntah a la shica equivocaa, solo soy una simple leshera."
+msgstr "Zin embargo, le ehtah preguntando a la mosa equivocaa, solo zoy una simple leshera."
 
 #. Key:	589C39424192EF623DC606AE1E6D2D75
 #. SourceLocation:	/Game/Ranch/Upgrades/DemonPool.Default__DemonPool_C.Upgrade.DisplayName
@@ -4840,7 +4840,7 @@ msgstr "*Sorbe* *Lame*"
 #: /Game/Dialogue/Cassie/Default/CassieHadSex01.Default__CassieHadSex01_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",5A9731DD46A8ADC8650FC7A682C0D08C"
 msgid "You're going to have lots of cute kittens with how much love butter I gave you!!!"
-msgstr "¡¡¡Vas a tener muchos gatitos lindos con la cantidad de mantequilla de amor que te di!!!"
+msgstr "¡¡¡Vas a tener montones de lindos gatitos con la cantidad de mantequilla de amor que te di!!!"
 
 #. Key:	5AA0883E43DAD4AAE0EF269EA3233B0A
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_RL.Default__ParvatiDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
@@ -4854,7 +4854,7 @@ msgstr "¡Enséñame una nueva posición sexual!"
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(6).Lines
 msgctxt ",5AA8E62541EFA61D3ED30CAD3E1D0946"
 msgid "Demons crawled out of the darkness, and immediately started having sex with the Seraphim."
-msgstr "Los demonios salieron de la oscuridad e inmediatamente comenzaron a tener sexo con las serafines."
+msgstr "Los demonios se arrastraron fuera de la oscuridad e inmediatamente comenzaron a tener sexo con los serafines."
 
 #. Key:	5ACEB47B4DC474437836D1BE5DF53CC7
 #. SourceLocation:	/Game/Dialogue/Blossom/Default/BlossomDefault01_RL_F.Default__BlossomDefault01_RL_F_C.ResponseData(1).ResponseData.BreederPrompt
@@ -4868,7 +4868,7 @@ msgstr "¡Fern, tu flor esta hablando!"
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToFuta(7).LinesToFuta
 msgctxt ",5AEA5C7F4EB5E13F37FC0C9552530212"
 msgid "I want to feel warm human cum course through me!"
-msgstr "¡Quiero sentir un cálido semen humano a través de mí!"
+msgstr "¡Quiero sentir el cálido semen humano a través de mí!"
 
 #. Key:	5B354C0D4D37B6FD0F25BCA917BD6BE1
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeAboutOrb.Default__MegaSlimeAboutOrb_C.SessionData.Lines(6).Lines
@@ -4952,7 +4952,7 @@ msgstr "Cuando la Diosa vio que sus creaciones se entregaban en gran medida a lo
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(18).Lines
 msgctxt ",5D244F6542342816F374B582D37B9B98"
 msgid "Swearing to return again one day, the Goddess departed and faded from sight."
-msgstr "Jurando regresar de nuevo algún día, la Diosa se fue y desapareció de la vista."
+msgstr "Jurando regresar de nuevo algún día, la Diosa partió y se desvaneció de la vista."
 
 #. Key:	5D28B49D4DE445D9A31C4FA2B4501737
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.CBGate_Sands.PlaceMessage
@@ -4966,14 +4966,14 @@ msgstr "El Desierto Lascivo ahora es accesible."
 #: /Game/Dialogue/Fesssi/Default/FesssiIdiots.Default__FesssiIdiots_C.SessionData.Lines(1).Lines
 msgctxt ",5DBBC25548CE64C57F539B87D36558A9"
 msgid "Now human, we are going to need a mighty creature in order to free my girthy hindquarters."
-msgstr "Ahora humano, vamos a necesitar una criatura poderosa para liberar mis orondos cuartos traseros."
+msgstr "Ahora humano, vamos a necesitar una criatura poderosa para liberar mis rollizos cuartos traseros."
 
 #. Key:	5E27E8A74A30D389BBB939B5142249BB
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiGreeting01.Default__ParvatiGreeting01_C.SessionData.LinesToFuta(7).LinesToFuta
 #: /Game/Dialogue/Parvati/Default/ParvatiGreeting01.Default__ParvatiGreeting01_C.SessionData.LinesToFuta(7).LinesToFuta
 msgctxt ",5E27E8A74A30D389BBB939B5142249BB"
 msgid "I greatly desire to experience your fat cock."
-msgstr "Tengo muchas ganas de experimentar tu gorda polla."
+msgstr "Tengo enorme deseo de experimentar tu gordo “pistolero”."
 
 #. Key:	5E335B804845931D253C9186CD06C403
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(8).LinesToFemale
@@ -5051,7 +5051,7 @@ msgstr "Ah, bueno, podría concederte acceso, pero... hay algo que quiero a camb
 #: /Game/Dialogue/Emissary/Default/EmissaryHadSex01.Default__EmissaryHadSex01_C.SessionData.LinesToFuta(3).LinesToFuta
 msgctxt ",604FA2154312C173E208F3949C0C0A75"
 msgid "Judging by the mess on the temple floor, quite good."
-msgstr "A juzgar por el desorden en el suelo del templo, bastante buena."
+msgstr "A juzgar por el desorden en el suelo del templo, bastante bueno."
 
 #. Key:	60635C454CEF8341039602B6529EEE22
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowSpiders.Default__WidowSpiders_C.SessionData.Lines(6).Lines
@@ -5100,7 +5100,7 @@ msgstr "Algunos te adoran tanto que están dispuestos a unirse a tu cuerpo físi
 #: /Game/Dialogue/QueenBee/Default/BeeTaskFulfilled.Default__BeeTaskFulfilled_C.SessionData.Lines(2).Lines
 msgctxt ",611DEEEA4F0BEB84BE76FDAD70AB9B96"
 msgid "You came through for us human, and for that you have my thanks. My girls have removed the honey preventing you from entering Sultry Plateau."
-msgstr "Viniste por nosotras, humano, y por eso tienes mi agradecimiento. Mis chicas te han quitado la miel que te impide entrar en la Meseta Bochornosa."
+msgstr "Viniste por nosotras, humano, y por eso tienes mi agradecimiento. Mis chicas han quitado la miel que te impide entrar en la Meseta Bochornosa."
 
 #. Key:	61341EBA4A04883698FF08BF81A229FB
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_RL.Default__EmissaryDefault01_RL_C.ResponseData(5).ResponseData.BreederPrompt
@@ -5114,14 +5114,14 @@ msgstr "¿Qué es la Gran Concepción?"
 #: /Game/Dialogue/DragonMatriarch/Default/DMTaskFulfilled.Default__DMTaskFulfilled_C.SessionData.Lines(0).Lines
 msgctxt ",613E368A449069B472AC11842731C6AB"
 msgid "Ahhh so sweet and creamy! I haven't felt this good in decades."
-msgstr "¡Ahhh, tan dulce y cremoso! No me había sentido tan bien en décadas."
+msgstr "¡Ahhh, tan dulce y cremosa! No me había sentido tan bien en décadas."
 
 #. Key:	61A8146D43CCAA9D468CCC9D2CB22F42
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon.Default__AmberMaeLockedDungeon_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon.Default__AmberMaeLockedDungeon_C.SessionData.Lines(4).Lines
 msgctxt ",61A8146D43CCAA9D468CCC9D2CB22F42"
 msgid "If I recall... they rigged up some switch 'an pulley system."
-msgstr "Si mar no recuerdo... inhtalaron un interrustor y sihtema de poleah."
+msgstr "Si mar no recuerdo... inhtalaron un sihtema de interrustor y poleah."
 
 #. Key:	61C3C47B425E2ACFE03921A38EDBD93D
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.CBGate_Glade.PlaceMessage
@@ -5184,7 +5184,7 @@ msgstr "¿Por qué me llamaste, Master?"
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(13).Lines
 msgctxt ",627219374671317BBA6148B048EA7B8F"
 msgid "Such creations roamed in weak forms purely by instinct, what you call animals."
-msgstr "Tales creaciones vagaban en formas débiles puramente por instinto, lo que llamais animales."
+msgstr "Tales creaciones vagaban en formas débiles puramente por instinto, lo que llamáis animales."
 
 #. Key:	6272317B4A4AE3E76212F6A3B94CDAAA
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleTaskFulfilled.Default__KybeleTaskFulfilled_C.SessionData.LinesToFuta(2).LinesToFuta
@@ -5219,21 +5219,21 @@ msgstr "No tienes idea de cuánto me estoy conteniendo en este momento..."
 #: /Game/Dialogue/Kybele/Default/KybeleTittyPony_T.Default__KybeleTittyPony_T_C.SessionData.LinesToMale(2).LinesToMale
 msgctxt ",630D79B54CCF1CADC252DB970D8C7327"
 msgid "That should teach you to cross this titty po--I mean mighty centaur warmaiden, again!"
-msgstr "Eso debería enseñarte a cruzar esta poni tet-: ¡otra vez, me refiero a la poderosa doncella-guerrera centauro!"
+msgstr "Eso debería enseñarte a cruzarte con esta poni tet-: ¡otra vez, me refiero a la poderosa doncella-guerrera centauro!"
 
 #. Key:	63185F8D44DB00B8514792BA4971889F
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_SexPositions.Default__FaleneDefault01_SexPositions_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_SexPositions.Default__FaleneDefault01_SexPositions_C.SessionData.Lines(4).Lines
 msgctxt ",63185F8D44DB00B8514792BA4971889F"
 msgid "She will probably know more, she sleeps... I mean gets... around."
-msgstr "Probablemente ella sabrá más, duerme... quiero decir, se mueve... alrededor."
+msgstr "Probablemente ella sabrá más, duerme... quiero decir, se mueve... por todas partes."
 
 #. Key:	6340E0A045F87C6E35C3348C97609B67
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01.Default__ParvatiDefault01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01.Default__ParvatiDefault01_C.SessionData.Lines(1).Lines
 msgctxt ",6340E0A045F87C6E35C3348C97609B67"
 msgid "I want to make love with you, I will not lie."
-msgstr "Quiero hacer el amor contigo, no mentiré."
+msgstr "Quiero hacer el amor contigo, no he mentido."
 
 #. Key:	639BDE8A40D4ABAD77555A89D2C8E86B
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeMasturbate.Default__BeeMasturbate_C.SessionData.Lines(2).Lines
@@ -5261,7 +5261,7 @@ msgstr "*Lame* *Sorbe*"
 #: /Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon.Default__AmberMaeLockedDungeon_C.SessionData.Lines(0).Lines
 msgctxt ",63ACAC1E4A5D5DFE164A168EAFEE76BC"
 msgid "Aye, 'tis been countless years since anyone's been down there!"
-msgstr "¡Seh, han pasao incontableh añoh dehde que arguien ehtuvo allí!"
+msgstr "¡Seh, han pasao incontableh añoh dehde que arguien ehtuvo allí abajo!"
 
 #. Key:	63B540744119014025598C8555237076
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMHadSex01.Default__DMHadSex01_C.SessionData.LinesToFemale(2).LinesToFemale
@@ -5324,21 +5324,21 @@ msgstr "Toma la Perla"
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(27).LinesToFemale
 msgctxt ",646A76464079BB23F12A50A6B8512B75"
 msgid "We just love you too much, and sometimes our desires spiral out of control!"
-msgstr "Te amamos demasiado y, a veces, ¡nuestros deseos se descontrolan!"
+msgstr "Te amamos demasiado y, a veces, ¡nuestros deseos se salen fuera de control!"
 
 #. Key:	646F99EA498DD1E54CCB8AB5413F39DB
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiGreeting01.Default__ParvatiGreeting01_C.SessionData.LinesToFemale(2).LinesToFemale
 #: /Game/Dialogue/Parvati/Default/ParvatiGreeting01.Default__ParvatiGreeting01_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",646F99EA498DD1E54CCB8AB5413F39DB"
 msgid "Different ways of seducing your mates, but all with the same goal."
-msgstr "Diferentes formas de seducir a tus compañeros, pero todas con la misma meta."
+msgstr "Diferentes formas de seducir a tus compañeros, pero todas con el mismo objetivo."
 
 #. Key:	6472B92C4C77BC77E4D51599F203425B
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_RL.Default__CamillaDefault01_RL_C.ResponseData(5).ResponseData.BreederPrompt
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_RL.Default__CamillaDefault01_RL_C.ResponseData(5).ResponseData.BreederPrompt
 msgctxt ",6472B92C4C77BC77E4D51599F203425B"
 msgid "Girthy lump? More like... delicious fuck lump!"
-msgstr "¿Bulto orondo? Mas bien... ¡delicioso bulto que joder!"
+msgstr "¿Bulto rollizo? Mas bien... ¡jodido bulto delicioso!"
 
 #. Key:	6473C6F3408A6FDB0321298B46707D81
 #. SourceLocation:	/Game/Dialogue/Blossom/Default/BlossomDefault01.Default__BlossomDefault01_C.SessionData.Lines(1).Lines
@@ -5401,14 +5401,14 @@ msgstr "En realidad, ¡el culo gordo me recuerda algo!"
 #: /Game/Dialogue/Monarch/Default/MonarchPrettyButterfly.Default__MonarchPrettyButterfly_C.SessionData.Lines(6).Lines
 msgctxt ",657B8CAA4F7FC96AAD9188A418E914E3"
 msgid "To start s-s-sex and... control it."
-msgstr "Para iniciar el s-s-sexo y ... controlarlo."
+msgstr "Para iniciar el s-s-sexo y... controlarlo."
 
 #. Key:	659F65A5454F216DBCA2DE943F3D816D
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_R04.Default__FernDefault02_R04_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02_R04.Default__FernDefault02_R04_C.SessionData.Lines(0).Lines
 msgctxt ",659F65A5454F216DBCA2DE943F3D816D"
 msgid "Oh Master... you are too good to me."
-msgstr "Oh, Master... eres demasiado bueno para mí."
+msgstr "Oh, Master... eres demasiado buena para mí."
 
 #. Key:	65F2B1384977D80660A4E4A91389BC9D
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(12 - Value).TraitIcons.DisplayName
@@ -5500,7 +5500,7 @@ msgstr "¡Soy Amber-Mae, tu mosa leshera bovaur!"
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_Formuria.Default__MirruDefault01_Formuria_C.SessionData.Lines(5).Lines
 msgctxt ",679174774B8AE81A6C98AE933C6D1BF3"
 msgid "Let me just say, \"experience\" what you drylanders have to offer."
-msgstr "Permíteme sólo decir, \"experimenta\" lo que tienen para ofrecer los de tierra firme."
+msgstr "Permíteme decirlo, \"experimenten\" lo que tienen para ofrecer los de tierra firme."
 
 #. Key:	679B9CA8446900121B93359B9CD3CC08
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_YourMusic_ToneDeaf.Default__RomyDefault01_YourMusic_ToneDeaf_C.SessionData.Lines(0).Lines
@@ -5592,7 +5592,7 @@ msgstr ""
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeAboutOrb.Default__MegaSlimeAboutOrb_C.SessionData.Lines(4).Lines
 msgctxt ",694BFC904B3397B73FEBEF836CD65954"
 msgid "We have been best friends ever since, even though she won't tell me her name."
-msgstr "Hemos sido mejores amigos desde entonces, aunque ella no me dirá su nombre."
+msgstr "Hemos sido mejores amigos desde entonces, aunque él no me dirá su nombre."
 
 #. Key:	695409264F52725B30031E8F0FB4052C
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_RL_F.Default__FernDefault02_RL_F_C.ResponseData(2).ResponseData.BreederPrompt
@@ -5613,7 +5613,7 @@ msgstr "Puedo o no aprovecharme de las lindas vacas durmientes..."
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_StartForgotten.Default__ParvatiDefault01_StartForgotten_C.SessionData.Lines(1).Lines
 msgctxt ",697AC02A4A47BBBD70150ABE216F79E9"
 msgid "Contemplate for moment while I apply some lube."
-msgstr "Contempla por un momento mientras aplico un poco de lubricante."
+msgstr "Contempla por un momento mientras te dejo bien lubricado."
 
 #. Key:	698288A146113C1492125B891EA3456D
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleDefault01_RL.Default__KybeleDefault01_RL_C.ResponseData(4).ResponseData.BreederPrompt
@@ -5669,7 +5669,7 @@ msgstr "No se moverá."
 #: /Game/Dialogue/AmberMae/Default/AmberMaeSuckJugs_Start.Default__AmberMaeSuckJugs_Start_C.SessionData.Lines(0).Lines
 msgctxt ",6AD76D124EA5FF55B998D39AD1070F08"
 msgid "Oh my! Ohhhh!"
-msgstr "¡Oh cielos! ¡Ohhhh!"
+msgstr "¡Oh cieloh! ¡Ohhhh!"
 
 #. Key:	6AFADD1A416223C71B86159050C16A67
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchShySexT_RL.Default__MonarchShySexT_RL_C.ResponseData(0).ResponseData.BreederPrompt
@@ -5697,7 +5697,7 @@ msgstr "En cierto modo, envidio a mis hermanos menores, no están obligados a em
 #: /Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon.Default__AmberMaeLockedDungeon_C.SessionData.Lines(2).Lines
 msgctxt ",6BC585A94AB919791876E989ABC6AFC2"
 msgid "Didn't get very far though, me jugs 'an buxom hips said no!"
-msgstr "Sin embargo, no llegué muy lejoh, ¡mis cántaroh de leshe y caderah ezuberanteh dijeron que no!"
+msgstr "Sin embargo, no llegué muy lejoh, ¡mis cántaroh de leshe y mis caderah ezuberanteh dijeron que no!"
 
 #. Key:	6BD3487945B18914AE271E871E682D15
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiTaskFulfilled.Default__FesssiTaskFulfilled_C.SessionData.Lines(3).Lines
@@ -5718,14 +5718,14 @@ msgstr "Soy demasiado tímida... así que solo recojo néctar para nuestra reina
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(26).LinesToFemale
 msgctxt ",6C9735694D5FA2594461AF9E28110F5C"
 msgid "Gently of course. To date there has never been an instance where a @MONSTER_RACE@ has intentionally harmed a human."
-msgstr "Gentilmente por supuesto. Hasta la fecha, nunca ha habido un caso en el que un @MONSTER_RACE@ haya lastimado intencionalmente a un humano."
+msgstr "Gentilmente por supuesto. Hasta la fecha, nunca ha habido un caso en el que un @MONSTER_RACE@ haya lastimado intencionalmente a una humana."
 
 #. Key:	6CE8D4CC4972C62CFCB7FE9919BBA235
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleTittyPony.Default__KybeleTittyPony_C.SessionData.LinesToFuta(2).LinesToFuta
 #: /Game/Dialogue/Kybele/Default/KybeleTittyPony.Default__KybeleTittyPony_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",6CE8D4CC4972C62CFCB7FE9919BBA235"
 msgid "That should teach you to cross this titty po--I mean mighty centaur warmaiden, again!"
-msgstr "Eso debería enseñarte a cruzar esta poni tet-: ¡otra vez, me refiero a la poderosa doncella-guerrera centauro!"
+msgstr "Eso debería enseñarte a cruzarte con esta poni tet-: ¡otra vez, me refiero a la poderosa doncella-guerrera centauro!"
 
 #. Key:	6CEBE4ED41B379988D725290EDC4FE95
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaHadSex01.Default__CamillaHadSex01_C.SessionData.LinesToFemale(1).LinesToFemale
@@ -5817,7 +5817,7 @@ msgstr "Debido a que esto sucede desde el Vacío, existen algunas limitaciones. 
 #: /Game/Dialogue/Kybele/Default/KybeleAnyMeans.Default__KybeleAnyMeans_C.SessionData.LinesToFuta(4).LinesToFuta
 msgctxt ",6DD6D2E84735C26D7103ADA9DEA53E81"
 msgid "If you do not leave this place, you will mount me with that modest sized cock until I'm satisfied!"
-msgstr "Si no abandonas este lugar, ¡me montarás con esa polla de tamaño modesto hasta quedar satisfecha!"
+msgstr "Si no abandonas este lugar, ¡me montarás con esa polla de tamaño modesto hasta que quede satisfecha!"
 
 #. Key:	6DFA50D843F564F540771EAD2DCC848B
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleHaveKeystone.Default__KybeleHaveKeystone_C.SessionData.Lines(3).Lines
@@ -5929,7 +5929,7 @@ msgstr "Pero primero, una donación altísima Diosa. Alabado sea Su nombre."
 #: /Game/Dialogue/AmberMae/SexScenes/AmberMilkyF.Default__AmberMilkyF_C.SessionData.Lines(0).Lines
 msgctxt ",6F5E6DAB49A4FDFA3CF6ADB4F98239E5"
 msgid "Ahhhh! Suck 'em hard, 'mai milk is all for you!"
-msgstr "¡Ahhhh! Chúpalah fuerte, ¡mi leshe es toa pa ti!"
+msgstr "¡Ahhhh! ¡Chúpalah fuerte, mi leshe es toa pa' ti!"
 
 #. Key:	6F8F41154136EFB2D479DCB4A853DC48
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcBrashDumb.Default__OrcBrashDumb_C.SessionData.Lines(9).Lines
@@ -5957,7 +5957,7 @@ msgstr "Mira mi hermosa flor, ¡floreció! Oh cielos, se sintió raro..."
 #: /Game/Dialogue/DragonMatriarch/Default/DMGrasslandsTrees.Default__DMGrasslandsTrees_C.SessionData.Lines(0).Lines
 msgctxt ",6FBC636D494A40330AAEBDBCD6886299"
 msgid "What do you know human!"
-msgstr "¡Qué sabes humano!"
+msgstr "¡Qué sabrás, humano!"
 
 #. Key:	6FD7E94044B57DA992A79BA4422CF69C
 #. SourceLocation:	/Game/Dialogue/Yasmine/Default/YasmineDefault01_RL.Default__YasmineDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
@@ -5986,7 +5986,7 @@ msgstr "¿Qué pasa con la mazmorra junto al templo?"
 #: /Game/Dialogue/DragonMatriarch/Default/DMDefault_RL5_F.Default__DMDefault_RL5_F_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",703D9D7D4CD9D794DDE1929CCE0E5D1C"
 msgid "Bring it on dragon."
-msgstr "Tráela en dragón."
+msgstr "Tráela dragón."
 
 #. Key:	703E8E554AE59D97908541A592216732
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcFixOwnGate.Default__OrcFixOwnGate_C.SessionData.LinesToFemale(0).LinesToFemale
@@ -6000,7 +6000,7 @@ msgstr "¡¡¡Grrrrrrrr!!!"
 #: /Game/Dialogue/Cassie/Default/CassieDefault01_RL.Default__CassieDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
 msgctxt ",703FABE24E96D3592AA524833F23CA4D"
 msgid "Remind me about that dungeon under the temple."
-msgstr "Recuérdame algo de esa mazmorra debajo del templo."
+msgstr "Recuérdame esa mazmorra debajo del templo."
 
 #. Key:	705BCA1D4ACA54FF178C9DA094C9DBA1
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_R01.Default__FernDefault02_R01_C.SessionData.Lines(1).Lines
@@ -6028,7 +6028,7 @@ msgstr "Convertimos el semen que se desperdiciaría en una nueva vida, ¡incluso
 #: /Game/Dialogue/DragonMatriarch/Default/DMDefault_RL5_T.Default__DMDefault_RL5_T_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",709579B446D8D4D2C2F3EE98857ED27A"
 msgid "Bring it on dragon."
-msgstr "Tráelo en dragón."
+msgstr "Tráelo dragón."
 
 #. Key:	709C1A4748A9B0773A823DB8EB5B31E0
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeHadSex01.Default__BeeHadSex01_C.SessionData.Lines(2).Lines
@@ -6056,7 +6056,7 @@ msgstr "Quiero ese delicioso pene futa dentro de mí... ¡ohhh, ahora mismo!"
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_FutaBalls.Default__FaleneDefault01_FutaBalls_C.SessionData.Lines(3).Lines
 msgctxt ",70CF21944D42682E43C6EBB4A8757DB0"
 msgid "Like we say here in @WORLD_NAME@: SUGAR WALLS BEFORE BALLS!!"
-msgstr "Como decimos aquí en @WORLD_NAME@: ¡¡AZÚCAR EN GOTAS ANTES QUE PELOTAS!!"
+msgstr "Como decimos aquí en @WORLD_NAME@: ¡¡COÑOS CON MANGO, SIN PELOTAS COLGANDO!!"
 
 #. Key:	70D390BA48724A55513FB282118180B9
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R04.Default__CamillaDefault01_R04_C.SessionData.Lines(1).Lines
@@ -6091,7 +6091,7 @@ msgstr "¡Prepárate, pequeño gatito!"
 #: /Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFuta(7).LinesToFuta
 msgctxt ",717D6D564578FC099110B6899F65067E"
 msgid "That creepy golden seraphim, the one in the temple. She appeared only a few days ago, constantly asking to speak with \"the human\"."
-msgstr "Esa espeluznante serafín dorada, la del templo. Ella apareció hace solo unos días, constantemente pidiendo hablar con \"el humano\"."
+msgstr "Esa espeluznante serafín dorada, la del templo. Ella apareció hace solo unos días, constantemente pidiendo hablar con \"la humana\"."
 
 #. Key:	71914E004F66CB40BEDE07BF85D0FDC5
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcBrashDumb.Default__OrcBrashDumb_C.SessionData.Lines(0).Lines
@@ -6126,7 +6126,7 @@ msgstr "Experimentarás el éxtasis mientras te corres dentro de mi flor una y o
 #: /Game/Dialogue/Parvati/Default/ParvatiHadSex01.Default__ParvatiHadSex01_C.SessionData.Lines(0).Lines
 msgctxt ",721BAB5440338ECB3CE2EB9A27D969B0"
 msgid "Returning to me with that familiar glint in your eye."
-msgstr "Volviendo a mí con ese brillo familiar en tus ojos."
+msgstr "Volviendo a mí tus ojos con ese brillo conocido."
 
 #. Key:	722820CF485DAAEF312AD7B7C497D3AD
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03_R05.Default__FernDefault03_R05_C.SessionData.Lines(0).Lines
@@ -6140,7 +6140,7 @@ msgstr "¡¿No es hermosa?!"
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_Forgot.Default__ParvatiDefault01_Forgot_C.SessionData.Lines(6).Lines
 msgctxt ",72570AA14FB2D285DAAB6584C841B08C"
 msgid "Which position shall we review?"
-msgstr "¿Qué posición repasaremos?"
+msgstr "¿Qué posición repasaremos, criador?"
 
 #. Key:	725969164426D429929F949920B9A0BD
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadGreeting01.Default__DryadGreeting01_C.SessionData.Lines(2).Lines
@@ -6331,7 +6331,7 @@ msgstr "¿Cómo obtengo la forma espiritual?"
 #: /Game/Dialogue/Parvati/Default/ParvatiGreeting01.Default__ParvatiGreeting01_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",7553E8614616B738728FC0BCAFAFD4D2"
 msgid "For knowledge of contorting the body can I bestow."
-msgstr "Para el conocimiento de contorsionar el cuerpo, puedo otorgar."
+msgstr "Para el conocimiento de contorsionar el cuerpo poderle conferir."
 
 #. Key:	75848F9C47DF47B57018B9BD12602720
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_GettingWeird.Default__LeylannaDefault01_GettingWeird_C.SessionData.Lines(0).Lines
@@ -6416,7 +6416,7 @@ msgstr "¡Mojada! Estoy mojada y cachonda, solo tu puedes ayudar. Esta vez quier
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R04.Default__FaleneDefault01_R04_C.SessionData.Lines(7).Lines
 msgctxt ",77D22B994A5CAE9D14BE2DA1F7D43473"
 msgid "Want to taste mine? Hehehe! You can if you want... I would love to feel you sucking on my nipples!"
-msgstr "¿Quieres probar el mío? ¡Jejeje! Puedes si quieres... ¡me encantaría sentirte chupando mis pezones!"
+msgstr "¿Quieres probar la mía? ¡Jejeje! Puedes si quieres... ¡me encantaría sentirte chupando mis pezones!"
 
 #. Key:	77DDFABE4F632A4183C2FE891D6AC9EA
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(24).LinesToMale
@@ -6430,7 +6430,7 @@ msgstr "Sin duda te encontrarás con bendecidos en este mundo que simplemente qu
 #: /Game/Dialogue/Romy/Default/RomyDefault01_AboutMusic.Default__RomyDefault01_AboutMusic_C.SessionData.Lines(5).Lines
 msgctxt ",77E7C4FC4287147D1A10F5BD3D5F5081"
 msgid "Bathe them of course, if they're dirty. Fortunately, @MONSTER_RACE@ are very clean naturally."
-msgstr "Báñalos, por supuesto, si están sucios. Afortunadamente, los @MONSTER_RACE@ son muy limpios por instintito."
+msgstr "Báñarlos, por supuesto, si están sucios. Afortunadamente, los @MONSTER_RACE@ son muy limpios por naturaleza."
 
 #. Key:	786684AF43E49B03AB1575A2054AC196
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(3 - Value).TraitIcons.DisplayName
@@ -6523,7 +6523,7 @@ msgstr "Mi nombre es Mirru."
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_Teach.Default__ParvatiDefault01_Teach_C.SessionData.LinesToFuta(1).LinesToFuta
 msgctxt ",7A6479A946793FED41931F8AF7F6B4DE"
 msgid "Relax while I slather your dick with lube."
-msgstr "Relájate mientras unto tu pene con lubricante."
+msgstr "Relájate mientras tu polla es bien lubricada."
 
 #. Key:	7A69F5FB4A97FC4EE925589FFD78142E
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiIdiots.Default__FesssiIdiots_C.SessionData.Lines(0).Lines
@@ -6615,7 +6615,7 @@ msgstr "Amm, el lindo humano ha vuelto."
 #: /Game/Dialogue/Widow/Default/WidowDefault01_RL.Default__WidowDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",7C3F628D4E83DBC5016EC8A8263D2372"
 msgid "Scary!"
-msgstr "¡De miedo!"
+msgstr "¡Aterrador!"
 
 #. Key:	7C4054234127D8843978CD80C4B540B7
 #. SourceLocation:	/Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToMale(1).LinesToMale
@@ -6636,14 +6636,14 @@ msgstr "Me iré ahora..."
 #: /Game/Dialogue/Romy/Default/RomyLockedDungeon.Default__RomyLockedDungeon_C.SessionData.Lines(0).Lines
 msgctxt ",7C5554A44E14D8611780E99EAC37F747"
 msgid "I don't know how to access it, but beware."
-msgstr "No sé cómo acceder a él, pero cuidado."
+msgstr "No sé cómo acceder a ella, pero cuidado."
 
 #. Key:	7C5853BA4383F9B61021B3A6AD59FA09
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01.Default__ParvatiDefault01_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01.Default__ParvatiDefault01_C.SessionData.Lines(3).Lines
 msgctxt ",7C5853BA4383F9B61021B3A6AD59FA09"
 msgid "Using our bodies in ways all too perverse."
-msgstr "Usando nuestros cuerpos de formas demasiado perversas."
+msgstr "Usando nuestros cuerpos de un modo demasiado perverso."
 
 #. Key:	7CBF0BC045EF15D872E4EC89A2B54116
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_HowToSpiritForm_RL_F.Default__LeylannaDefault01_HowToSpiritForm_RL_F_C.ResponseData(2).ResponseData.BreederPrompt
@@ -6785,7 +6785,7 @@ msgstr "Si pensabas que mi miel era deliciosa ahora, es solo una sombra de lo qu
 #: /Game/Dialogue/Petra/Default/PetraGreeting01.Default__PetraGreeting01_C.SessionData.Lines(1).Lines
 msgctxt ",7FD5123E4461F41BFB2CAF8A15B94955"
 msgid "Have you also come to this jungle to seek the Enlightened One?"
-msgstr "¿Has venido también a esta jungla a buscar al Iluminado?"
+msgstr "¿Has venido también a esta jungla a buscar a la Iluminada?"
 
 #. Key:	7FEBA6A748A632320A5759BABB317345
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R02.Default__CamillaDefault01_R02_C.SessionData.Lines(4).Lines
@@ -6834,7 +6834,7 @@ msgstr ""
 #: /Game/Dialogue/Romy/Default/RomyDefault01.Default__RomyDefault01_C.SessionData.Lines(0).Lines
 msgctxt ",8044648D4BB5A708D0C1658B377C01A4"
 msgid "Warm bath, sweet music, and now the pleasant company of the human."
-msgstr "Baño tibio, música dulce y ahora la agradable compañía del humano."
+msgstr "Un baño tibio, música dulce y ahora la agradable compañía del humano."
 
 #. Key:	809919A3474406E99443B39588E9EAE7
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimePlay1.Default__MegaSlimePlay1_C.SessionData.LinesToFemale(0).LinesToFemale
@@ -7053,7 +7053,7 @@ msgstr "Desafortunadamente, solo se puede usar para viajar."
 #: /Game/Dialogue/Parvati/Default/ParvatiGreeting01.Default__ParvatiGreeting01_C.SessionData.LinesToFemale(4).LinesToFemale
 msgctxt ",84E329854997BD3064CA67922BD88726"
 msgid "One with the Goddess, one with infinity."
-msgstr "Uno con la Diosa, uno con el infinito."
+msgstr "Una con la Diosa, una con la infinidad."
 
 #. Key:	84ECDF64481524BC47B862968D5475BE
 #. SourceLocation:	/Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToMale(7).LinesToMale
@@ -7132,7 +7132,7 @@ msgstr "Oh... tan hermoso... ahhhhhhh."
 #: /Game/Dialogue/Kybele/Default/KybeleAnyMeans.Default__KybeleAnyMeans_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",85C0F318409CD0EE03C6A0866A2BC236"
 msgid "My greatest weapon is my spear, the massive one between my legs!"
-msgstr "Mi mayor arma es mi lanza, ¡la inmensa que tengo entre las piernas!"
+msgstr "Mi mayor arma es mi lanza, ¡la inmensa que tengo entre las patas!"
 
 #. Key:	85D697914BECD8CA4AD94DB4BE76C00A
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMAboutDragons.Default__DMAboutDragons_C.SessionData.Lines(4).Lines
@@ -7195,7 +7195,7 @@ msgstr "Dulce y deliciosa semilla humana, ¡déjala ir toda! Ahhh..."
 #: /Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToFemale(4).LinesToFemale
 msgctxt ",863C3850414A8A0B8C0C45907E4898EA"
 msgid "Oh... ah... yes! Human... ohhhh."
-msgstr "¡Oh... ah... sí! Humano... ohhhh."
+msgstr "¡Oh... ah... sí! Humana... ohhhh."
 
 #. Key:	86705CF240B11C01C39F05BA7F02F512
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R02.Default__FaleneDefault01_R02_C.SessionData.Lines(15).Lines
@@ -7223,21 +7223,21 @@ msgstr "¡Guau! Es tan hermosa."
 #: /Game/Dialogue/Parvati/Default/ParvatiGreeting01.Default__ParvatiGreeting01_C.SessionData.LinesToFemale(9).LinesToFemale
 msgctxt ",86C230E147542961EF516C854DF91DDB"
 msgid "Now let's make love, or you shall find the Her ire."
-msgstr "Ahora hagamos el amor, o te encontrarás con Su ira."
+msgstr "Ahora hagamos el amor, o con Su ira te encontrarás."
 
 #. Key:	86DA9E6A4C65102E4B28A3968C3DA8FC
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_Teach.Default__ParvatiDefault01_Teach_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_Teach.Default__ParvatiDefault01_Teach_C.SessionData.Lines(4).Lines
 msgctxt ",86DA9E6A4C65102E4B28A3968C3DA8FC"
 msgid "I can assure you this will feel so good."
-msgstr "Te puedo asegurar que esto se sentirá muy bien."
+msgstr "Te puedo asegurar que esto se sentirá genial."
 
 #. Key:	86DCDE444C6876DE3F3C6D8EC7E6FC20
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R05.Default__FaleneDefault01_R05_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R05.Default__FaleneDefault01_R05_C.SessionData.Lines(4).Lines
 msgctxt ",86DCDE444C6876DE3F3C6D8EC7E6FC20"
 msgid "Do you wanna see all of mine?"
-msgstr "¿Quieres ver todo lo mío?"
+msgstr "¿Quieres ver todas las mías?"
 
 #. Key:	86DE4E4645DF60181C48AD85C95C97BA
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.DemonPool.ManageActionMessage
@@ -7251,7 +7251,7 @@ msgstr "Gestiona tus Demonios"
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeVerySad.Default__MegaSlimeVerySad_C.SessionData.Lines(3).Lines
 msgctxt ",86F7371A4137035AE44922A31E9A0F25"
 msgid "*Sniff*"
-msgstr "*Olfatea*"
+msgstr "*Sniff*"
 
 #. Key:	86F7401346D43F3587BFEFAB87819829
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R03.Default__FaleneDefault01_R03_C.SessionData.Lines(8).Lines
@@ -7265,7 +7265,7 @@ msgstr "Pasean alrededor de un Avatar, encontraras @MONSTER_RACE@ silvestres dea
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02_R02_R01.Default__FernDefault02_R02_R01_C.SessionData.Lines(1).Lines
 msgctxt ",8702885F4AD8627AC254029214EED99B"
 msgid "Sure, it can be tempting to drink all of the fluids, but I love you Master and know you need them."
-msgstr "Claro, puede ser tentador beber todos los fluidos, pero te amo Master y sé que los necesitas."
+msgstr "Claro, puede ser tentador beber todos los fluidos, pero quiero Master y sé que los necesitas."
 
 #. Key:	870E3E9A4756B06E4D8C9FB1967261E9
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_BatheAllDay.Default__RomyDefault01_BatheAllDay_C.SessionData.Lines(0).Lines
@@ -7349,7 +7349,7 @@ msgstr "Los @MONSTER_RACE@ son mitad humanos, lo sabemos a ciencia cierta. Para 
 #: /Game/Dialogue/Kybele/Default/KybeleAnyMeans_RL.Default__KybeleAnyMeans_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",889821A14F372C605AB0A58DD716FB9E"
 msgid "Pfff I can handle a titty pony."
-msgstr "Pfff, puedo manejar una pony tetudita."
+msgstr "Pfff, puedo manejar una poni tetuda."
 
 #. Key:	889D5D974E2DA932F5EAC7B50EC85E50
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(5).Lines
@@ -7377,7 +7377,7 @@ msgstr "Ese es un tema que merece todo un volumen."
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_FloatRhyme.Default__ParvatiDefault01_FloatRhyme_C.SessionData.Lines(9).Lines
 msgctxt ",88C6CA66419DF0FF12D0A4B560B847DA"
 msgid "Thus, you should stay and hear my rhymes."
-msgstr "Por tanto, deberías quedarte y escuchar mis rimas."
+msgstr "Por tanto, deberías quedarte y en mis rimas poner el oído."
 
 #. Key:	88C799D944DFFE73BC3FD485C3770EEE
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchShySexF_RL.Default__MonarchShySexF_RL_C.ResponseData(1).ResponseData.BreederPrompt
@@ -7391,7 +7391,7 @@ msgstr "¡No!"
 #: /Game/Dialogue/Autumn/Default/DryadAboutDryads.Default__DryadAboutDryads_C.SessionData.Lines(3).Lines
 msgctxt ",88DA748247D4C0C5CE3BEC9851A55E05"
 msgid "Our nature inclines us to plant roots and help life flourish. In my case, I saw so many cows wandering aimlessly here."
-msgstr "Nuestra naturaleza nos inclina a plantar raíces y ayudar a que la vida florezca. En mi caso, vi tantas vacas vagando sin rumbo fijo aquí."
+msgstr "Nuestra naturaleza nos inclina a plantar raíces y ayudar a que la vida florezca. En mi caso, vi tantas vacas aquí deambulando sin rumbo fijo."
 
 #. Key:	88E908134B3B56C2274F33974CFB4AE5
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(0).LinesToMale
@@ -7405,7 +7405,7 @@ msgstr "¡Guau! ¡No puede ser!"
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R01.Default__CamillaDefault01_R01_C.SessionData.Lines(5).Lines
 msgctxt ",8914763C4965D6C23C2F2FA37534FDA8"
 msgid "However if you're a lame human who hates fun, you can give them their favorite body fluid instead."
-msgstr "Sin embargo, si eres un humano aburrido que odia la diversión, puedes darles su fluido corporal favorito en su lugar."
+msgstr "Sin embargo, si eres un humano aburrido que odia la diversión, en su lugar puedes darles su fluido corporal favorito."
 
 #. Key:	896A556649DF30C2C9A122A0DA91A3C0
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_YourMusic.Default__RomyDefault01_YourMusic_C.SessionData.LinesToFemale(0).LinesToFemale
@@ -7475,7 +7475,7 @@ msgstr "¿Cómo te trata esa akabeko?"
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_Daze.Default__EmissaryDefault01_Daze_C.SessionData.Lines(3).Lines
 msgctxt ",8A7AA1664D50A6AD3F66CE8B9B57C01F"
 msgid "But beware, a toll will she require."
-msgstr "Pero cuidado, necesitarás un peaje."
+msgstr "Pero cuidado, ella exigirá un peaje."
 
 #. Key:	8AF6FC6641A12C2B4A5B90B25313D5E2
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03.Default__FernDefault03_C.SessionData.LinesToFemale(0).LinesToFemale
@@ -7547,7 +7547,7 @@ msgstr "Pero creo que le gusta tener un acceso más fácil a mi entrepierna..."
 #: /Game/Dialogue/Cassie/SexScenes/CassieButterButtF.Default__CassieButterButtF_C.SessionData.Lines(3).Lines
 msgctxt ",8C159EEF4934350128EF61B587714DE0"
 msgid "Meow! It feels so good! Kitty cum for you soon ohhh!"
-msgstr "¡Miau! ¡Se siente tan bien! ¡La gatita se correrá para ti pronto, ohhh!"
+msgstr "¡Miau! ¡Se siente tan bien! ¡El gatito se correrá para ti pronto, ohhh!"
 
 #. Key:	8C3EC08A4B6E0CBD02C0D9A1DF7CF43E
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R01.Default__FaleneDefault01_R01_C.SessionData.Lines(16).Lines
@@ -7582,7 +7582,7 @@ msgstr "Fluidos corporales de Híbrido."
 #: /Game/Dialogue/Monarch/Default/MonarchHaveKeystone2.Default__MonarchHaveKeystone2_C.SessionData.Lines(0).Lines
 msgctxt ",8C9B5804468F5F400DC62BBD043B050E"
 msgid "Please take it... maybe we will cross paths again."
-msgstr "Por favor, tómalo... tal vez nos volvamos a cruzar de nuevo."
+msgstr "Por favor, tómala... tal vez nos volvamos a cruzar de nuevo."
 
 #. Key:	8CA4D43149A0F1DAAAC64681E65FE7BE
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiDefault03_RL_T.Default__FesssiDefault03_RL_T_C.ResponseData(0).ResponseData.BreederPrompt
@@ -7596,7 +7596,7 @@ msgstr "Guau... este mundo está lleno de idiotas."
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(3).Lines
 msgctxt ",8CB5ACBF46F02BEA48B084A15F2AD8C2"
 msgid "Once the Seraphim had started propagating, the Goddess ordered them to spread their light across the empty expanse."
-msgstr "Una vez que las serafines comenzaron a propagarse, la Diosa les ordenó que extendieran su luz a través de la extensión vacía."
+msgstr "Una vez que los serafines comenzaron a propagarse, la Diosa les ordenó que extendieran su luz a través de la extensión vacía."
 
 #. Key:	8CD67FB74B2E43F406AB5B932B717B19
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToMale(2).LinesToMale
@@ -7659,7 +7659,7 @@ msgstr "Va a ser triste perder la capacidad de moverme, ¡pero al menos te tengo
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_FloatRhyme.Default__ParvatiDefault01_FloatRhyme_C.SessionData.Lines(7).Lines
 msgctxt ",8D4C9C144C33EE6A19B08696ABFFB5DA"
 msgid "I will make you feel so good, if it is pleasure that you seek."
-msgstr "Te haré sentir tan bien, si es placer lo que buscas."
+msgstr "Te haré sentir tan bien, si es placer lo que buscarás."
 
 #. Key:	8D8E77CB4454DA71E9231DA6647955ED
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowHadSex01.Default__WidowHadSex01_C.SessionData.Lines(2).Lines
@@ -7786,7 +7786,7 @@ msgstr "Hmm... quizás."
 #: /Game/Dialogue/Emissary/Default/EmissaryGreeting01.Default__EmissaryGreeting01_C.SessionData.Lines(3).Lines
 msgctxt ",900A82D44250A3392806469644B7B93B"
 msgid "However, roaming this land are lesser @MONSTER_RACE@, to which many brand as \"wild\"."
-msgstr "Sin embargo, vagando por esta tierra hay @MONSTER_RACE@ menores, a lo que muchos califican como \"silvestres\"."
+msgstr "Sin embargo, deambulando por esta tierra hay @MONSTER_RACE@ menores, a lo que muchos califican como \"silvestres\"."
 
 #. Key:	902A41DB403EFA60B99E8CB596EFE0BF
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02.Default__FernDefault02_C.SessionData.LinesToFemale(3).LinesToFemale
@@ -7807,7 +7807,7 @@ msgstr "Este no es para mí, sino la hermosa ángel dorada Emisaria. No parece i
 #: /Game/Dialogue/Romy/Default/RomyGreeting01.Default__RomyGreeting01_C.SessionData.LinesGrungy(2).LinesGrungy
 msgctxt ",907E7C35462D4EC3BC72C5B05C7ABDB9"
 msgid "I hear your eyes working your way down my voluptuous form, your heart beats faster, but... oh... no."
-msgstr "Escucho a tus ojos recorrer su camino bajando por mi voluptuosa forma, tu corazón late más rápido, pero... oh... no."
+msgstr "Escucho a tus ojos recorrer su camino bajando por mi voluptuosa figura, tu corazón late más rápido, pero... oh... no."
 
 #. Key:	90AAD27D43E39D45DAC8A492F1373436
 #. SourceLocation:	/Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToMale(9).LinesToMale
@@ -7892,7 +7892,7 @@ msgstr "Necesito semen humano para crecer hasta mi forma final. Tu pene se desli
 #: /Game/Dialogue/Petra/Default/PetraGetKeystone.Default__PetraGetKeystone_C.SessionData.Lines(0).Lines
 msgctxt ",91EBB0754C1505A5258A0CB3E6CE0D71"
 msgid "Sure can! I'm a bunny, so hopping up there wouldn't be a problem."
-msgstr "¡Claro que sí! Soy una conejita, así que saltar allí no sería un problema."
+msgstr "¡Claro que puedo! Soy una conejita, así que brincar ahí arriba no sería un problema."
 
 #. Key:	926325814BBC6464CA76E097764B7F27
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(0 - Value).TraitIcons.HelpText
@@ -7907,7 +7907,7 @@ msgstr "Humanoide: heredó más rasgos humanos."
 #: /Game/Dialogue/Kybele/Default/KybeleTittyPony_T.Default__KybeleTittyPony_T_C.SessionData.LinesToFuta(1).LinesToFuta
 msgctxt ",926950C44065493241D67FA1816D2447"
 msgid "It's been sometime since I have been mouted, so I might get rough!"
-msgstr "Ha pasado algún tiempo desde que me montaron, ¡así que podría ponerme dura!"
+msgstr "Ha pasado algún tiempo desde que me montaron, ¡así que podría ponerme brava!"
 
 #. Key:	92840010469055DB3A7EADA0FB5C99E1
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcTribeSucks.Default__OrcTribeSucks_C.SessionData.Lines(1).Lines
@@ -7970,7 +7970,7 @@ msgstr "¡Asombroso!"
 #: /Game/Dialogue/Autumn/Default/DryadGreeting01.Default__DryadGreeting01_C.SessionData.Lines(0).Lines
 msgctxt ",934029E9456E811CFA0084839F9BABE4"
 msgid "Sweet and juicy, but just a little squishy."
-msgstr "Dulce y jugosa, pero solo un poco blanda."
+msgstr "Dulce y jugosa, pero un poquitín blanda."
 
 #. Key:	93692542487EDBAE8A18A699EC9053E1
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeHadSex01.Default__MegaSlimeHadSex01_C.SessionData.LinesToFemale(4).LinesToFemale
@@ -8026,7 +8026,7 @@ msgstr "Misionero"
 #: /Game/Dialogue/Cassie/Default/CassieDefault01_RL.Default__CassieDefault01_RL_C.ResponseData(3).ResponseData.BreederPrompt
 msgctxt ",93B6CD7C4E7ECCBA8FD7F38BD9A11025"
 msgid "Uh... meow!"
-msgstr "Uh... ¡miau!"
+msgstr "Eh... ¡miau!"
 
 #. Key:	93BFA77B4203C927F888AA9756403DB1
 #. SourceLocation:	/Game/Ranch/Upgrades/DragonHoard.Default__DragonHoard_C.Upgrade.Description
@@ -8040,14 +8040,14 @@ msgstr "Esto te permite capturar y almacenar todas las variantes de Dragones."
 #: /Game/Dialogue/Camilla/Default/CamillaDungeon.Default__CamillaDungeon_C.SessionData.Lines(1).Lines
 msgctxt ",93DE33A2469E1BAFBEC17DAF59AF4070"
 msgid "Go talk to bulge kitty, she pretends to be exactly that."
-msgstr "Ve a hablar con la gatita con bulto, ella finge ser exactamente eso."
+msgstr "Ve a hablar con el gatito con bulto, ella finge ser exactamente eso."
 
 #. Key:	941010544E6432D137832FA1B37E0C10
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_Teach.Default__ParvatiDefault01_Teach_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_Teach.Default__ParvatiDefault01_Teach_C.SessionData.Lines(3).Lines
 msgctxt ",941010544E6432D137832FA1B37E0C10"
 msgid "So we can do any position that might arise."
-msgstr "Entonces podemos hacer cualquier posición que pueda surgir."
+msgstr "Entonces podemos hacer cualquier posición sin excepciones."
 
 #. Key:	943C15EB4C419656532B6A8A133CD0F3
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01_RL_M.Default__FernDefault01_RL_M_C.ResponseData(3).ResponseData.BreederPrompt
@@ -8097,7 +8097,7 @@ msgstr "¡En efecto! Tu delicioso fluido ha hecho maravillas."
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_Princess.Default__MirruDefault01_Princess_C.SessionData.Lines(2).Lines
 msgctxt ",94861BA24AA560F31BB02F9A4AC431F9"
 msgid "Unlike most Krakens, she is pure female and not futa. She is very rare."
-msgstr "A diferencia de la mayoría de los krakens, ella es puramente hembra y no futa. Ella es muy rara."
+msgstr "A diferencia de la mayoría de los krakens, ella es puramente hembra y no futa. Es muy rara."
 
 #. Key:	94DDBB0049FCED99D5C08FB803C12B7D
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleHadSex01.Default__KybeleHadSex01_C.SessionData.LinesToFuta(1).LinesToFuta
@@ -8168,7 +8168,7 @@ msgstr "¡Vaquera!"
 #: /Game/Dialogue/Kybele/Default/KybeleTittyPony.Default__KybeleTittyPony_C.SessionData.LinesToMale(2).LinesToMale
 msgctxt ",96224E4C41C21D56ABD895A4ACFB4843"
 msgid "That should teach you to cross this titty po--I mean mighty centaur warmaiden, again!"
-msgstr "Eso debería enseñarte a cruzar esta poni tet-: ¡otra vez, me refiero a la poderosa doncella-guerrera centauro!"
+msgstr "Eso debería enseñarte a cruzarte con esta poni tet-: ¡otra vez, me refiero a la poderosa doncella-guerrera centauro!"
 
 #. Key:	9656DDC24323054BCA6436A90C28AD1C
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleDragonMatriarch.Default__KybeleDragonMatriarch_C.SessionData.Lines(2).Lines
@@ -8189,7 +8189,7 @@ msgstr "A diferencia de la nephnip, el humo azul destruye tu mente... solo mira 
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(30).LinesToMale
 msgctxt ",96824C894B9B4241DBDFEEB68C760057"
 msgid "If you want to learn about how to catch @MONSTER_RACE@, head to the town located up the plateau ahead and speak to my assistant Camilla. You can't miss her... actually wait you might, she's so tiny and cute hehehe."
-msgstr "Si quieres aprender cómo atrapar @MONSTER_RACE@, dirígete a la ciudad ubicada en la meseta más adelante y habla con mi asistente Camilla. No puedes fallarle... en realidad, espera, es posible, es tan pequeña y linda jejeje."
+msgstr "Si quieres aprender cómo atrapar @MONSTER_RACE@, dirígete al pueblo ubicado en la meseta más adelante y habla con mi asistente Camilla. No puedes fallarle... en realidad, espera, es posible, es tan pequeña y linda jejeje."
 
 #. Key:	9697386D4E5433DC67FA228576AC58B4
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernBeeFlowers3.Default__FernBeeFlowers3_C.SessionData.Lines(0).Lines
@@ -8253,7 +8253,7 @@ msgstr "Rápido"
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_Teach.Default__ParvatiDefault01_Teach_C.SessionData.LinesToMale(0).LinesToMale
 msgctxt ",975E8DE7431AB39F97281DB7BD7DE314"
 msgid "Remove your garments, for you must be nude."
-msgstr "Quítate tus prendas, debes estar desnudo."
+msgstr "Quítate tus prendas, debes estar en pelota picada."
 
 #. Key:	97819B7A480CF2968256F1AD74021DAD
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_AboutMusic.Default__RomyDefault01_AboutMusic_C.SessionData.Lines(4).Lines
@@ -8267,7 +8267,7 @@ msgstr "Entonces... bueno, puedes imaginar lo que hacemos."
 #: /Game/Dialogue/QueenBee/Default/BeeDefault01.Default__BeeDefault01_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",9787E49C47227601EF65578F30C5CCA2"
 msgid "Is t-t-there something... you want human?"
-msgstr "¿Hay a-a-algo... que quieras humana?"
+msgstr "¿Hay a-a-algo... que quieras, humana?"
 
 #. Key:	97A580FD4F8820DD9E8FA09B6B69797A
 #. SourceLocation:	/Game/Ranch/Upgrades/SeraphimLoft.Default__SeraphimLoft_C.Upgrade.DisplayName
@@ -8302,7 +8302,7 @@ msgstr "*Sonrojo*"
 #: /Game/Dialogue/Mirru/SexScenes/MirruSnatchT.Default__MirruSnatchT_C.SessionData.Lines(3).Lines
 msgctxt ",97C48C5D4FCF938DF123EA94C35A3858"
 msgid "Feel my soft girthy tentacles embrace you... oh... yes."
-msgstr "Siente mis suaves y gruesos tentáculos abrazándote... oh... sí."
+msgstr "Siente mis suaves y rollizos tentáculos abrazándote... oh... sí."
 
 #. Key:	97DE1E2D44F75CDC8B07A3ACE527EFC4
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03_R03.Default__FernDefault03_R03_C.SessionData.Lines(1).Lines
@@ -8323,7 +8323,7 @@ msgstr "¡Más miel!"
 #: /Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFemale(8).LinesToFemale
 msgctxt ",97E4D09B44D082B3154FEE94A88EE112"
 msgid "That must have been you, perhaps you should go and talk to her."
-msgstr "Debes haber sido tú, quizás deberías ir a hablar con ella."
+msgstr "Esa debes haber sido tú, quizás deberías ir a hablar con ella."
 
 #. Key:	9823997B4369C9710C0858A44B670A9D
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_RL.Default__CamillaDefault01_RL_C.ResponseData(4).ResponseData.BreederPrompt
@@ -8351,7 +8351,7 @@ msgstr "¿Hoooora de cosechar fluidosssss?"
 #: /Game/Dialogue/Parvati/Default/ParvatiHadSex01.Default__ParvatiHadSex01_C.SessionData.Lines(1).Lines
 msgctxt ",982CC755420F84E3E4F0E5A5452A5A48"
 msgid "I want to make love with you, I will not lie."
-msgstr "Quiero hacer el amor contigo, no mentiré."
+msgstr "Quiero hacer el amor contigo, no he mentido."
 
 #. Key:	985E4BA14797DC7FF94FF4974E66471A
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R06.Default__FaleneDefault01_R06_C.SessionData.Lines(6).Lines
@@ -8477,7 +8477,7 @@ msgstr "¡Blossom!"
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToMale(3).LinesToMale
 msgctxt ",9B115CE5485736847F748591F0C8FB2A"
 msgid "All have been pleasurable and delicious... but oh have I wanted something more..."
-msgstr "Todos han sido placenteros y deliciosos... pero oh, he querido algo más..."
+msgstr "Todos han sido placenteros y deliciosos... pero oh, estoy buscando algo más..."
 
 #. Key:	9B2F56474FA9D82EE9F76EBEB5723F74
 #. SourceLocation:	/Game/Dialogue/Fern/SexScenes/FernCum_01.Default__FernCum_01_C.SessionData.Lines(4).Lines
@@ -8519,21 +8519,21 @@ msgstr "Arrodíllate ante tu reina... ahhh... ohhh..."
 #: /Game/Dialogue/Kybele/Default/KybeleGreeting01.Default__KybeleGreeting01_C.SessionData.Lines(2).Lines
 msgctxt ",9BD2015749AE3D2CD457DDB2CBC112F4"
 msgid "The offspring of the Dragon Matriarch will be protected by any means necessary."
-msgstr "La descendencia de la Matriarca Dragón estará protegida por todos los medios necesarios."
+msgstr "La descendencia de la Matriarca Dragón será protegida por cualquier medio necesario."
 
 #. Key:	9BDBC0EB4511337E7515C89A6620BBA0
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeHadSex01.Default__AmberMaeHadSex01_C.SessionData.LinesToFemale(3).LinesToFemale
 #: /Game/Dialogue/AmberMae/Default/AmberMaeHadSex01.Default__AmberMaeHadSex01_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",9BDBC0EB4511337E7515C89A6620BBA0"
 msgid "Come back and drink up anytime."
-msgstr "Vuelve y bebe en cualquier momento."
+msgstr "Vuerve y bebela cuando quierah."
 
 #. Key:	9BF2AD09410781A66302329DB25BA0EC
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_Forgot.Default__ParvatiDefault01_Forgot_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_Forgot.Default__ParvatiDefault01_Forgot_C.SessionData.Lines(5).Lines
 msgctxt ",9BF2AD09410781A66302329DB25BA0EC"
 msgid "As I meditate, all I want is to make love with you."
-msgstr "Mientras medito, todo lo que quiero es hacer el amor contigo."
+msgstr "Mientras medito, todo lo que quiero es hacerte el amor."
 
 #. Key:	9C0628944A08387197D344B7CBC502FB
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMYourChildren.Default__DMYourChildren_C.SessionData.LinesToFemale(3).LinesToFemale
@@ -8561,7 +8561,7 @@ msgstr "¡Grrr! Hazlo o te reproducirás conmigo ahora."
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R01.Default__CamillaDefault01_R01_C.SessionData.Lines(3).Lines
 msgctxt ",9C3FDDD5490B3180DDD3329C692C0B4D"
 msgid "The fastest way is to sex them into submission, just use what's between your legs human!"
-msgstr "La forma más rápida es tener sexo con ellos hasta someterlos, ¡solo usa lo que está entre tus piernas humano!"
+msgstr "La forma más rápida es tener sexo con ellos hasta someterlos, ¡solo usa lo que está entre tus piernas, humano!"
 
 #. Key:	9C7CF64D42692442A687709D5C22BB3D
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeLikesPresent.Default__MegaSlimeLikesPresent_C.SessionData.Lines(0).Lines
@@ -8582,7 +8582,7 @@ msgstr "¡Háblame de las dríadas!"
 #: /Game/UI/TaskDescriptions.TaskDescriptions.TextEntries(8).TextEntries
 msgctxt ",9CB6C5E14DD6C412AD7898B8D2120925"
 msgid "Having fins makes moving on dry land challenging. Would you breed me a loveable Nephelym that can fetch things around town? I suppose it doesn't HAVE to be attractive... though if you could... just in case.  -Romy"
-msgstr "Tener aletas hace que moverse en tierra firme sea un desafío. ¿Me criarías un adorable Nephelym que pueda ir a buscar cosas por la ciudad? Supongo que no TIENE que ser atractivo... aunque si pudieras... por si acaso. -Romy"
+msgstr "Tener aletas hace que moverse en tierra firme sea un desafío. ¿Me criarías un adorable Nephelym que pueda ir a buscar cosas por el pueblo? Supongo que no TIENE que ser atractivo... aunque si pudieras... por si acaso. -Romy"
 
 #. Key:	9D593DC94FAA9CCF2CB35CBA7EA06A73
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToMale(2).LinesToMale
@@ -8603,7 +8603,7 @@ msgstr "¿A dónde lleva esa cueva?"
 #: /Game/Dialogue/Kybele/Default/KybeleDefault01_RL.Default__KybeleDefault01_RL_C.ResponseData(3).ResponseData.BreederPrompt
 msgctxt ",9DCE82F542FEDB443D7432A9C8EE7AF6"
 msgid "By any means necessary..."
-msgstr "Por cualquier medio que sea necesario..."
+msgstr "Por cualquier medio necesario..."
 
 #. Key:	9E0F2A7F4F6510D820FB12BE4580D421
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_EnlightenedOne.Default__NeelaDefault01_EnlightenedOne_C.SessionData.Lines(3).Lines
@@ -8645,7 +8645,7 @@ msgstr "¿Cómo abro los portones de piedra?"
 #: /Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFuta(3).LinesToFuta
 msgctxt ",9E8C52C446FF788D61D6B98D9189D88D"
 msgid "Maybe between my fat ass cheeks?"
-msgstr "¿Quizás entre mis gordas mejillas del culo?"
+msgstr "¿Quizás entre mis gordos mofletes del culo?"
 
 #. Key:	9EB1E11442BB00388C518B8B9CDC9A62
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiDefault01.Default__FesssiDefault01_C.SessionData.Lines(1).Lines
@@ -8688,7 +8688,7 @@ msgstr "Gestiona tus Formurians"
 #: /Game/Dialogue/Cassie/Default/CassieHadSex01.Default__CassieHadSex01_C.SessionData.LinesToFuta(5).LinesToFuta
 msgctxt ",9F2120194C14A491202338AEB2C05883"
 msgid "I want to release again already... you humans have it so easy."
-msgstr "Quiero descargar de nuevo ya... vosotros, los humanos, lo tieneis muy fácil."
+msgstr "Quiero descargar de nuevo ya... vosotros, los humanos, lo tenéis muy fácil."
 
 #. Key:	9F25BEB847378BA942933C8A503B4F1A
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(22 - Value).TraitIcons.HelpText
@@ -8747,14 +8747,14 @@ msgstr "¡Nosotros también podemos ser amigos! ¿Por qué no te quedas y juegas
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_FloatRhyme.Default__ParvatiDefault01_FloatRhyme_C.SessionData.Lines(4).Lines
 msgctxt ",9F9D5BEE4F26E405A81EB09066622552"
 msgid "Eons in Her embrace have taught me bodily forms."
-msgstr "Eones en Su abrazo me han enseñado formas corporales."
+msgstr "Eones en Su abrazo me han enseñado corporales formas."
 
 #. Key:	9FAD5CA34B7A4B192E688C9C72A825B3
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R06.Default__FaleneDefault01_R06_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R06.Default__FaleneDefault01_R06_C.SessionData.Lines(1).Lines
 msgctxt ",9FAD5CA34B7A4B192E688C9C72A825B3"
 msgid "According to the high priestess Leylana at the temple, the Goddess and her angels descended from the heavens."
-msgstr "Según la suma sacerdotisa Leylana en el templo, la Diosa y sus ángeles descendieron de los cielos."
+msgstr "Según la suma sacerdotisa Leylanna en el templo, la Diosa y sus ángeles descendieron de los cielos."
 
 #. Key:	9FE3B8C04B35B846B4CFB99902294CDE
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcWantWrestle.Default__OrcWantWrestle_C.SessionData.Lines(1).Lines
@@ -8768,7 +8768,7 @@ msgstr "Sabía que a los humanos les gustaba sentir este poderoso cuerpo."
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(20).LinesToFemale
 msgctxt ",9FE7AADC4372F0B32E971C838E6554EA"
 msgid "Since you're a breeder, it's your job to catch and mate as many @MONSTER_RACE@ as possible!"
-msgstr "Ya que eres un criador, ¡es tu trabajo atrapar y aparearte con tantos @MONSTER_RACE@ como sea posible!"
+msgstr "Ya que eres una criadora, ¡es tu trabajo atrapar y aparearte con tantos @MONSTER_RACE@ como sea posible!"
 
 #. Key:	9FF8B7CE43E6A9321DDB60919962BBB7
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(17).LinesToMale
@@ -8824,7 +8824,7 @@ msgstr "¿Qué puedes hacer?"
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePlay1.Default__MegaSlimePlay1_C.SessionData.LinesToFuta(1).LinesToFuta
 msgctxt ",A1243ACB4057D3CAD0A25787BA4DF627"
 msgid "I think... you might be my best friend of all time."
-msgstr "Creo que... podrías ser mi mejor amigo de todos los tiempos."
+msgstr "Creo que... podrías ser mi mejor amigui de todos los tiempos."
 
 #. Key:	A12A50F34FE88A004CB5458C982B3915
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(16).LinesToFemale
@@ -8859,7 +8859,7 @@ msgstr "Granero de Nephelym"
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(28).LinesToFemale
 msgctxt ",A2DA50B44D0A24E096AF488F787D4928"
 msgid "Well I must be off, good luck breeder!"
-msgstr "Bueno, debo irme, ¡buena suerte criador!"
+msgstr "Bueno, debo irme, ¡buena suerte criadora!"
 
 #. Key:	A2EE900942F55DC4C6AA92BC44E482E4
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R03.Default__CamillaDefault01_R03_C.SessionData.Lines(2).Lines
@@ -8901,7 +8901,7 @@ msgstr "¡El pecho de Mastah tan suave! A Fern gustarle."
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_Teach.Default__ParvatiDefault01_Teach_C.SessionData.Lines(2).Lines
 msgctxt ",A40264BD4BB3E658212ECE987CC24B4A"
 msgid "Don't worry, for I can change my size."
-msgstr "No te preocupes, puedo cambiar mi tamaño."
+msgstr "No te preocupes, puedo cambiar mis dimensiones."
 
 #. Key:	A41D55094C37585E241DB98D76B52F65
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToFemale(6).LinesToFemale
@@ -8972,7 +8972,7 @@ msgstr "¡Menos mal que tengo mi juguete!"
 #: /Game/Dialogue/DragonMatriarch/Default/DMGreeting01.Default__DMGreeting01_C.SessionData.Lines(3).Lines
 msgctxt ",A5496AE246B786D1E975C6A2F4004B43"
 msgid "That useless titty pony failed again I see. She will feel my wrath."
-msgstr "Veo que esa inútil pony tetudita falló de nuevo. Ella sentirá mi ira."
+msgstr "Veo que esa inútil poni tetuda falló de nuevo. Ella sentirá mi ira."
 
 #. Key:	A56B0F264A329DF192CE53B3DBA118EB
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiWantAss.Default__FesssiWantAss_C.SessionData.Lines(2).Lines
@@ -9000,7 +9000,7 @@ msgstr "¡Jaja! Bromeas humano, mis genitales son demasiado grandes para ti."
 #: /Game/Dialogue/QueenBee/Default/BeeHaveKeystone1.Default__BeeHaveKeystone1_C.SessionData.Lines(2).Lines
 msgctxt ",A5B9250C4C49694C624437927A399459"
 msgid "Ohhh! Ahhh... that was a good one."
-msgstr "¡Ohhh! Ahhh... esa fue una buena."
+msgstr "¡Ohhh! Ahhh... ese fue uno bueno."
 
 #. Key:	A5C9D438443FEDCB4CF41985385B02E1
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiStuck.Default__FesssiStuck_C.SessionData.Lines(4).Lines
@@ -9042,7 +9042,7 @@ msgstr "Mira, no hay ningún lugar en @WORLD_NAME@ por el que no me haya desliza
 #: /Game/Dialogue/Blossom/Default/BlossomDefault_R03_RL.Default__BlossomDefault_R03_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",A709A6A94647E3F1218D6BB7BF74686D"
 msgid "Oh no not again..."
-msgstr "Oh no, no otra vez..."
+msgstr "Oh no, otra vez no..."
 
 #. Key:	A7310E5A43F60121BD9352B96FBB8369
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_RL.Default__RomyDefault01_RL_C.ResponseData(3).ResponseData.BreederPrompt
@@ -9056,7 +9056,7 @@ msgstr "¿Cómo subiste hasta aquí?"
 #: /Game/Dialogue/QueenBee/Default/BeeUhNo.Default__BeeUhNo_C.SessionData.Lines(0).Lines
 msgctxt ",A77C67204806B8B31933BD9C7A4C5C54"
 msgid "Such... ahhh... deviance..."
-msgstr "Tal... ahhh... desviación..."
+msgstr "Tal... ahhh... rebeldía..."
 
 #. Key:	A794490B471FFA8A958C3BA3B3BFDB9C
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchDefault01_RL.Default__MonarchDefault01_RL_C.ResponseData(3).ResponseData.BreederPrompt
@@ -9252,7 +9252,7 @@ msgstr "¡Has cambiado!"
 #: /Game/Dialogue/Autumn/Default/DryadHaveKeystone.Default__DryadHaveKeystone_C.SessionData.Lines(6).Lines
 msgctxt ",AA4B233A44217B671C811FA495E456B5"
 msgid "She can pollinate me all day, and together we will make amazing fruit."
-msgstr "Ella puede polinizarme todo el día y juntos haremos una fruta increíble."
+msgstr "Ella puede polinizarme todo el día y juntas haremos una fruta increíble."
 
 #. Key:	AAD8CEA34AE6DE13A8683089046598D3
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R02.Default__FaleneDefault01_R02_C.SessionData.Lines(6).Lines
@@ -9441,7 +9441,7 @@ msgstr "¡Te espera un mundo de sexo y aventuras!"
 #: /Game/Dialogue/DragonMatriarch/Default/DMYourChildren.Default__DMYourChildren_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",AE940C0E4203F3605E98088D0827EA0B"
 msgid "Believe me human, I have sired many offspring."
-msgstr "Créeme, humana, he dado a luz a muchos descendientes."
+msgstr "Créeme, humano, he dado a luz a muchos descendientes."
 
 #. Key:	AE9DC6E246625CE553B669ADBD1EB570
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDefault01_Meow_RL_F.Default__CassieDefault01_Meow_RL_F_C.ResponseData(0).ResponseData.BreederPrompt
@@ -9476,7 +9476,7 @@ msgstr "Eres el señor de este suelo: o más bien el dueño de la Granja en la l
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeSad_RL.Default__MegaSlimeSad_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",AF5E23FC4ED6AD9A92E6E98CE8F2080F"
 msgid "Uh... are you alright?"
-msgstr "Uh... ¿estás bien?"
+msgstr "Eh... ¿estás bien?"
 
 #. Key:	AF6126694453EEB0A7AA7787649EC605
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFuta(2).LinesToFuta
@@ -9541,7 +9541,7 @@ msgstr "Si logras hacerlo, se te otorgará la Keystone y daré instrucciones a m
 #: /Game/Dialogue/QueenBee/Default/BeeMasturbate.Default__BeeMasturbate_C.SessionData.Lines(3).Lines
 msgctxt ",B0F5CCC741FEDFC39587579F638D56DC"
 msgid "Asking one of the @MONSTER_RACE@ if they masturbate all day is the most redundant question I've heard."
-msgstr "Preguntarle a uno de los @MONSTER_RACE@ si se masturban todo el día es la pregunta más redundante que he escuchado."
+msgstr "Preguntarle a un @MONSTER_RACE@ si se masturba todo el día es la pregunta más redundante que he escuchado."
 
 #. Key:	B100F65E4495A60CD1761FA5FA43CBEE
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaHadSex02.Default__CamillaHadSex02_C.SessionData.LinesToMale(2).LinesToMale
@@ -9583,7 +9583,7 @@ msgstr "¿Bueno, qué estás esperando? ¡Venga!"
 #: /Game/Dialogue/Kybele/Default/KybeleTittyPony.Default__KybeleTittyPony_C.SessionData.LinesToFuta(1).LinesToFuta
 msgctxt ",B16A16AD4DAD11735CC38DBC5E9237B1"
 msgid "It's been sometime since I have been mounted, so I might get rough!"
-msgstr "Ha pasado algún tiempo desde que me montaron, ¡así que podría ponerme dura!"
+msgstr "Ha pasado algún tiempo desde que me montaron, ¡así que podría ponerme brava!"
 
 #. Key:	B17C429C4AE53B8CA98F5E8166D598D2
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadCherryHelp.Default__DryadCherryHelp_C.SessionData.LinesToFemale(3).LinesToFemale
@@ -9597,7 +9597,7 @@ msgstr "Acércate humano..."
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeAboutOrb.Default__MegaSlimeAboutOrb_C.SessionData.Lines(5).Lines
 msgctxt ",B18F6EA040A16FCFD95EB3894A067B79"
 msgid "She speaks to me! Such wonderful stories about her adventures rolling around the world."
-msgstr "¡Ella me habla! Historias tan maravillosas sobre sus aventuras rodando por todo el mundo."
+msgstr "¡Él me habla! Historias tan maravillosas sobre sus aventuras rodando por todo el mundo."
 
 #. Key:	B1A4C4984540058620CA09A3FC603DBE
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeDefault01_Accent.Default__AmberMaeDefault01_Accent_C.SessionData.Lines(1).Lines
@@ -9661,14 +9661,14 @@ msgstr "Puedeh considerahme una conosedora de la leshe @MONSTER_RACE@. La leshe 
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_StartForgotten.Default__ParvatiDefault01_StartForgotten_C.SessionData.Lines(2).Lines
 msgctxt ",B235542C44D65B1D62C721A3C4CD289F"
 msgid "Pay close attention to my form, and learn you should."
-msgstr "Presta mucha atención a mi forma, y aprende lo que debas."
+msgstr "Presta mucha atención a mi forma, y aprende lo esencial."
 
 #. Key:	B27218744AEBAD507E1037B620EC16DA
 #. SourceLocation:	/Game/Dialogue/Blossom/Default/BlossomDefault01_R03_R01.Default__BlossomDefault01_R03_R01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Blossom/Default/BlossomDefault01_R03_R01.Default__BlossomDefault01_R03_R01_C.SessionData.Lines(0).Lines
 msgctxt ",B27218744AEBAD507E1037B620EC16DA"
 msgid "Hiss! Blossom love you mastah!"
-msgstr "¡Sss! ¡Blossom te ama Mastah!"
+msgstr "¡Sss! ¡Blossom te quiere, Mastah!"
 
 #. Key:	B27FC78147626E1ED81B86A06FCF68F9
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiWantAss.Default__FesssiWantAss_C.SessionData.Lines(1).Lines
@@ -9710,7 +9710,7 @@ msgstr "¡Un humano! Un humano super lindo... este es mi día de suerte. He esta
 #: /Game/Dialogue/Fern/Default/FernDefault01_R03.Default__FernDefault01_R03_C.SessionData.Lines(1).Lines
 msgctxt ",B36EC36B46E4D040A92BF09236F605F9"
 msgid "Fern need human cum to grow into big Alraune! Hissss, Fern suck dick now!"
-msgstr "¡Fern necesita semen humano para convertirse en una gran alraune! ¡Sssss, Fern ahora chupa pene!"
+msgstr "¡Fern necesita semen humano para convertirse en gran alraune! ¡Sssss, Fern ahora chupa pene!"
 
 #. Key:	B3953BA1451F630DE2CF019EB4CB6A69
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(23 - Value).TraitIcons.DisplayName
@@ -9725,7 +9725,7 @@ msgstr "Valioso"
 #: /Game/Dialogue/Romy/Default/RomyGreeting01.Default__RomyGreeting01_C.SessionData.Lines(2).Lines
 msgctxt ",B3B231554333647A7518C9A44578C0B1"
 msgid "I hear your eyes working your way down my voluptuous form, your heart beats faster."
-msgstr "Escucho a tus ojos recorrer su camino bajando por mi voluptuosa forma, tu corazón late más rápido."
+msgstr "Escucho a tus ojos recorrer su camino bajando por mi voluptuosa figura, tu corazón late más rápido."
 
 #. Key:	B3B7244F401573EDDD24A0BB5011F55C
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_HowToSpiritForm_RL_T.Default__LeylannaDefault01_HowToSpiritForm_RL_T_C.ResponseData(2).ResponseData.BreederPrompt
@@ -9739,7 +9739,7 @@ msgstr "Esto se está volviendo raro..."
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R03.Default__FaleneDefault01_R03_C.SessionData.Lines(7).Lines
 msgctxt ",B3B9D4DE46AC98F7EC5432A2F06C92D6"
 msgid "Also, you will be making more cute little @MONSTER_RACE@ for me to \"play\" with!"
-msgstr "Además, ¡harás pequeños @MONSTER_RACE@ más lindos para que yo \"juegue\" con ellos!"
+msgstr "Además, ¡harás más pequeños @MONSTER_RACE@ lindos para que yo \"juegue\" con ellos!"
 
 #. Key:	B40DA93F4D87A08B36AB2198B2D523AF
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiHadSex01.Default__ParvatiHadSex01_C.SessionData.Lines(2).Lines
@@ -9802,14 +9802,14 @@ msgstr "Llévalas a la Granja y engendra descendencia."
 #: /Game/Dialogue/Widow/Default/WidowDefault01.Default__WidowDefault01_C.SessionData.Lines(1).Lines
 msgctxt ",B5AD6A9A40AB4528FFC0BCBCD051C66B"
 msgid "Ah little one... you are now mine. Don't be afraid, for I only wish to please."
-msgstr "Ah, pequeña... ahora eres mía. No temas, pues solo deseo complacer."
+msgstr "Ah, pequeño... ahora eres mío. No temas, pues solo deseo complacer."
 
 #. Key:	B5B8312540B0C71F1DDBCEADEF6C3E02
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(10).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(10).Lines
 msgctxt ",B5B8312540B0C71F1DDBCEADEF6C3E02"
 msgid "I meant what I said about ye between 'mai jugs. Mayhaps we can have a li'l fun in the future?"
-msgstr "Quise desih lo que dije sobre ti entre cántaroh de leshe. ¿Quisáh podamoh divertirnoh un poco en er futuro?"
+msgstr "Quise desih lo que dije sobre ti entre mih cántaroh de leshe. ¿Quisáh podamoh divertirnoh un poco en er futuro?"
 
 #. Key:	B5C876DA4DBA230757C412BE4612735C
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcHaveKeystone.Default__OrcHaveKeystone_C.SessionData.Lines(4).Lines
@@ -9823,7 +9823,7 @@ msgstr "¡¡¡Grrrr!!! Una vaca con algo de agallas, ¡ahora hazlo humano!"
 #: /Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFemale(5).LinesToFemale
 msgctxt ",B5E173FA45294C4DE256EF836668F092"
 msgid "Both?"
-msgstr "¿Ambas?"
+msgstr "¿Ambos?"
 
 #. Key:	B5F3B5B2436545B9AAC067B451FA7563
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchQueen.Default__MonarchQueen_C.SessionData.Lines(2).Lines
@@ -9865,7 +9865,7 @@ msgstr "Ensenada del Éxtasis ahora es accesible."
 #: /Game/Dialogue/Camilla/Default/CamillaGreeting01.Default__CamillaGreeting01_C.SessionData.Lines(2).Lines
 msgctxt ",B685468D40290FF6E84B0D812D2A7F2F"
 msgid "Everyone wants Falene. She's so beautiful, and no one cares about the short girthy lump in the corner!"
-msgstr "Todos quieren a Falene. Ella es tan hermosa, ¡y a nadie le importa el pequeño bulto orondo en la esquina!"
+msgstr "Todos quieren a Falene. Ella es tan hermosa, ¡y a nadie le importa el pequeño bulto rollizo en la esquina!"
 
 #. Key:	B69447294A19D4E4338E36BBB1C2DADE
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_HowToSpiritForm.Default__LeylannaDefault01_HowToSpiritForm_C.SessionData.LinesToFuta(2).LinesToFuta
@@ -9886,21 +9886,21 @@ msgstr "La gente del pueblo viene aquí para relajarse y hacer el amor, es hermo
 #: /Game/Dialogue/Autumn/Default/DryadFlowers.Default__DryadFlowers_C.SessionData.Lines(3).Lines
 msgctxt ",B72B154840C9EFADCC67BE89C1C467AA"
 msgid "I can feel the roots of many cuminus flowers, but no ejaculum-phallis. Hmm..."
-msgstr "Puedo sentir las raíces de muchas flores de comino, pero no de ejaculum-phallis. Mmm..."
+msgstr "Puedo sentir las raíces de muchas flores de cuminus, pero no de ejaculum-phallis. Mmm..."
 
 #. Key:	B740BA7F4ADFB18E32DFE99606B483B3
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeDefault01_SuckJugs.Default__AmberMaeDefault01_SuckJugs_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeDefault01_SuckJugs.Default__AmberMaeDefault01_SuckJugs_C.SessionData.Lines(0).Lines
 msgctxt ",B740BA7F4ADFB18E32DFE99606B483B3"
 msgid "Bless me for say'n so, but I was wish'n you'd ask that!"
-msgstr "Bendíseme poh desirlo, ¡pero me guhtaría que me preguntarah eso!"
+msgstr "Bendíseme poh desirlo, ¡pero ehtaba deseando que me preguntarah eso!"
 
 #. Key:	B792D83B44DC1E7BF9DAE08B4D4A3E70
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_UpHere.Default__RomyDefault01_UpHere_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Romy/Default/RomyDefault01_UpHere.Default__RomyDefault01_UpHere_C.SessionData.Lines(0).Lines
 msgctxt ",B792D83B44DC1E7BF9DAE08B4D4A3E70"
 msgid "The real question is: how did you get here human?"
-msgstr "La verdadera pregunta es: ¿cómo llegaste aquí humano?"
+msgstr "La verdadera pregunta es: ¿Como llegaste tú aquí, humano?"
 
 #. Key:	B79398FF462643C6AD3C78BBEBD9E244
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernBeeFlowers3.Default__FernBeeFlowers3_C.SessionData.Lines(1).Lines
@@ -9979,7 +9979,7 @@ msgstr "Recoger néctar como una delicada mariposa es difícil."
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_Forgot.Default__ParvatiDefault01_Forgot_C.SessionData.Lines(1).Lines
 msgctxt ",B8035279491515770BA6408AEE0EC908"
 msgid "Worry not of your forgetful mind."
-msgstr "No te preocupes por tu mente olvidadiza."
+msgstr "No te preocupes por tu olvidadiza mente."
 
 #. Key:	B8242BCA4C426CBD3195A28D03A195C3
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimePlay1.Default__MegaSlimePlay1_C.SessionData.LinesToFemale(4).LinesToFemale
@@ -10021,7 +10021,7 @@ msgstr "Coloca la Keystone"
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R02.Default__CamillaDefault01_R02_C.SessionData.Lines(9).Lines
 msgctxt ",B832AA994DBADAA17A15049B206652C5"
 msgid "Well I've answered your question so you probably want to leave now. If you have any more questions you should feel free to ask me. Although I'm sure Falene could answer your questions too."
-msgstr "Bueno, he respondido a tu pregunta, así que probablemente quieras irte ahora. Si tienes más preguntas, no dudes en preguntarme. Aunque estoy segura de que Falene también podría responder a tus preguntas."
+msgstr "Bueno, he respondido a tu pregunta, así que probablemente quieras irte ahora. Si tienes más preguntas, deberías sentirte libre de preguntarme. Aunque estoy segura de que Falene también podría responder a tus preguntas."
 
 #. Key:	B841784842366C72B99D7BABC88D97E6
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_RL.Default__FaleneDefault01_RL_C.ResponseData(3).ResponseData.BreederPrompt
@@ -10133,7 +10133,7 @@ msgstr "De vez en cuando, viajeros aleatorios intentaban rodearme, pero pronto s
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_FutaBalls.Default__FaleneDefault01_FutaBalls_C.SessionData.Lines(1).Lines
 msgctxt ",B9F630DD484439D0C2B6EFBC3D01D2C5"
 msgid "Semen is stored internally to reduce the potential for damage and make more room for the vagina to expand."
-msgstr "El semen se almacena internamente para reducir el potencial de daño y hacer más espacio para que la vagina se expanda."
+msgstr "El semen se almacena internamente para reducir la posibilidad de daños y deja más espacio para que la vagina se expanda."
 
 #. Key:	BA4F5C334B416E6C99C047BD1AF731C9
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R02.Default__FaleneDefault01_R02_C.SessionData.Lines(7).Lines
@@ -10161,7 +10161,7 @@ msgstr "Desde el Vacío, Ella creó este universo y comenzó a disfrutar de la c
 #: /Game/Dialogue/Cassie/Default/CassieGreeting01.Default__CassieGreeting01_C.SessionData.Lines(7).Lines
 msgctxt ",BB0E7B2D4F49CAAB00A884BE87ED9F44"
 msgid "Or if ya wanna really butter my butt and let me see your \"property\"."
-msgstr "O si realmente quieres untame el trasero y dejame ver tu \"propiedad\"."
+msgstr "O si realmente quieres, úntame el trasero y déjame ver tu \"propiedad\"."
 
 #. Key:	BB111DD44D5B70DED7DD519DD967FEC8
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimePlay.Default__MegaSlimePlay_C.SessionData.LinesToFuta(0).LinesToFuta
@@ -10175,7 +10175,7 @@ msgstr "¡¿En serio?! ¡Estos son verdaderamente los mejores días de mi vida!"
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeHowLong.Default__MegaSlimeHowLong_C.SessionData.Lines(3).Lines
 msgctxt ",BB8503A14E015AEDED4E1C866261B05C"
 msgid "If I could only get some townsfolk to come here and feed me warm cum!"
-msgstr "¡Si tan solo pudiera hacer que algunos habitantes vinieran aquí y me alimentaran con semen caliente!"
+msgstr "¡Si tan solo pudiera hacer que alguna gente del pueblo viniera aquí y me alimentaran con semen caliente!"
 
 #. Key:	BB8EC0EA497B20CC5A726AA919605178
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R04.Default__CamillaDefault01_R04_C.SessionData.Lines(0).Lines
@@ -10203,7 +10203,7 @@ msgstr "¡Deberías darle un nombre a nuestra hija!"
 #: /Game/Dialogue/Autumn/Default/DryadCherryHelp_RL.Default__DryadCherryHelp_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",BC29BB8B478C65C2CBA0898E60299364"
 msgid "Uh, I only make babies not fruit."
-msgstr "Uh, solo hago bebés, no frutas."
+msgstr "Eh, solo hago bebés, no frutas."
 
 #. Key:	BC33AF644FC93D01CDEF628CB3209014
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchHadSex01.Default__MonarchHadSex01_C.SessionData.LinesToFuta(2).LinesToFuta
@@ -10301,7 +10301,7 @@ msgstr "Son para las ayrshires que deambulan por aquí, ¡y oh cielos, lo que pu
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",BDF9214F4D266A69032FE9921524969C"
 msgid "You have just become @WORLD_NAME@'s newest resident!"
-msgstr "¡Te acabas de convertir en el residente más nuevo de @WORLD_NAME@!"
+msgstr "¡Te acabas de convertir en la residente más nueva de @WORLD_NAME@!"
 
 #. Key:	BDFBF2444482EC9CA1B83B92138A12DD
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(35 - Value).TraitIcons.HelpText
@@ -10330,7 +10330,7 @@ msgstr "Bueno saberlo."
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01.Default__CamillaDefault01_C.SessionData.Lines(0).Lines
 msgctxt ",BE946F0645DD9D40528D2A9DB1FB48B4"
 msgid "Sometimes Falene makes me ride on her back around town."
-msgstr "A veces, Falene me hace montar en su espalda por la ciudad."
+msgstr "A veces, Falene me hace montar en su espalda por el pueblo."
 
 #. Key:	BE9F677046DE7F9AE5246FB18D7F8FFB
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01.Default__CamillaDefault01_C.SessionData.Lines(1).Lines
@@ -10351,14 +10351,14 @@ msgstr "Pero cuidado, otros @MONSTER_RACE@ bendecidos han recolectado las Keysto
 #: /Game/Dialogue/Monarch/Default/MonarchHadSex01.Default__MonarchHadSex01_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",BEDA154E4410DE62211DBFA48872ED35"
 msgid "Thank you h-h-human!"
-msgstr "¡Gracias h-h-humano!"
+msgstr "¡Gracias, h-h-humano!"
 
 #. Key:	BEDA7D94498AC1A3091C29BABE2C94F7
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_RL.Default__CamillaDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_RL.Default__CamillaDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",BEDA7D94498AC1A3091C29BABE2C94F7"
 msgid "Falene said you could tell me how to catch @MONSTER_RACE@?"
-msgstr "¿Falene dijo que podrías decirme cómo atrapar @MONSTER_RACE@?"
+msgstr "¿Falene dijo que podrías contarme cómo atrapar @MONSTER_RACE@?"
 
 #. Key:	BF0DF5C24AC9872B58BA689D790CE436
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeTaskFulfilled.Default__BeeTaskFulfilled_C.SessionData.Lines(3).Lines
@@ -10386,14 +10386,14 @@ msgstr "Ahora las hermanas de la tribu están teniendo descendencia con ella. Es
 #: /Game/Dialogue/QueenBee/Default/BeeDefault01.Default__BeeDefault01_C.SessionData.LinesToFemale(4).LinesToFemale
 msgctxt ",BF75C6BF46495EB7F48CD398677B4B16"
 msgid "Is t-t-there something... you want human?"
-msgstr "¿Hay a-a-algo... que quieras humana?"
+msgstr "¿Hay a-a-algo... que quieras, humana?"
 
 #. Key:	BF7F7E1041AD5B8267C70694F83985F6
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R03.Default__CamillaDefault01_R03_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R03.Default__CamillaDefault01_R03_C.SessionData.Lines(0).Lines
 msgctxt ",BF7F7E1041AD5B8267C70694F83985F6"
 msgid "Meh... you're just another one of those who thinks I'm cute because I'm small!"
-msgstr "Meh... ¡eres uno más de los que piensan que soy linda porque soy pequeña!"
+msgstr "Meh... ¡eres sólo uno más de los que piensan que soy linda porque soy pequeña!"
 
 #. Key:	BF975F284EF533BA005E9DB9E53ED275
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcBrashDumb.Default__OrcBrashDumb_C.SessionData.Lines(5).Lines
@@ -10520,7 +10520,7 @@ msgstr "Esto ha provocado que muchos kraken se hayan impuesto a sus compañeros 
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_PussyPortals.Default__NeelaDefault01_PussyPortals_C.SessionData.Lines(1).Lines
 msgctxt ",C198075048B96603CACC81A045A05956"
 msgid "It is said, they are an exact replica of the Goddess' vagina itself!"
-msgstr "¡Se dice que son una réplica exacta de la vagina de la Diosa misma!"
+msgstr "¡Se dice que son una réplica exacta de la mismísima vagina de la Diosa!"
 
 #. Key:	C2409B0E43C4FECF37A9A4AEC03EA9E7
 #. SourceLocation:	/Game/Ranch/Upgrades/FormurianPond.Default__FormurianPond_C.Upgrade.Description
@@ -10548,7 +10548,7 @@ msgstr "Los krakens fundaron Formuria, y desde entonces hemos mantenido el seño
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_StartKrakVag.Default__MirruDefault01_StartKrakVag_C.SessionData.Lines(0).Lines
 msgctxt ",C2F976F9463088F39315118741B15D32"
 msgid "Ohh... you will not regret it human."
-msgstr "Ohh... no te arrepentirás humano."
+msgstr "Ohh... no te arrepentirás, humano."
 
 #. Key:	C31358424DDC04F9D0E9C2AFEADAFCE4
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMSoBeItT.Default__DMSoBeItT_C.SessionData.Lines(0).Lines
@@ -10590,7 +10590,7 @@ msgstr "Grrrrr... la cacique cachonda de nuevo. El humano no debería quedarse m
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_FloatRhyme.Default__ParvatiDefault01_FloatRhyme_C.SessionData.Lines(1).Lines
 msgctxt ",C45BFAF14EABF8D1BD3502825C5C1560"
 msgid "And became one with the Goddess who indulged in beastiality."
-msgstr "Y con la Diosa me convertí en una que se entregaba a la bestialidad."
+msgstr "Y con la Diosa me convertí en una que se entregó a la bestialidad."
 
 #. Key:	C462B3344F759413A7C6F28489176C99
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R03_RL.Default__CamillaDefault01_R03_RL_C.ResponseData(1).ResponseData.BreederPrompt
@@ -10611,7 +10611,7 @@ msgstr "¡Amm! ¡Alguien quiere que le chupen el pene!"
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_Teach.Default__ParvatiDefault01_Teach_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",C4A89EE6414BE3013E77CA81E8105E53"
 msgid "Remove your garments, for you must be nude."
-msgstr "Quítate tus prendas, debes estar desnuda."
+msgstr "Quítate tus prendas, debes estar en pelota picada."
 
 #. Key:	C4C596ED4DE277B929ABDDB01255A79B
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDungeon.Default__CassieDungeon_C.SessionData.Lines(1).Lines
@@ -10653,7 +10653,7 @@ msgstr "Entrégame tu cuerpo, y en éxtasis lo haremos conformar."
 #: /Game/Dialogue/Fesssi/Default/FesssiStuck.Default__FesssiStuck_C.SessionData.Lines(2).Lines
 msgctxt ",C540E787424068F17DC21E839F8383CC"
 msgid "I blame that dryad, she kept bringing me her sweet fruit, and before I knew it my ass was too big to leave my cave."
-msgstr "Culpo a esa dríada, ella seguía trayendo su dulce fruta, y antes de que me diera cuenta, mi trasero era demasiado grande para salir de mi cueva."
+msgstr "Maldigo a esa dríada, ella seguía trayendo su dulce fruta, y antes de que me diera cuenta, mi trasero era demasiado grande para salir de mi cueva."
 
 #. Key:	C544F8824FC4DDC6DBEFE084C3987F32
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon2.Default__AmberMaeLockedDungeon2_C.SessionData.Lines(4).Lines
@@ -10688,7 +10688,7 @@ msgstr "Un trato es un trato, tómala."
 #: /Game/Dialogue/Fern/Default/FernDefault01_R02.Default__FernDefault01_R02_C.SessionData.Lines(1).Lines
 msgctxt ",C5E724D9440EB6AC1E01458A6325FC39"
 msgid "Me like this name Fern. Hiss!"
-msgstr "Yo gustar este nombre, Fern. ¡Sss!"
+msgstr "Me gusta este nombre, Fern. ¡Sss!"
 
 #. Key:	C5F9CCA94803FF5DA8A42E947B60C68D
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(12).LinesToMale
@@ -10744,7 +10744,7 @@ msgstr "¡Si! Puedo sentir que estás a punto de correrte... lo quiero todo. Mmm
 #: /Game/Dialogue/Autumn/Default/DryadHaveKeystone2.Default__DryadHaveKeystone2_C.SessionData.Lines(0).Lines
 msgctxt ",C6E5F355439A82543536AA974313674B"
 msgid "It's yours now, I hope it serves you well."
-msgstr "Es tuyo ahora, espero que te sirva bien."
+msgstr "Es tuya ahora, espero que te sirva bien."
 
 #. Key:	C720F2B64D81061E9D1CC7A3ACD4F0BB
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R02.Default__FaleneDefault01_R02_C.SessionData.Lines(12).Lines
@@ -10758,7 +10758,7 @@ msgstr "¡Cuidado, algunos bendecidos pueden sucumbir a sus deseos y sorprendert
 #: /Game/Dialogue/Parvati/Default/ParvatiGreeting01.Default__ParvatiGreeting01_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",C73CE27C41A91E73C54B58B65E56049E"
 msgid "You seek to learn a new way to use your pleasure hole."
-msgstr "Buscas aprender una nueva forma de usar tu agujero del placer."
+msgstr "Buscas aprender una nueva forma de usar tu agujero afectivo."
 
 #. Key:	C760FF8B46FA4C58A2012CB2F41CE6F8
 #. SourceLocation:	/Game/Characters/Procedural/Variants/Risu/Harvest/RisuHarvest.Default__RisuHarvest_C.Harvest.RaceName
@@ -10802,14 +10802,14 @@ msgstr "Sí, ven conmigo, más profundo en mi nido de amor. Sentirás oleada tra
 #: /Game/Dialogue/Yasmine/Default/YasmineAwake.Default__YasmineAwake_C.SessionData.Lines(0).Lines
 msgctxt ",C80F35DE492B934FC30FBE82A653139B"
 msgid "Ah shooooot, my pearl went and rolled away again."
-msgstr "Ah, disparaaaa, mi perla se fue y rodó de nuevo."
+msgstr "Ah, disparadaaaa, mi perla se fue y se alejó rodando de nuevo."
 
 #. Key:	C831296B46D9E6D1B4ECA181BCD5520B
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_SexPositions.Default__EmissaryDefault01_SexPositions_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_SexPositions.Default__EmissaryDefault01_SexPositions_C.SessionData.Lines(1).Lines
 msgctxt ",C831296B46D9E6D1B4ECA181BCD5520B"
 msgid "She will teach you how to position the body for optimal sexual experience."
-msgstr "Ella le enseñará cómo colocar el cuerpo para una experiencia sexual óptima."
+msgstr "Ella te enseñará cómo colocar el cuerpo para una experiencia sexual óptima."
 
 #. Key:	C8F56B5143EC7D77BCE3D483F91BD832
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeMasturbate.Default__BeeMasturbate_C.SessionData.Lines(4).Lines
@@ -10830,14 +10830,14 @@ msgstr "¡Sss! Lo tengo."
 #: /Game/Dialogue/QueenBee/Default/BeeMasturbate.Default__BeeMasturbate_C.SessionData.Lines(0).Lines
 msgctxt ",C90FBEEB4770B7951F9099B01096A1B0"
 msgid "What... ahhh... a silly thing to ask... ohhh."
-msgstr "Qué... ahhh... cosa tan tonta para preguntar... ohhh."
+msgstr "Qué... pregunta más tonta... ohhh."
 
 #. Key:	C91B08354F7D144D174BCB8A2C8384CF
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMGreeting01.Default__DMGreeting01_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/DragonMatriarch/Default/DMGreeting01.Default__DMGreeting01_C.SessionData.Lines(5).Lines
 msgctxt ",C91B08354F7D144D174BCB8A2C8384CF"
 msgid "Now if you don't mind, I'd love to get back to my nap."
-msgstr "Ahora, si no le importa, me encantaría volver a mi siesta."
+msgstr "Ahora, si no te importa, me encantaría volver a mi siesta."
 
 #. Key:	C933962A4C5DD7F022D428AEE50FE2C0
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeDefault01_RL.Default__MegaSlimeDefault01_RL_C.ResponseData(5).ResponseData.BreederPrompt
@@ -10851,7 +10851,7 @@ msgstr "¡Quiero jugar en tu limo de nuevo!"
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_SexPositions.Default__FaleneDefault01_SexPositions_C.SessionData.Lines(2).Lines
 msgctxt ",C93F66124DFE84936731BDBDEB0840B9"
 msgid "There is plenty of sex around Hedon to occupy my small attention span."
-msgstr "Hay mucho sexo alrededor de Hedon para ocupar mi pequeña capacidad de atención."
+msgstr "Hay abundancia de sexo alrededor de Hedon para ocupar mi pequeña capacidad de atención."
 
 #. Key:	C94B41FA4308FFD8A8F985BFB7D0411F
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowKeystone.Default__WidowKeystone_C.SessionData.Lines(2).Lines
@@ -10887,7 +10887,7 @@ msgstr "Tamaño Mediano"
 #: /Game/Dialogue/Autumn/Default/DryadFlowers.Default__DryadFlowers_C.SessionData.Lines(2).Lines
 msgctxt ",CA7A7B57487A850B58D2F18581846801"
 msgid "Lets see. The flowers native to the Hivelands are cuminus-labialata and ejaculum-phallis."
-msgstr "Vamos a ver. Las flores nativas de las tierras altas son cuminus-labialata y ejaculum-phallus."
+msgstr "Vamos a ver. Las flores nativas de las Tierras-Colmena son cuminus-labialata y ejaculum-phallus."
 
 #. Key:	CA7FAE6645EB660782FB59BB2F359378
 #. SourceLocation:	/Game/Ranch/Upgrades/TitanCave.Default__TitanCave_C.Upgrade.TypeDisplay
@@ -10915,7 +10915,7 @@ msgstr "Cuidado humana, la lujuria de un kraken no debe ser subestimada."
 #: /Game/Dialogue/Kybele/Default/KybeleTittyPony_T.Default__KybeleTittyPony_T_C.SessionData.LinesToMale(1).LinesToMale
 msgctxt ",CAC37D3345B82EE95615E0BB5C42ED5B"
 msgid "It's been sometime since I have been mouted, so I might get rough!"
-msgstr "Ha pasado algún tiempo desde que me montaron, ¡así que podría ponerme dura!"
+msgstr "Ha pasado algún tiempo desde que me montaron, ¡así que podría ponerme brava!"
 
 #. Key:	CADDB09246D63E86CBE17C8852675D4B
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01_RL_F.Default__FernDefault01_RL_F_C.ResponseData(4).ResponseData.BreederPrompt
@@ -10929,7 +10929,7 @@ msgstr "La Abeja Reina exige flores."
 #: /Game/Dialogue/Fesssi/Default/FesssiCave.Default__FesssiCave_C.SessionData.Lines(7).Lines
 msgctxt ",CADF79DB4BDC5031DE5FA79A12695348"
 msgid "If you are heading down there, you will no doubt confront Widow. Don't let her frighten you... trust me, she knows how to please. Hiss!"
-msgstr "Si te diriges hacia allí, sin duda te enfrentarás a Widow. No dejes que te asuste... créeme, sabe complacer. ¡Sss!"
+msgstr "Si te diriges hacia allí abajo, sin duda te enfrentarás a Widow. No dejes que te asuste... créeme, sabe cómo complacer. ¡Sss!"
 
 #. Key:	CB48004E4E339F82564495A0A7D0209C
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcDefault02_RL.Default__OrcDefault02_RL_C.ResponseData(0).ResponseData.BreederPrompt
@@ -11069,7 +11069,7 @@ msgstr "@MONSTER_RACE@ bendecidos como yo tienen una inteligencia a nivel humano
 #: /Game/Dialogue/Cassie/Default/CassieDefault01_WhatCanBuild.Default__CassieDefault01_WhatCanBuild_C.SessionData.Lines(0).Lines
 msgctxt ",CE3738E344825C4371847CB9F0E4445E"
 msgid "I can build anything your genitalia desires!"
-msgstr "¡Puedo construir cualquier cosa que deseen tus genitales!"
+msgstr "¡Puedo construir cualquier cosa que te salga de tus partes!"
 
 #. Key:	CE38F80044474A7AE6C3A68384DE4350
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadHaveKeystone.Default__DryadHaveKeystone_C.SessionData.Lines(1).Lines
@@ -11112,7 +11112,7 @@ msgstr "¿Estás seguro de que puedes manejar esto, humano?"
 #: /Game/Dialogue/QueenBee/Default/BeeHaveKeystone.Default__BeeHaveKeystone_C.SessionData.Lines(3).Lines
 msgctxt ",CEB5AB8346357320346305B899A9C7BB"
 msgid "Long ago, large flowers grew here. The nectar they produced was worthy of the Goddess Herself."
-msgstr "Hace mucho tiempo, aquí crecían grandes flores. El néctar que producían era digno de la propia Diosa."
+msgstr "Hace mucho tiempo, aquí crecían grandes flores. El néctar que producían era digno de la mismísima Diosa."
 
 #. Key:	CEC4092D45D0DBE6546A729EE34F0267
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_AboutMusic.Default__RomyDefault01_AboutMusic_C.SessionData.Lines(3).Lines
@@ -11175,7 +11175,7 @@ msgstr "Ah, entonces es verdad. De hecho, un humano camina por tierra firme."
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R03.Default__FaleneDefault01_R03_C.SessionData.Lines(3).Lines
 msgctxt ",CFB4BE294E1D3D81CE72719BCB08B1C7"
 msgid "You know, the floating busty winged statues with the sparkles... I will admit I get all tingly inside around them too!"
-msgstr "Ya sabes, las estatuas aladas y tetonas flotantes con los destellos... ¡debo admitir que también siento un hormigueo dentro de ellas!"
+msgstr "Ya sabes, las estatuas aladas y pechugonas flotantes con los destellos... ¡debo admitir que también siento un hormigueo dentro de ellas!"
 
 #. Key:	CFBBDFD5421C17E7EB1CBBB86EEBD93C
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraAboutPawsmaati.Default__PetraAboutPawsmaati_C.SessionData.Lines(7).Lines
@@ -11232,7 +11232,7 @@ msgstr "Meseta Bochornosa"
 #: /Game/Dialogue/Kybele/Default/KybeleHadSex01.Default__KybeleHadSex01_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",D0AFE2FE43D96C0225B202A9DF9DC0CB"
 msgid "You paid the price, now you are filled with a giant load of centaur cum."
-msgstr "Pagaste el precio, ahora estás lleno de una carga gigante de semen centauro."
+msgstr "Pagaste el precio, ahora estás llena de una carga gigante de semen centauro."
 
 #. Key:	D0D371BB447B4CD8A5A17682F596B922
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDungeon.Default__CamillaDungeon_C.SessionData.Lines(0).Lines
@@ -11246,7 +11246,7 @@ msgstr "¡¡¿Me veo como una ingeniera civil?!!"
 #: /Game/Dialogue/Kybele/Default/KybeleTittyPony_T.Default__KybeleTittyPony_T_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",D0DE0CF44CDB98087C882AA54375F7BD"
 msgid "That should teach you to cross this titty po--I mean mighty centaur warmaiden, again!"
-msgstr "Eso debería enseñarte a cruzar esta poni tet-: ¡otra vez, me refiero a la poderosa doncella-guerrera centauro!"
+msgstr "Eso debería enseñarte a cruzarte con esta poni tet-: ¡otra vez, me refiero a la poderosa doncella-guerrera centauro!"
 
 #. Key:	D0FA90CC4E9378DF7150FB881B18DC60
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(5 - Value).TraitIcons.HelpText
@@ -11297,7 +11297,7 @@ msgstr "Es la fruta roja gigante que ves por todos los pastos. Todas fueron crea
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_Formuria.Default__MirruDefault01_Formuria_C.SessionData.Lines(1).Lines
 msgctxt ",D1984E71418CEF4F3D39AC911B217790"
 msgid "Many aquatic @MONSTER_RACE@ inhabit our fair kingdom, but only Krakens have the might and will to rule."
-msgstr "Muchos @MONSTER_RACE@ acuáticos habitan nuestro bello reino, pero solo los krakens tiene el poder y la voluntad de gobernar."
+msgstr "Muchos @MONSTER_RACE@ acuáticos habitan nuestro bello reino, pero solo los krakens tienen el poder y la voluntad de gobernar."
 
 #. Key:	D1B21A3544F4242222944E97EA03E1BB
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMHadSex01.Default__DMHadSex01_C.SessionData.LinesToFemale(3).LinesToFemale
@@ -11325,7 +11325,7 @@ msgstr "Es por eso que nuestra raza desea tanto el sexo: es tan satisfactorio y 
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03_R04.Default__FernDefault03_R04_C.SessionData.Lines(0).Lines
 msgctxt ",D202E32F436700405E2417A73206A501"
 msgid "Oh Master... I have waited for this."
-msgstr "Oh, Master... he esperado para esto."
+msgstr "Oh, Master... he estado esperando para esto."
 
 #. Key:	D209ED1D49C6A4C6106AC69A3100D415
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01_R02_R01.Default__FernDefault01_R02_R01_C.SessionData.Lines(1).Lines
@@ -11346,7 +11346,7 @@ msgstr "Lo admito, es bastante tentador. Los humanos eran un mito hasta que te c
 #: /Game/Dialogue/OrcChief/Default/OrcBrashDumb.Default__OrcBrashDumb_C.SessionData.Lines(6).Lines
 msgctxt ",D2843C204C6DDAA26611B0B57F67BC41"
 msgid "Grrrrrr! Me human!"
-msgstr "¡Grrrrrr! ¡Yo humano!"
+msgstr "¡Grrrrrr! ¡Yo, humano!"
 
 #. Key:	D2C5AD664FCA892932A70188B37B1378
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFemale(4).LinesToFemale
@@ -11360,7 +11360,7 @@ msgstr "..."
 #: /Game/Dialogue/Camilla/Default/CamillaGreeting01.Default__CamillaGreeting01_C.SessionData.Lines(1).Lines
 msgctxt ",D2DF40244F8B96F91F4101A5AD5F08AA"
 msgid "I'm Camilla! Falene's little goblin assistant! You probably won't need to talk to me much because she's the smart one around here."
-msgstr "Soy Camilla ¡La pequeña asistente goblin de Falene! Probablemente no necesites hablar mucho conmigo porque ella es la inteligente por aquí."
+msgstr "¡Soy Camilla! ¡La pequeña asistente goblin de Falene! Probablemente no necesites hablar mucho conmigo porque ella es la inteligente por aquí."
 
 #. Key:	D2F9DD5648274637A18B9A8777C5CF03
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeDefault01_RL.Default__MegaSlimeDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
@@ -11444,7 +11444,7 @@ msgstr "Ahh... oh... tan delicioso."
 #: /Game/Dialogue/Mirru/SexScenes/MirruSnatchF.Default__MirruSnatchF_C.SessionData.Lines(4).Lines
 msgctxt ",D4BAFDEE4340A6062B18808C4CB9ABF1"
 msgid "Soon... ahhh... you will be covered and impregnated by sticky Kraken pleasure..."
-msgstr "Pronto... ahhh... estarás cubierto e impregnado por el pegajoso placer de kraken..."
+msgstr "Pronto... ahhh... estarás cubierta e impregnada por el pegajoso placer de kraken..."
 
 #. Key:	D4E7C4CC40DA7F02F81C91A5CFBF13E8
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMClimaxPeak.Default__DMClimaxPeak_C.SessionData.Lines(5).Lines
@@ -11508,7 +11508,7 @@ msgstr "Si no lo haces, ¡ellos lo harán!"
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_FloatRhyme.Default__ParvatiDefault01_FloatRhyme_C.SessionData.Lines(2).Lines
 msgctxt ",D5C1C3B248D402846D813ABD2800F061"
 msgid "Mentally I have sex with Her every day."
-msgstr "Mentalmente tengo sexo con Ella todos los días."
+msgstr "A diario sexo con Ella mentalmente he tenido."
 
 #. Key:	D5C1EFC54081F21A6C1F538839E450A2
 #. SourceLocation:	/Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToFuta(3).LinesToFuta
@@ -11564,7 +11564,7 @@ msgstr "¡Ella es asombrosa!"
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToFuta(3).LinesToFuta
 msgctxt ",D681E76840B85B19D8C08BBCF50268C8"
 msgid "All have been pleasurable and delicious... but oh have I wanted something more..."
-msgstr "Todos han sido placenteros y deliciosos... pero oh, he querido algo más..."
+msgstr "Todos han sido placenteros y deliciosos... pero oh, estoy buscando algo más..."
 
 #. Key:	D6BF802E4E5B43F72E7B4F90BD61A387
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_StartWaterfall.Default__ParvatiDefault01_StartWaterfall_C.SessionData.Lines(0).Lines
@@ -11585,7 +11585,7 @@ msgstr "Le traemos néctar y la complacemos sexualmente, y a cambio ella nos dej
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",D6E5B72340D672B892908385DF8BC169"
 msgid "In my case, that Alchemist Guild on the surface constantly dumps fresh semen down here."
-msgstr "En mi caso, ese Gremio de Alquimistas de la superficie arroja constantemente semen fresco aquí."
+msgstr "En mi caso, ese Gremio de Alquimistas de la superficie arroja constantemente semen fresco aquí abajo."
 
 #. Key:	D6ECEFA141121C7CDA69A5BAC65087CE
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMClimaxPeak.Default__DMClimaxPeak_C.SessionData.Lines(0).Lines
@@ -11606,7 +11606,7 @@ msgstr "¿Bueno, qué estás esperando? ¡Venga!"
 #: /Game/Dialogue/Kybele/Default/KybeleTaskFulfilled.Default__KybeleTaskFulfilled_C.SessionData.LinesToFuta(1).LinesToFuta
 msgctxt ",D75F1B6640E7E50789CBE7B4CBEE0FF3"
 msgid "The random mounts I get when I'm not paying attention never gets old."
-msgstr "Las montas aleatorias que obtengo cuando no estoy prestando atención nunca envejecen."
+msgstr "Las montas aleatorias que obtengo cuando no estoy prestando atención nunca pasan de moda."
 
 #. Key:	D76798CF4DCADF9AF42C6B88C36E27FB
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeAboutOrb_RL.Default__MegaSlimeAboutOrb_RL_C.ResponseData(0).ResponseData.BreederPrompt
@@ -11676,7 +11676,7 @@ msgstr "Mira mi hermosa flor, ¡floreció! Oh cielos, se sintió raro..."
 #: /Game/Dialogue/Kybele/Default/KybeleRideYou_RL.Default__KybeleRideYou_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",D8048E504EF52CFA3D3F618130F77DB0"
 msgid "Aww what an adorable titty pony."
-msgstr "Amm, que adorable poni tetudita."
+msgstr "Amm, que adorable poni tetuda."
 
 #. Key:	D839985345EFF273DA362C9BB07DA471
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMAboutDragons.Default__DMAboutDragons_C.SessionData.Lines(1).Lines
@@ -11697,7 +11697,7 @@ msgstr "Las Rupturas Vírgenes ahora son accesibles."
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeVerySad.Default__MegaSlimeVerySad_C.SessionData.Lines(0).Lines
 msgctxt ",D8702B7C4C5E95A9D843A79FCFBFB106"
 msgid "*Sniff*"
-msgstr "*Olfatea*"
+msgstr "*Sniff*"
 
 #. Key:	D87AAD604344FB1EAE2D0F9DCC51E7EA
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleHaveKeystone2.Default__KybeleHaveKeystone2_C.SessionData.Lines(1).Lines
@@ -11796,14 +11796,14 @@ msgstr "Cada vez gime un poco más fuerte, creo que empieza a volverse adicta a 
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R05.Default__CamillaDefault01_R05_C.SessionData.Lines(1).Lines
 msgctxt ",D9AEE8B346F04D85CD643FA456C20645"
 msgid "Did you really just phrase it that way?"
-msgstr "¿De verdad simplemente lo expresaste de esa manera?"
+msgstr "¿De verdad lo expresaste de esa manera?"
 
 #. Key:	D9E588CA4CF77A887584A3B57617B58C
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeVerySad.Default__MegaSlimeVerySad_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeVerySad.Default__MegaSlimeVerySad_C.SessionData.Lines(5).Lines
 msgctxt ",D9E588CA4CF77A887584A3B57617B58C"
 msgid "*Sobbing*"
-msgstr "*Sollozando*"
+msgstr "*Sollozo*"
 
 #. Key:	D9E7689541319CEB860F4A99964E97FE
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R03.Default__FaleneDefault01_R03_C.SessionData.Lines(5).Lines
@@ -11873,7 +11873,7 @@ msgstr "¡Puedes tener mi semen!"
 #: /Game/Dialogue/OrcChief/Default/OrcDefault03_RL.Default__OrcDefault03_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",DAA21E23412F638CF86C45BDFEF403A9"
 msgid "Uh... so... want to wrestle?"
-msgstr "Uh... entonces... ¿quieres luchar?"
+msgstr "Eh... entonces... ¿quieres luchar?"
 
 #. Key:	DAC926244203A48C0547B89807D93FA8
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R01.Default__FaleneDefault01_R01_C.SessionData.Lines(6).Lines
@@ -11915,14 +11915,14 @@ msgstr "¿Qué te trae por aquí?"
 #: /Game/Dialogue/Cassie/Default/CassieDefault01.Default__CassieDefault01_C.SessionData.Lines(2).Lines
 msgctxt ",DB15AC1342DDCD7D060351944CB369E4"
 msgid "Meeeeeow!"
-msgstr "¡Miiiiiau!"
+msgstr "¡Miaaaaau!"
 
 #. Key:	DB1DF3C343E55ED6022897831EFCA30B
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleAnyMeans.Default__KybeleAnyMeans_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/Kybele/Default/KybeleAnyMeans.Default__KybeleAnyMeans_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",DB1DF3C343E55ED6022897831EFCA30B"
 msgid "Haha! Humans do have a one-track mind... you aren't so different from us after all."
-msgstr "¡Jaja! Los humanos tienen una mente de una sola pista... después de todo, no eres tan diferente de nosotros."
+msgstr "¡Jaja! Los humanos solo piensan en una cosa... después de todo, no eres tan diferente de nosotros."
 
 #. Key:	DB4129DC426B367CD877BE889495E940
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_RL.Default__CamillaDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
@@ -11936,7 +11936,7 @@ msgstr "¡Intercambiemos semen!"
 #: /Game/Dialogue/Kybele/Default/KybeleAnyMeans_RL_T.Default__KybeleAnyMeans_RL_T_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",DB44149945F62048F1EF0D9C2BF75EFB"
 msgid "Pfff I can handle a titty pony."
-msgstr "Pfff, puedo manejar una pony tetudita."
+msgstr "Pfff, puedo manejar una poni tetuda."
 
 #. Key:	DB49BD62447CAE7EAA40869818522E59
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R03_RL.Default__CamillaDefault01_R03_RL_C.ResponseData(0).ResponseData.BreederPrompt
@@ -11957,7 +11957,7 @@ msgstr "Sss..."
 #: /Game/Dialogue/Cassie/Default/CassieDungeon2.Default__CassieDungeon2_C.SessionData.Lines(3).Lines
 msgctxt ",DB700CCB477FAB622C9638923D9D31D6"
 msgid "That old rusty set of gears above the town entrance controls a pulley system."
-msgstr "Ese viejo y oxidado juego de engranajes sobre la entrada de la ciudad controla un sistema de poleas."
+msgstr "Ese viejo y oxidado juego de engranajes sobre la entrada del pueblo controla un sistema de poleas."
 
 #. Key:	DB7D31B143C7D61531D61790BE87667B
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03_R01.Default__FernDefault03_R01_C.SessionData.Lines(1).Lines
@@ -11971,7 +11971,7 @@ msgstr "Crecí en tu suelo, y ahora es mi hogar permanente. ¡Ojalá te guste tu
 #: /Game/Dialogue/Blossom/Default/BlossomDefault01_R02.Default__BlossomDefault01_R02_C.SessionData.Lines(1).Lines
 msgctxt ",DC0025004492CEEAE0F8D1A26E169F34"
 msgid "Me like this name Blossom. Hiss!"
-msgstr "Yo gustar este nombre, Blossom. ¡Sss!"
+msgstr "Me gusta este nombre, Blossom. ¡Sss!"
 
 #. Key:	DC23BE8C475FA9FCC7F22596C3D47F3F
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01_R02.Default__FernDefault01_R02_C.SessionData.Lines(2).Lines
@@ -12006,7 +12006,7 @@ msgstr "Aún así... me complaciste como un semental. ¡Eso es asombroso para al
 #: /Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFemale(7).LinesToFemale
 msgctxt ",DC59A07E4D2FC78409E32EA7A64B7007"
 msgid "That creepy golden seraphim, the one in the temple. She appeared only a few days ago, constantly asking to speak with \"the human\"."
-msgstr "Esa espeluznante serafín dorada, la del templo. Ella apareció hace solo unos días, constantemente pidiendo hablar con \"el humano\"."
+msgstr "Esa espeluznante serafín dorada, la del templo. Ella apareció hace solo unos días, constantemente pidiendo hablar con \"la humana\"."
 
 #. Key:	DC843E8A4828B0881624D494C080BC2B
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeDefault01_SuckJugs.Default__AmberMaeDefault01_SuckJugs_C.SessionData.Lines(1).Lines
@@ -12027,7 +12027,7 @@ msgstr "Son muy diferentes a sus contrapartidas humanas."
 #: /Game/Dialogue/Mirru/SexScenes/MirruSnatchF.Default__MirruSnatchF_C.SessionData.Lines(0).Lines
 msgctxt ",DC880E904973CDED818EF58F9949FB40"
 msgid "Submit human... I cannot control my desires!"
-msgstr "Entrégate humana... ¡No puedo controlar mis deseos!"
+msgstr "Entrégate humana... ¡no puedo controlar mis deseos!"
 
 #. Key:	DC956C0949E5CA05486F1583CEACA3ED
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(24 - Value).TraitIcons.DisplayName
@@ -12098,7 +12098,7 @@ msgstr "Mira mi hermosa flor, ¡floreció! Oh cielos, se sintió raro..."
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01.Default__ParvatiDefault01_C.SessionData.Lines(0).Lines
 msgctxt ",DD90913F4C544CDB2D79CDAE67287C68"
 msgid "Returning to me with that familiar glint in your eye."
-msgstr "Volviendo a mí con ese brillo familiar en tus ojos."
+msgstr "Volviendo a mí tu mirada con ese brillo conocido."
 
 #. Key:	DDC7B99042CEA89C790895990EB876BE
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R02.Default__FaleneDefault01_R02_C.SessionData.Lines(1).Lines
@@ -12126,7 +12126,7 @@ msgstr "Autumn está satisfecha."
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeHadSex01.Default__MegaSlimeHadSex01_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",DE21C1784F767D32E852689C8D264665"
 msgid "It's been so long since I have given slime."
-msgstr "Ha pasado tanto tiempo desde que le di limo."
+msgstr "Ha pasado tanto tiempo desde que di limo."
 
 #. Key:	DE7B484C4224680737F160881A189942
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_Emissary.Default__LeylannaDefault01_Emissary_C.SessionData.Lines(2).Lines
@@ -12140,7 +12140,7 @@ msgstr "Ella solo me dijo una frase: \"debo hablar con el humano\"."
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R05.Default__CamillaDefault01_R05_C.SessionData.Lines(2).Lines
 msgctxt ",DED16C92469A536D38021EBB9437E929"
 msgid "I think we're going to get along well human."
-msgstr "Creo que nos llevaremos bien humano."
+msgstr "Creo que nos llevaremos bien, humano."
 
 #. Key:	DED8326741203DABBF5FDBB2B97D6492
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_Formuria.Default__MirruDefault01_Formuria_C.SessionData.Lines(0).Lines
@@ -12217,7 +12217,7 @@ msgstr "Errrr, no puedo soportarlo más, ¡voy a ordeñarte hasta dejarte seco! 
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_Leylanna.Default__EmissaryDefault01_Leylanna_C.SessionData.Lines(2).Lines
 msgctxt ",E082A93948F5919CEB7D19BF935DA14E"
 msgid "All were in vain, for I am an archangel, but her kindess and loyatly to the Goddess are unquestionable."
-msgstr "Todos fueron en vano, ya que soy una arcángel, pero su amabilidad y lealtad a la Diosa son incuestionables."
+msgstr "Todos fueron en vano, ya que soy un arcángel, pero su amabilidad y lealtad a la Diosa son incuestionables."
 
 #. Key:	E0B9E9894DD5921A03759097168DF006
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_RL_T.Default__FernDefault02_RL_T_C.ResponseData(4).ResponseData.BreederPrompt
@@ -12238,7 +12238,7 @@ msgstr "Como tal, con frecuencia nos encontramos en el extremo receptor del sexo
 #: /Game/Dialogue/Autumn/Default/DryadAboutDryads.Default__DryadAboutDryads_C.SessionData.Lines(6).Lines
 msgctxt ",E0CB0262419C2D4379873799FB2844BC"
 msgid "I guess I do spoil them..."
-msgstr "Supongo que las arruino..."
+msgstr "Supongo que las mimo..."
 
 #. Key:	E0E93AA54E36B2C3F876CEBE1F52C2FC
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_Emissary.Default__LeylannaDefault01_Emissary_C.SessionData.Lines(4).Lines
@@ -12252,7 +12252,7 @@ msgstr "*Suspira* Cómo desearía que volara hasta aquí y sentara sus dorados b
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",E1403BCA4E98EC6272FC2E86F860771C"
 msgid "All have been pleasurable and delicious... but oh have I wanted something more..."
-msgstr "Todos han sido placenteros y deliciosos... pero oh, he querido algo más..."
+msgstr "Todos han sido placenteros y deliciosos... pero oh, estoy buscando algo más..."
 
 #. Key:	E1682EC8470332A4284BBB8EEDB147A2
 #. SourceLocation:	/Game/Dialogue/Blossom/Default/BlossomGreeting01.Default__BlossomGreeting01_C.SessionData.Lines(3).Lines
@@ -12266,7 +12266,7 @@ msgstr "..."
 #: /Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon.Default__AmberMaeLockedDungeon_C.SessionData.Lines(1).Lines
 msgctxt ",E17B89624E06BB5038FB7A90A70FFD12"
 msgid "As Hedon's oldest citizen, I remember trying to fit in there ages ago."
-msgstr "Como ziudadana de mayoh edah de Hedon, recuerdo habeh intentao encajah allí hase musho tiempo."
+msgstr "Como la ziudadana máh antigua de Hedon, recuerdo habeh intentao cabeh allí hase musho tiempo."
 
 #. Key:	E1AA64794D412D85279E1C928CB75EFF
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_RL.Default__FaleneDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
@@ -12316,7 +12316,7 @@ msgstr "¡¡Vamos a hacer el amor!!"
 #: /Game/Dialogue/Fesssi/Default/FesssiIdiots.Default__FesssiIdiots_C.SessionData.Lines(6).Lines
 msgctxt ",E255306C4E1CCD9DDB61B0AAC4AFBF04"
 msgid "A titan with plenty of muscle should work, use those breeding skillsssss."
-msgstr "Un titán con mucho músculo debería funcionar, usa esas habilidades de crianza."
+msgstr "Un titán abundante de músculo debería funcionar, usa esas habilidades de crianza."
 
 #. Key:	E264C5AA4DFA58630DD1B5AF551D5C38
 #. SourceLocation:	/Game/Dialogue/Blossom/Default/BlossomGreeting01.Default__BlossomGreeting01_C.SessionData.Lines(1).Lines
@@ -12344,7 +12344,7 @@ msgstr "Sss..."
 #: /Game/Dialogue/Kybele/Default/KybeleTittyPony_T.Default__KybeleTittyPony_T_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",E28456C04008409976B97DAD9E483D99"
 msgid "That should teach you to cross this titty po--I mean mighty centaur warmaiden, again!"
-msgstr "Eso debería enseñarte a cruzar esta poni tet-: ¡otra vez, me refiero a la poderosa doncella-guerrera centauro!"
+msgstr "Eso debería enseñarte a cruzarte con esta poni tet-: ¡otra vez, me refiero a la poderosa doncella-guerrera centauro!"
 
 #. Key:	E29F5BAA40F6C8758245C58555D4F73E
 #. SourceLocation:	/Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToFemale(2).LinesToFemale
@@ -12513,7 +12513,7 @@ msgstr "Sus descendientes fueron restaurados a fuertes formas inmortales, y la D
 #: /Game/Dialogue/Kybele/Default/KybeleHaveKeystone.Default__KybeleHaveKeystone_C.SessionData.Lines(2).Lines
 msgctxt ",E5582CD145475FD1FDA1C88BC2821A2A"
 msgid "The Dragon Matriarch probably wouldn't mind if I let you BORROW it for awhile."
-msgstr "A la Matriarca Dragón probablemente no le importaría si te la dejo PRESTADA por un tiempo."
+msgstr "A la Matriarca Dragón probablemente no le importará si te la dejo PRESTADA por un tiempo."
 
 #. Key:	E594716B40413B6747D21BA87B26EE43
 #. SourceLocation:	/Game/Breeding/Positions/Test4.Default__Test4_C.SessionData.PositionName
@@ -12534,7 +12534,7 @@ msgstr "Qué dulce abejita de la miel."
 #: /Game/Dialogue/Romy/Default/RomyDefault01_YourMusic_Start.Default__RomyDefault01_YourMusic_Start_C.SessionData.Lines(0).Lines
 msgctxt ",E5B7F2E2469864C41253FC892250ED92"
 msgid "Yes! Sing with me human."
-msgstr "¡Si! Canta conmigo humano."
+msgstr "¡Si! Canta conmigo, humano."
 
 #. Key:	E5ED1DF6437395916BD42CBCD355E384
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruHadSex01.Default__MirruHadSex01_C.SessionData.LinesToFemale(2).LinesToFemale
@@ -12605,7 +12605,7 @@ msgstr "Fuiste amable conmigo... puedo separarme de eso."
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R05.Default__FaleneDefault01_R05_C.SessionData.Lines(2).Lines
 msgctxt ",E6AE999D442B37DD898ED3B14ADA261A"
 msgid "Wild elves aren't as common as other @MONSTER_RACE@, Painted Elves even less so."
-msgstr "Las elfas silvestres no son tan comunes como otros @MONSTER_RACE@, las elfas pintadas aún menos."
+msgstr "Los elfos silvestres no son tan comunes como otros @MONSTER_RACE@, los elfos pintados aún menos."
 
 #. Key:	E6EFAF84489D0FE3730843AEC3483A12
 #. SourceLocation:	/Game/Ranch/Upgrades/DragonHoard.Default__DragonHoard_C.Upgrade.DisplayName
@@ -12619,7 +12619,7 @@ msgstr "Tesoro Escondido del Dragón"
 #: /Game/Dialogue/Fesssi/Default/FesssiWantAss.Default__FesssiWantAss_C.SessionData.Lines(0).Lines
 msgctxt ",E71D6B9A4400127440C060AAD55FB07B"
 msgid "Hiss! I knew you wanted it. Don't think I haven't noticed you gazing upon my girthy glory."
-msgstr "¡Sss! Sabía que lo querías. No creas que no te he visto contemplando mi oronda gloria."
+msgstr "¡Sss! Sabía que lo querías. No creas que no te he visto contemplando mi rolliza gloria."
 
 #. Key:	E771BFFB4897C621A00726862D211233
 #. SourceLocation:	/Game/Breeding/Positions/ReverseCowgirl.Default__ReverseCowgirl_C.SessionData.Description
@@ -12690,14 +12690,14 @@ msgstr "Exótico: heredó mas rasgos de monstruo."
 #: /Game/Dialogue/Kybele/Default/KybeleDefault01.Default__KybeleDefault01_C.SessionData.Lines(0).Lines
 msgctxt ",E884B8E5410C3C8C00BFC3AFDA4097F9"
 msgid "By any means necessary, I will not let you pass human."
-msgstr "Por cualquier medio que sea necesario, no dejaré que pases humano."
+msgstr "Por cualquier medio necesario, no dejaré que pases humano."
 
 #. Key:	E887131048CFFB8EF5A2E0A1DA1194FE
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraTaskFulfilled.Default__PetraTaskFulfilled_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Petra/Default/PetraTaskFulfilled.Default__PetraTaskFulfilled_C.SessionData.Lines(2).Lines
 msgctxt ",E887131048CFFB8EF5A2E0A1DA1194FE"
 msgid "I got the keystone for you as promised, take it. Don't be a stranger though!"
-msgstr "Tengo la Keystone para ti como prometí, tómala. ¡Aunque no seas un extraño!"
+msgstr "Tengo la Keystone para ti como prometí, tómala. ¡No seas un forastero de paso!"
 
 #. Key:	E89A6BB74D15111C98632A99F45745CC
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(17 - Value).TraitIcons.DisplayName
@@ -12712,7 +12712,7 @@ msgstr "Carnoso"
 #: /Game/Dialogue/Fern/Default/FernDefault01_R02_R01.Default__FernDefault01_R02_R01_C.SessionData.Lines(2).Lines
 msgctxt ",E89B660E4DCD6EDBFE7FBDB73A354FD0"
 msgid "If mastah let Fern drink mastah's fluids, Fern give shiny. Hiss!"
-msgstr "Si Mastah deja que Fern beba los fluidos de Mastah, Fern dar brillante. ¡Sss!"
+msgstr "Si Mastah deja que Fern beba los fluidos de Mastah, Fern da brillante. ¡Sss!"
 
 #. Key:	E8E336B64B994547FA9BF2A5CFD5F9EE
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault02.Default__CamillaDefault02_C.SessionData.Lines(3).Lines
@@ -12790,14 +12790,14 @@ msgstr "Fluidos corporales de Neko."
 #: /Game/Dialogue/Kybele/Default/KybeleAnyMeans.Default__KybeleAnyMeans_C.SessionData.LinesToFemale(4).LinesToFemale
 msgctxt ",EA2B04154B0261A512D72EBBD877304B"
 msgid "Well... my back legs. You can't miss it, nor handle it for that matter."
-msgstr "Bueno... mis patas traseras. No te lo puedes perder, ni tampoco puedes manejarlo."
+msgstr "Bueno... mis patas traseras. No tiene pérdida, ni tampoco puedes manejarla."
 
 #. Key:	EA5E734B4238AB7601156A936E5E99DF
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchStartShySex.Default__MonarchStartShySex_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/Monarch/Default/MonarchStartShySex.Default__MonarchStartShySex_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",EA5E734B4238AB7601156A936E5E99DF"
 msgid "Oh... m-m-my... uh."
-msgstr "Oh... m-m-mi... eh."
+msgstr "Oh... c-c-cielos... eh."
 
 #. Key:	EA5FEF4E48F8E04291135AA9D42A6CE4
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_Formuria.Default__MirruDefault01_Formuria_C.SessionData.Lines(2).Lines
@@ -12853,7 +12853,7 @@ msgstr "Sorpresa"
 #: /Game/Dialogue/Widow/Default/WidowScary.Default__WidowScary_C.SessionData.Lines(5).Lines
 msgctxt ",EB6E4330432136A859E45AAF024E2DC0"
 msgid "And perhaps to suck my companion dry when the hunger arises... but I always strive to make it feel good."
-msgstr "Y tal vez para chupar a mi compañera hasta dejarla seca cuando surja el hambre... pero siempre me esfuerzo en hacer que se sienta bien."
+msgstr "Y tal vez para chupar a mi compañero hasta dejarlo seco cuando surja el hambre... pero siempre me esfuerzo en hacer que se sienta bien."
 
 #. Key:	EB717BA44A439427B1DE6CA60FA650A2
 #. SourceLocation:	/Game/Dialogue/Mirru/SexScenes/MirruKrakVag.Default__MirruKrakVag_C.SessionData.Lines(2).Lines
@@ -12917,7 +12917,7 @@ msgstr "Aburrida. ¡Pensé que la Matriarca Dragón sería mejor!"
 #: /Game/Dialogue/Cassie/Default/CassieDungeon2.Default__CassieDungeon2_C.SessionData.Lines(2).Lines
 msgctxt ",EC7D97C640A2B4A5E3BFACACD27F84F8"
 msgid "It was locked for many years."
-msgstr "Estuvo bloqueado durante muchos años."
+msgstr "Estuvo cerrado durante muchos años."
 
 #. Key:	EC82D74441832F387397BE94F0621215
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeGreeting02.Default__BeeGreeting02_C.SessionData.Lines(0).Lines
@@ -12931,7 +12931,7 @@ msgstr "Arrodíllate ante tu reina... ahhh... ohhh..."
 #: /Game/Dialogue/Neela/SexScenes/NeelaSnakeCuddleF.Default__NeelaSnakeCuddleF_C.SessionData.Lines(4).Lines
 msgctxt ",EC9757E141CD427BCC7326B974A16B82"
 msgid "Oh human, your thighs are soft... ahhh..."
-msgstr "Oh, humano, tus muslos son suaves... ahhh..."
+msgstr "Oh, humana, tus muslos son suaves... ahhh..."
 
 #. Key:	ECA6FC524716FE3EA1D0A181491FCFC8
 #. SourceLocation:	/Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToFemale(0).LinesToFemale
@@ -12952,7 +12952,7 @@ msgstr "¡Necesitamos otro silvestre del que extraer fluidos! Puedes pensar que 
 #: /Game/Dialogue/Autumn/Default/DryadHaveKeystone.Default__DryadHaveKeystone_C.SessionData.Lines(0).Lines
 msgctxt ",ECE912E146D6A887F2F7C39091185320"
 msgid "Oh that old thing stuck in my roots?"
-msgstr "¿Oh, esa cosa vieja clavada en mis raíces?"
+msgstr "¿Oh, esa cosa vieja atascada en mis raíces?"
 
 #. Key:	ECF633104DBC2948B9EE9FB8C499DCA5
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcHadSex01.Default__OrcHadSex01_C.SessionData.LinesToFuta(1).LinesToFuta
@@ -12980,7 +12980,7 @@ msgstr "..."
 #: /Game/Dialogue/Parvati/Default/ParvatiGreeting01.Default__ParvatiGreeting01_C.SessionData.LinesToFemale(8).LinesToFemale
 msgctxt ",EDA3DF9D4C1774AA8DDFC69C0EFD0035"
 msgid "Favor from the Goddess will you require."
-msgstr "El Favor de la Diosa tu requerirás."
+msgstr "El Favor de la Diosa requerirás."
 
 #. Key:	EDB37C414F34D2DB942D46BC07E82687
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraGetKeystone.Default__PetraGetKeystone_C.SessionData.Lines(3).Lines
@@ -13051,7 +13051,7 @@ msgstr "Han pasado miles de años desde que este recipiente sagrado fue tocado d
 #: /Game/Dialogue/DragonMatriarch/Default/DMNapSomewhereElse.Default__DMNapSomewhereElse_C.SessionData.Lines(3).Lines
 msgctxt ",EF23DE3948A14D6E8E26C397EFF2D243"
 msgid "You're just jealous and want it for yourself!"
-msgstr "¡Estás celoso y lo quieres para ti!"
+msgstr "¡Estás celoso y la quieres para ti!"
 
 #. Key:	EF7904964EA5BDAA8F91D29F54021C40
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowSpiders.Default__WidowSpiders_C.SessionData.Lines(8).Lines
@@ -13065,21 +13065,21 @@ msgstr "Oh, no me mires así, amamos nuestras capturas y nunca las lastimamos."
 #: /Game/Dialogue/Autumn/Default/DryadStartMakeCherry.Default__DryadStartMakeCherry_C.SessionData.Lines(0).Lines
 msgctxt ",EF902B4F424735BE83B622865F58AED8"
 msgid "Climb up here with me..."
-msgstr "Sube trepando aquí conmigo..."
+msgstr "Trepa aquí arriba conmigo..."
 
 #. Key:	EFEE39A441DF6F79110B608104881B11
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeAboutOrb.Default__MegaSlimeAboutOrb_C.SessionData.Lines(7).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeAboutOrb.Default__MegaSlimeAboutOrb_C.SessionData.Lines(7).Lines
 msgctxt ",EFEE39A441DF6F79110B608104881B11"
 msgid "But I love it down here, it's perfect for a slime... if only I had more company."
-msgstr "Pero me encanta estar aquí, es perfecto para una limo... si tan solo tuviera más compañía."
+msgstr "Pero me encanta estar aquí, es perfecto para un limo... si tan solo tuviera más compañía."
 
 #. Key:	EFF175ED431E22A2893E90913974E354
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchTaskFulfilled.Default__MonarchTaskFulfilled_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Monarch/Default/MonarchTaskFulfilled.Default__MonarchTaskFulfilled_C.SessionData.Lines(0).Lines
 msgctxt ",EFF175ED431E22A2893E90913974E354"
 msgid "Whoa... this Foxen is f-f-fast!"
-msgstr "Buah... ¡este foxen es r-r-rápido!"
+msgstr "Buah... ¡esta foxen es r-r-rápida!"
 
 #. Key:	EFFEEA9A4CC82094FD20CABC0AF432BB
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMDefault_RL5_T.Default__DMDefault_RL5_T_C.ResponseData(1).ResponseData.BreederPrompt
@@ -13128,14 +13128,14 @@ msgstr "La mayoría de las veces se caen y luego se duermen inmediatamente debid
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R02.Default__CamillaDefault01_R02_C.SessionData.Lines(7).Lines
 msgctxt ",F05FD1324ABB81C7141ED7A41A996723"
 msgid "Last but by no means least, you can find the Seraphim in their temporary home Esoteric Glade."
-msgstr "Por último, pero no menos importante, puedes encontrar a las serafines en su hogar temporal, el Claro Esotérico."
+msgstr "Por último, pero no menos importante, puedes encontrar a los serafines en su hogar temporal, el Claro Esotérico."
 
 #. Key:	F06D080B472FAC8F39770EB5B3818956
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(15).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(15).Lines
 msgctxt ",F06D080B472FAC8F39770EB5B3818956"
 msgid "Outraged, the Goddess Herself descended and cursed the demons for their sins."
-msgstr "Indignada, la Mismísima Diosa descendió y maldijo a los demonios por sus pecados."
+msgstr "Indignada, la mismísima Diosa descendió y maldijo a los demonios por sus pecados."
 
 #. Key:	F091EDAA4504CD138BB740BD4D4EBCB6
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(14).LinesToMale
@@ -13416,7 +13416,7 @@ msgstr "*Gime*"
 #: /Game/Dialogue/Cassie/Default/CassieDungeon.Default__CassieDungeon_C.SessionData.Lines(2).Lines
 msgctxt ",F7525328451BBC6ED4F59587DBE6C854"
 msgid "It has been locked for many years."
-msgstr "Ha estado bloqueado durante muchos años."
+msgstr "Ha estado cerrado durante muchos años."
 
 #. Key:	F75595714B06DF676D20B5B79FB8C222
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(20).LinesToMale
@@ -13451,7 +13451,7 @@ msgstr "Cuidado humana, la lujuria de un kraken no debe ser subestimada."
 #: /Game/Dialogue/Fesssi/Default/FesssiIdiots.Default__FesssiIdiots_C.SessionData.Lines(3).Lines
 msgctxt ",F7B920EC4CAAD4CD4E61C8915489F45C"
 msgid "Those damn centaurs only care about money and sticking their spears in places."
-msgstr "A esos malditos centauros solo les importa el dinero y clavar sus lanzas en algunos lugares."
+msgstr "A esos malditos centauros solo les importa el dinero y clavar sus lanzas en ciertos lugares."
 
 #. Key:	F7C4336C4CE85A985EE8819488AD2853
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMYourChildren.Default__DMYourChildren_C.SessionData.LinesToFuta(1).LinesToFuta
@@ -13493,7 +13493,7 @@ msgstr "Dulce y suculento humano, estabas delicioso..."
 #: /Game/Dialogue/AmberMae/SexScenes/AmberMilkyF.Default__AmberMilkyF_C.SessionData.Lines(2).Lines
 msgctxt ",F8A579884E09A8EAFE39C78D6B221425"
 msgid "Drink it, ahhhh... ohhh..."
-msgstr "Bébelo, ahhhh... ohhh..."
+msgstr "Bébela, ahhhh... ohhh..."
 
 #. Key:	F8B7E4C84269C81CD36B5CB136D0AA4F
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcHaveKeystone.Default__OrcHaveKeystone_C.SessionData.Lines(2).Lines
@@ -13593,14 +13593,14 @@ msgstr "*Bosteza*"
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeDefault01.Default__MegaSlimeDefault01_C.SessionData.Lines(1).Lines
 msgctxt ",FAA596EC4B5291C8FF02FC9966C3C4B6"
 msgid "AND I have!! For nearly 1000 years, down here all by myself..."
-msgstr "¡¡Y yo tengo!! Durante casi 1000 años, aquí abajo toda para mi misma..."
+msgstr "¡¡Y yo tengo!! Durante casi 1000 años, aquí abajo todo para mi misma..."
 
 #. Key:	FAA5B41940157F8963E69CB4ACE814A4
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeDefault01_MilkyProducts.Default__AmberMaeDefault01_MilkyProducts_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeDefault01_MilkyProducts.Default__AmberMaeDefault01_MilkyProducts_C.SessionData.Lines(0).Lines
 msgctxt ",FAA5B41940157F8963E69CB4ACE814A4"
 msgid "Indulge yerself in 'mai milk!"
-msgstr "¡Deléitate en mi leshe!"
+msgstr "¡Deléitate con mi leshe!"
 
 #. Key:	FAA922F744CCD015043333AD26B1B5AF
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03_RL_F.Default__FernDefault03_RL_F_C.ResponseData(1).ResponseData.BreederPrompt
@@ -13635,21 +13635,21 @@ msgstr "Ohhh, sí... ahhh..."
 #: /Game/Dialogue/Mirru/Default/MirruHadSex01.Default__MirruHadSex01_C.SessionData.LinesToFemale(5).LinesToFemale
 msgctxt ",FAF0FA2D4B10AE21D5D8D2A27EAE488D"
 msgid "Perhaps next time I will indulge myself and not go so easy on you..."
-msgstr "Quizás la próxima vez me deleite a mi misma y no sea tan fácil contigo..."
+msgstr "Quizás la próxima vez me deleite a mi misma y no sea tan fácil para ti..."
 
 #. Key:	FAF57AE645B3D2B5A5373CA6FA1C5EA6
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadFlowers.Default__DryadFlowers_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Autumn/Default/DryadFlowers.Default__DryadFlowers_C.SessionData.Lines(1).Lines
 msgctxt ",FAF57AE645B3D2B5A5373CA6FA1C5EA6"
 msgid "However I am going to require a lot of... seed."
-msgstr "Sin embargo, voy a necesitar mucha... semilla."
+msgstr "Sin embargo, voy a necesitar un montón de... semilla."
 
 #. Key:	FB09A1964EDEBFF9F5E3839307040AEB
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchDefault01.Default__MonarchDefault01_C.SessionData.LinesToFemale(4).LinesToFemale
 #: /Game/Dialogue/Monarch/Default/MonarchDefault01.Default__MonarchDefault01_C.SessionData.LinesToFemale(4).LinesToFemale
 msgctxt ",FB09A1964EDEBFF9F5E3839307040AEB"
 msgid "Is t-t-there something... you want human?"
-msgstr "¿Hay a-a-algo... que quieras humano?"
+msgstr "¿Hay a-a-algo... que quieras, humano?"
 
 #. Key:	FB2BB3B44297DAF2860982BAD6C1819A
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToMale(0).LinesToMale
@@ -13684,7 +13684,7 @@ msgstr "¡Ahh... se siente tan bien! Me voy a correr."
 #: /Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(6).Lines
 msgctxt ",FB8D2D144CB9249F47237B94F66E71F1"
 msgid "Why I drink it and use it to make magic treats of course! I ain't a wee lass mind you--I drink lots o' the stuff! Also, me treats are famous world wide!"
-msgstr "¡Poh qué la bebo y la uso para haceh deliciah mágicah, poh zupuehto! No zoy una moza pequeñita sabeh: ¡bebo mushah cosah! ¡Ademáh, mih deliciah son famozah en to' el mundo!"
+msgstr "¡Pueh la bebo y la uso para haceh deliciah mágicah, poh zupuehto! No zoy una moza pequeñita sabeh: ¡bebo mushah cosah! ¡Ademáh, mih deliciah son famozah en to' el mundo!"
 
 #. Key:	FBA6175C45D9F4E3E3CD7F85021561C6
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_Pregnancy.Default__FaleneDefault01_Pregnancy_C.SessionData.Lines(0).Lines
@@ -13705,7 +13705,7 @@ msgstr "A pesar de más de 4,000 años atravesando el Vacío, todavía tengo que
 #: /Game/Dialogue/Autumn/Default/DryadCherryHelp.Default__DryadCherryHelp_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",FBC59E69493451F2A30A66818584F9BC"
 msgid "Ohhh how I've waited for this."
-msgstr "Ohhh, cómo he esperado para esto."
+msgstr "Ohhh, cómo he estado esperando para esto."
 
 #. Key:	FBDDB80F480F00F6DF7E1BA03EC927F6
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowTaskFullfilled2.Default__WidowTaskFullfilled2_C.SessionData.Lines(2).Lines
@@ -13768,7 +13768,7 @@ msgstr "Espero que mi juguete te haya hecho sentir bien. ¿Tal vez... p-p-podemo
 #: /Game/Dialogue/Yasmine/Default/YasmineAwake.Default__YasmineAwake_C.SessionData.Lines(1).Lines
 msgctxt ",FCFE3B3D4F76E0D8BBC19BBF1F504CC6"
 msgid "It happens every time I open, you think I would have learned by now."
-msgstr "Sucede cada vez que me abro, tu crees que ya lo hubiera sabido."
+msgstr "Sucede cada vez que me abro, crees que ya habría aprendido."
 
 #. Key:	FD102648460B4847C187CA85C454705B
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeMoreHoney.Default__BeeMoreHoney_C.SessionData.Lines(1).Lines
@@ -13840,7 +13840,7 @@ msgstr "Risco Gimiente"
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid_RL.Default__NeelaDefault01_YourVoid_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",FD905EC14D8B8AC5E3D8D28AB7280C39"
 msgid "Experience this human!"
-msgstr "¡Experimentar este humano!"
+msgstr "¡Experimenta este humano!"
 
 #. Key:	FD996BF544296A6A4A54CE82ABF12183
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernGreeting02.Default__FernGreeting02_C.SessionData.LinesToFuta(2).LinesToFuta
@@ -13918,7 +13918,7 @@ msgstr "*Bosteza* Puede que necesite una siesta después de que hagamos el amor 
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeVerySad.Default__MegaSlimeVerySad_C.SessionData.Lines(2).Lines
 msgctxt ",FEB3BE874AC81C2B63FD03953371A656"
 msgid "Who would... after years of loneliness... *sniff*"
-msgstr "¿Quién... después de años de soledad... *olfatea*"
+msgstr "¿Quién lo haría... después de años de soledad... *sniff*"
 
 #. Key:	FEE6416B44C40270EC8167ADD51EA060
 #. SourceLocation:	/Game/Dialogue/Mirru/SexScenes/MirruKrakVag.Default__MirruKrakVag_C.SessionData.Lines(0).Lines
@@ -13946,7 +13946,7 @@ msgstr "Presiento que buscas un ganado reproductor de mayor calidad."
 #: /Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFuta(8).LinesToFuta
 msgctxt ",FF2AAC0145D999DF7D9EE5BBF54B6B50"
 msgid "That must have been you, perhaps you should go and talk to her."
-msgstr "Debes haber sido tú, quizás deberías ir a hablar con ella."
+msgstr "Esa debes haber sido tú, quizás deberías ir a hablar con ella."
 
 #. Key:	FF350C0E49A57126AB07218CBF432744
 #. SourceLocation:	/Game/UI/TaskDescriptions.TaskDescriptions.TextEntries(9).TextEntries
@@ -13960,7 +13960,7 @@ msgstr "El Vacío se vuelve aburrido cuando lo has vagado durante incontables mi
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R06.Default__CamillaDefault01_R06_C.SessionData.Lines(0).Lines
 msgctxt ",FF56CAFF482C5F43FF4C419DCB359C8A"
 msgid "Mean human! Girthy little lumps have feelings too!"
-msgstr "¡Humano mezquino! ¡Los pequeños bultos orondos también tienen sentimientos!"
+msgstr "¡Humano mezquino! ¡Los pequeños bultos rollizos también tienen sentimientos!"
 
 #. Key:	FF5A245B4A28E802C1A30CAC4B4DE4E5
 #. SourceLocation:	/Game/Characters/Procedural/Variants/Seraphim/Harvest/SeraphimHarvest.Default__SeraphimHarvest_C.Harvest.Description
@@ -13989,7 +13989,7 @@ msgstr "Tetona: heredó unos pechos muy grandes."
 #: /Game/Dialogue/Fesssi/Default/FesssiAreYouOk.Default__FesssiAreYouOk_C.SessionData.Lines(1).Lines
 msgctxt ",FFF6AE0C41E39194F413A28DAC8CD9F5"
 msgid "Give into your desires human. I know you want to mate with all of thisss."
-msgstr "Cede a tus deseos humanos. Sé que quieres aparearte con todo esssto."
+msgstr "Cede a tus deseos, humano. Sé que quieres aparearte con todo esssto."
 
 #. Key:	SpiritFormActivate
 #. SourceLocation:	Source/Radiant/Public/Characters/SexyBreederCharacter.cpp:200

--- a/spanish.po
+++ b/spanish.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Radiant\n"
 "POT-Creation-Date: 2021-06-14 02:04\n"
-"PO-Revision-Date: 2022-01-15 01:01+0100\n"
+"PO-Revision-Date: 2022-02-22 03:28+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: es_ES\n"
@@ -153,7 +153,7 @@ msgstr "Gentilmente por supuesto. Hasta la fecha, nunca ha habido un caso en el 
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_AboutLamias.Default__NeelaDefault01_AboutLamias_C.SessionData.Lines(2).Lines
 msgctxt ",02FA062A4ABF915F50D8B38C08105557"
 msgid "From what I remember, I was of Liasis descent. A race said to roam Lewd Desert long ago."
-msgstr "Por lo que recuerdo, era descendiente de Liasis. Una raza que se dice que vagaba por el Desierto Lascivo hace mucho tiempo."
+msgstr "Por lo que recuerdo, era descendiente de liasis. Una raza que se dice que vagaba por el Desierto Lascivo hace mucho tiempo."
 
 #. Key:	02FDE6D44BCEE7E9CD0113AACDF9C4E2
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_RechargeSpiritForm_RL_T.Default__LeylannaDefault01_RechargeSpiritForm_RL_T_C.ResponseData(1).ResponseData.BreederPrompt
@@ -188,7 +188,7 @@ msgstr "Fluidos corporales de Titán."
 #: /Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToMale(4).LinesToMale
 msgctxt ",035F52234F8DA96ED37A5AAC5DD88039"
 msgid "Ahh, plant your delicious seed in my little body! Give me... ohhh... all of it!"
-msgstr "¡Ahh, planta tu deliciosa semilla en mi cuerpecito! ¡Dámelo... ohhh… todo!"
+msgstr "¡Ahh, planta tu deliciosa semilla en mi cuerpecito! ¡Dámelo... ohhh... todo!"
 
 #. Key:	03BD054E4D9907C2DF497EA4DCC0D8C3
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(6).LinesToFemale
@@ -279,7 +279,7 @@ msgstr "Ese viejo y oxidado juego de engranajes sobre la entrada del pueblo prob
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R07.Default__CamillaDefault01_R07_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",0522652344116C917836F4A1A78C8815"
 msgid "Don't waste your beautiful tall body on me human. Just wait for Falene to come back, or go suck on Amber's tits."
-msgstr "No desperdicies tu hermoso y alto cuerpo en mi, humana. Solo espera a que vuelva Falene o ve a chupar las tetas de Amber."
+msgstr "No desperdicies tu hermoso y alto cuerpo en mi, humano. Solo espera a que vuelva Falene o ve a chupar las tetas de Amber."
 
 #. Key:	052657834F6DBDBBC49BDAADA6E5E88A
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_RL.Default__NeelaDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
@@ -356,7 +356,7 @@ msgstr "¡Fern ayuda a Mastah! ¡Fern recolecta fluidossss para ti!"
 #: /Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(8).Lines
 msgctxt ",06F45D04453307E37897C89FC16861F0"
 msgid "Well, I'm sure you best be get'n off!"
-msgstr "Bueno, ¡ehtoy zegura de que eh mejoh que te vayah!"
+msgstr "Bueno, ¡ehtoy zegura de ke eh mejoh ke te vayah!"
 
 #. Key:	070169104C3375DAB052E18982B50AE4
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(3).LinesToMale
@@ -454,7 +454,7 @@ msgstr "Créeme, humano, he dado a luz a muchos descendientes."
 #: /Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon2.Default__AmberMaeLockedDungeon2_C.SessionData.Lines(1).Lines
 msgctxt ",093760FD4181D0AA284C4D96884A3801"
 msgid "Took me love for milk too far, 'an the 'ol bovaur genes kicked in."
-msgstr "Me llevó mi amor por la leshe demasiado lejoh, y loh viejoh geneh bovaur entraron en arsión."
+msgstr "Me llevó mi amoh poh la leshe demasiao lejoh, y loh viejoh geneh bovauh entraron en arsión."
 
 #. Key:	094AB3854E6DACE10C94B28ADCB83FE0
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaFaleneWeek.Default__CamillaFaleneWeek_C.SessionData.Lines(2).Lines
@@ -468,7 +468,7 @@ msgstr "Lo mejor que encuentra, lo trae aquí para examinarlo."
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R07.Default__FaleneDefault01_R07_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",0968DD0D4744523D6AFCEABE502C530F"
 msgid "I'm so horny I can't stand it anymore! Spread 'em human because here I come!"
-msgstr "¡Estoy tan caliente que no puedo soportarlo más! ¡Sepáralas humana porque aquí voy!"
+msgstr "¡Estoy tan caliente que no puedo soportarlo más! ¡Sepáralas, humano, porque aquí voy!"
 
 #. Key:	099488164DB48F48395E94B86F3EE565
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruHadSex01.Default__MirruHadSex01_C.SessionData.LinesToFemale(4).LinesToFemale
@@ -552,7 +552,7 @@ msgstr "Pasemos el día juntos, porque aquí, en el calor de estas aguas, podemo
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",0BB0A695454FD69DAA129F82F023EB23"
 msgid "A human! A super cute human, this is my lucky day. I've been waiting for this phenomenon for... huh. Well as long as I can remember!"
-msgstr "¡Una humana! Una humana super linda... este es mi día de suerte. He estado esperando este fenómeno desde... eh. Bueno, ¡desde que puedo recordar!"
+msgstr "¡Un humano! Un humano super lindo... este es mi día de suerte. He estado esperando este fenómeno desde... eh. Bueno, ¡desde que puedo recordar!"
 
 #. Key:	0BBD00B64AD7488CC6A8008C2BAF8B41
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.VulwargKennel.ManageActionMessage
@@ -820,7 +820,7 @@ msgstr "Ahhhh..."
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFuta(30).LinesToFuta
 msgctxt ",1019EEE14B67704DE6DE0B9FD7D0D596"
 msgid "If you want to learn about how to catch @MONSTER_RACE@, head to the town located up the plateau ahead and speak to my assistant Camilla. You can't miss her... actually wait you might, she's so tiny and cute hehehe."
-msgstr "Si quieres aprender cómo atrapar @MONSTER_RACE@, dirígete al pueblo ubicado en la meseta más adelante y habla con mi asistente Camilla. No puedes fallarle... en realidad, espera, es posible, es tan pequeña y linda jejeje."
+msgstr "Si quieres aprender cómo atrapar @MONSTER_RACE@, dirígete al pueblo ubicado en la meseta más adelante y habla con mi asistente, Camilla. No puedes fallarle... en realidad, espera, es posible, es tan pequeña y linda jejeje."
 
 #. Key:	106EA6A747A0901892BD12A925DA79A5
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy_RL_F.Default__MirruDefault01_BodySexToy_RL_F_C.ResponseData(0).ResponseData.BreederPrompt
@@ -890,7 +890,7 @@ msgstr "Quiero chupártela..."
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_AboutKrakens.Default__MirruDefault01_AboutKrakens_C.SessionData.Lines(3).Lines
 msgctxt ",115E28B04787E362B52C17AF826B86A5"
 msgid "You must understand human, our large fleshy bodies pulse with lust and are difficult to satisfy."
-msgstr "Debes entenderlo humano, nuestros grandes cuerpos carnosos palpitan con lujuria y son difíciles de satisfacer."
+msgstr "Debes entenderlo, humano, nuestros grandes cuerpos carnosos palpitan con lujuria y son difíciles de satisfacer."
 
 #. Key:	1187860A495AEE8B52286F8DA6A1DF53
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01_RL_F.Default__FernDefault01_RL_F_C.ResponseData(1).ResponseData.BreederPrompt
@@ -904,7 +904,7 @@ msgstr "Qué encantador helecho parlante..."
 #: /Game/Dialogue/Leylanna/Default/LeylannaDefault01_Emissary.Default__LeylannaDefault01_Emissary_C.SessionData.Lines(6).Lines
 msgctxt ",119BE39146D97EAD68AF26B063950DFD"
 msgid "Forgive my daydreaming human, Emissary is your archangel. She will help you."
-msgstr "Perdona mis ensoñaciones humano, la Emisaria es tu arcángel. Ella te ayudará."
+msgstr "Perdona mis ensoñaciones, humano, la Emisaria es tu arcángel. Ella te ayudará."
 
 #. Key:	11A588964451AB702EC48CA542D16E81
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToMale(6).LinesToMale
@@ -939,7 +939,7 @@ msgstr "¿Puedo... montarte?"
 #: /Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon2.Default__AmberMaeLockedDungeon2_C.SessionData.Lines(2).Lines
 msgctxt ",11C0FBB845185DFCD5E67DA5B758B432"
 msgid "At me peak I could barely walk! The jugs 'an belly were mighty heavy."
-msgstr "¡En mi cumbre apenah podía caminar! Loh cántaroh de leshe y la barriga pesaban muchísimo."
+msgstr "¡En mi cumbre apenah podía caminah! Loh cántaroh de leshe y la barriga pezaban mushízimo."
 
 #. Key:	12036FB64912193341380BA267A64971
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernGreeting03.Default__FernGreeting03_C.SessionData.LinesToFemale(4).LinesToFemale
@@ -1066,7 +1066,7 @@ msgstr "¡No me importa si no eres un titán! Ahhhhhhh... ohhh..."
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03_R02_R01.Default__FernDefault03_R02_R01_C.SessionData.Lines(1).Lines
 msgctxt ",13F822424D7968B826D8E79C10C52DBC"
 msgid "But we can make love now! Let's do that. Maybe something magical will happen."
-msgstr "¡Pero podemos hacer el amor ahora! Hagámoslo. Tal vez suceda algo mágico."
+msgstr "¡Pero ahora podemos hacer el amor! Hagámoslo. Tal vez suceda algo mágico."
 
 #. Key:	14065F34477043D39DE5A2A95756167D
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowSpiders.Default__WidowSpiders_C.SessionData.Lines(5).Lines
@@ -1263,7 +1263,7 @@ msgstr "Valioso: el Valor se incrementa en un 35%."
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",193F948E4333F3741026EABB87402DD3"
 msgid "A chance to mate with a human is making my hearts pound, and my tentacles slick..."
-msgstr "Una oportunidad de aparearme con una humana está haciendo que mi corazón se acelere y que mis tentáculos resbalen..."
+msgstr "Una oportunidad de aparearme con un humano está haciendo que mi corazón se acelere y que mis tentáculos resbalen..."
 
 #. Key:	195D4E38448666E82EA5BEA6A446E98A
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeSad_RL2.Default__MegaSlimeSad_RL2_C.ResponseData(0).ResponseData.BreederPrompt
@@ -1277,7 +1277,7 @@ msgstr "Qué he hecho..."
 #: /Game/Dialogue/AmberMae/Default/AmberMaeDefault01.Default__AmberMaeDefault01_C.SessionData.Lines(0).Lines
 msgctxt ",19A2E9D044587CE3E0AC5B8D366B6974"
 msgid "Have ye come back to feel 'mai jugs?"
-msgstr "¿Hah vuerto pa' sentih mih cántaroh de leshe?"
+msgstr "¿Hah vuerto pa' zentih mih cántaroh de leshe?"
 
 #. Key:	19AB0BB8417E1310F35D1D922EF9CFD5
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadFatAssLamia.Default__DryadFatAssLamia_C.SessionData.Lines(5).Lines
@@ -1319,7 +1319,7 @@ msgstr "¿Zabe bieh?"
 #: /Game/Dialogue/Cassie/SexScenes/CassieButterButtF.Default__CassieButterButtF_C.SessionData.Lines(2).Lines
 msgctxt ",1A7572BD4073E9E25BE3D1889A08E000"
 msgid "Experience my amazing butter stick human! Ahhhh..."
-msgstr "¡Experimenta mi increíble barra de mantequilla, humana! Ahhhh..."
+msgstr "¡Experimenta mi increíble barra de mantequilla, humano! Ahhhh..."
 
 #. Key:	1A7B16814705FD34BE5FF69AB7855D7B
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiGreeting01.Default__ParvatiGreeting01_C.SessionData.LinesToFuta(3).LinesToFuta
@@ -1417,7 +1417,7 @@ msgstr "Luego se aparearon con las criaturas naturales del mundo. Sí... lo prim
 #: /Game/Dialogue/Leylanna/Default/LeylannaDefault01_RechargeSpiritForm.Default__LeylannaDefault01_RechargeSpiritForm_C.SessionData.Lines(2).Lines
 msgctxt ",1C9CDC1147105A3D3F0A43BB6C94695C"
 msgid "Alternatively, you can recharge your spirit form partially by engaging in sex with blessed ones."
-msgstr "Alternativamente, puedes recargar tu forma espiritual parcialmente al tener sexo con bendecidos."
+msgstr "Alternativamente, puedes recargar tu forma espiritual parcialmente teniendo sexo con bendecidos."
 
 #. Key:	1CB51DBE4D43642F605E479B59AC73A0
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.EM_HedonDungeonSwitch.Message
@@ -1508,14 +1508,14 @@ msgstr "¡Esta lujuria me está volviendo loca, humano! No tienes idea."
 #: /Game/Dialogue/Romy/Default/RomyDefault01_AboutMusic.Default__RomyDefault01_AboutMusic_C.SessionData.Lines(2).Lines
 msgctxt ",1DA742CA40AC6A3A7EC5B6834EEA93B8"
 msgid "Mermaids are unique Formurians, we hear frequencies most others cannot."
-msgstr "Las sirenas son formurians únicas, escuchamos frecuencias que la mayoría no pueden."
+msgstr "Las sirenas somos formurians únicas, escuchamos frecuencias que la mayoría no pueden."
 
 #. Key:	1DB7FBDD4A80D06FCF9019965B0E0008
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeHadSex01.Default__AmberMaeHadSex01_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/AmberMae/Default/AmberMaeHadSex01.Default__AmberMaeHadSex01_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",1DB7FBDD4A80D06FCF9019965B0E0008"
 msgid "Ye drank so much for a wee lass!"
-msgstr "¡Bebihte musho para una mosa pequeñita!"
+msgstr "¡Bebihte musho para una mosa pekeñita!"
 
 #. Key:	1E0C491A43E8C2F67FA568B20B5A6743
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_Teach.Default__ParvatiDefault01_Teach_C.SessionData.Lines(5).Lines
@@ -1543,7 +1543,7 @@ msgstr "Pensé que... finalmente... volvería a tener amigos..."
 #: /Game/Dialogue/Cassie/SexScenes/CassieSplintersT.Default__CassieSplintersT_C.SessionData.Lines(2).Lines
 msgctxt ",1E3AD95641E1D41AAA9115A007EDC28A"
 msgid "So much pleasure! Ahhh..."
-msgstr "¡Tanto placer! Ahhh..."
+msgstr "¡Que placer! Ahhh..."
 
 #. Key:	1E80A3A048E90BE3C26622BC4F2230F7
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryGreeting01.Default__EmissaryGreeting01_C.SessionData.Lines(5).Lines
@@ -1691,7 +1691,7 @@ msgstr "Fern espera que esto complazca mucho a Mastah..."
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",20A752DD41AFEBDD2A4852BD029B894E"
 msgid "You have just become @WORLD_NAME@'s newest resident!"
-msgstr "¡Te acabas de convertir en la residente más nueva de @WORLD_NAME@!"
+msgstr "¡Te acabas de convertir en el residente más nuevo de @WORLD_NAME@!"
 
 #. Key:	20BEB0FA47066DBAB732F68642C6BAC3
 #. SourceLocation:	/Game/Breeding/Positions/Test5.Default__Test5_C.SessionData.PositionName
@@ -1930,7 +1930,7 @@ msgstr "*Gruñe*"
 #: /Game/Dialogue/AmberMae/Default/AmberMaeDefault01_Accent.Default__AmberMaeDefault01_Accent_C.SessionData.Lines(0).Lines
 msgctxt ",240A4A634DB7018141BD60B5A94B716C"
 msgid "Oh no! Me hopes ye can understand."
-msgstr "¡Oh, no! Espero que lo entiendah."
+msgstr "¡Oh, no! Ehpero ke lo entiendah."
 
 #. Key:	240E4A09421F907A3C7714B84A5BF051
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiHowLong.Default__FesssiHowLong_C.SessionData.Lines(1).Lines
@@ -1944,7 +1944,7 @@ msgstr "Al principio estaba molesta, pero luego se volvió divertido... ¡sss!"
 #: /Game/Dialogue/Fern/SexScenes/FernCum_01.Default__FernCum_01_C.SessionData.Lines(6).Lines
 msgctxt ",244693F347E948FB69765A8A6CFF9E08"
 msgid "Ohhh... mastah... ahhh... taste your fluids please. Fern feels them coming..."
-msgstr "Ohhh... Mastah... ahhh... el sabor de tus fluidos por favor. Fern los siente venir..."
+msgstr "Ohhh... Mastah... ahhh... el sabor de tus fluidos, por favor. Fern los siente venir..."
 
 #. Key:	244C8E5D4982978D00C8C4AD305CB067
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcDefault03_RL.Default__OrcDefault03_RL_C.ResponseData(0).ResponseData.BreederPrompt
@@ -1958,7 +1958,7 @@ msgstr "Todavía no he arreglando tu maldito portón."
 #: /Game/Dialogue/Widow/Default/WidowDefault01.Default__WidowDefault01_C.SessionData.Lines(3).Lines
 msgctxt ",245BCC9A45EB7B47E46534A6AE4EE9CF"
 msgid "In exchange for your fluids that is... oh how delicious you look."
-msgstr "A cambio de tus fluidos eso es... oh, qué delicioso te ves."
+msgstr "A cambio de tus fluidos, eso es... oh, qué delicioso te ves."
 
 #. Key:	24679A7147C3C737DE65DBA1F7CE9FAB
 #. SourceLocation:	/Game/Ranch/Upgrades/NekoCondo.Default__NekoCondo_C.Upgrade.DisplayName
@@ -2389,7 +2389,7 @@ msgstr "Con frecuencia debo cambiar mis prendas inferiores ya que mi vagina siem
 #: /Game/Dialogue/Fern/SexScenes/FernMilk_01.Default__FernMilk_01_C.SessionData.Lines(4).Lines
 msgctxt ",2DC7EABB434FE7136DE3498D19A6B8B9"
 msgid "Give Fern all milky... hiss! Grow faster with more milky."
-msgstr "Dale a Fern todo lo lechoso... ¡Sss! Crezco más rápido con más lechoso."
+msgstr "Dale a Fern todo lo lácteo... ¡Sss! Crezco más rápido con más lácteo."
 
 #. Key:	2DF7474B4ED132A075973ABFA667399C
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_RL.Default__RomyDefault01_RL_C.ResponseData(4).ResponseData.BreederPrompt
@@ -2473,7 +2473,7 @@ msgstr "Vete humano, este es mi sitio confortable y no puedes tomarlo."
 #: /Game/Dialogue/Kybele/Default/KybeleTittyPony.Default__KybeleTittyPony_C.SessionData.LinesToFuta(0).LinesToFuta
 msgctxt ",2EF1966C455529B6A75289AD5EF81C2E"
 msgid "That's it human, you have annoyed me long enough. Get against that rock and prepare to be smashed."
-msgstr "Eso es humana, me has molestado lo suficiente. Ponte contra esa roca y prepárate para ser aplastada."
+msgstr "Eso es, humano, me has molestado lo suficiente. Ponte contra esa roca y prepárate para ser aplastado."
 
 #. Key:	2EF454D94FCEA805F55F20A94627C808
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiGreeting01.Default__ParvatiGreeting01_C.SessionData.LinesToFuta(6).LinesToFuta
@@ -2494,7 +2494,7 @@ msgstr "El poder de una dríada alcanza su cumbre en el momento del orgasmo."
 #: /Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(4).Lines
 msgctxt ",2F5513164D00080A441C1292E501C786"
 msgid "If ye have @MONSTER_RACE@ milk to sell, or if ye want te buy some then I'm yer gal!"
-msgstr "Si tieneh leshe de @MONSTER_RACE@ pa' vendeh, o si quiereh comprah argo, en ese caso ¡soy tu shica!"
+msgstr "Zi tieneh leshe de @MONSTER_RACE@ pa' vendeh, o zi kiereh comprah argo, en eze cazo ¡zoy tu shica!"
 
 #. Key:	2F7D02EE4B2C5C30E72919BE9D83BD1F
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleDragonMatriarch.Default__KybeleDragonMatriarch_C.SessionData.Lines(5).Lines
@@ -2515,7 +2515,7 @@ msgstr "Primero, Ella hizo el amor con Ella misma para traer a luz y los serafin
 #: /Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon2.Default__AmberMaeLockedDungeon2_C.SessionData.Lines(0).Lines
 msgctxt ",2FA4621047A86335175276AF22BFDE52"
 msgid "If ye think I'm a big cow today, 'mai goodness was I larger in me younger days!"
-msgstr "Si piensah que soy una vaca grande hoy, ¡santo cielo, era máh grande en mih díah de juventuh!"
+msgstr "Si piensah ke zoy una vaca grande hoy, ¡zanto sielo, era máh grande en mih díah de juventuh!"
 
 #. Key:	2FA59C8A48A63BD0FE6D0289A8AF9587
 #. SourceLocation:	/Game/Dialogue/Yasmine/Default/YasmineDefault02_RL.Default__YasmineDefault02_RL_C.ResponseData(0).ResponseData.BreederPrompt
@@ -2711,7 +2711,7 @@ msgstr "La magia de Monarch te lo impide."
 #: /Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(9).Lines
 msgctxt ",330EAC0C483DA43FAFCBCBB789D5AB9E"
 msgid "'Twas nice meet'n ye @BREEDER_NAME@..."
-msgstr "Ha sioh un plaseh conoserte @BREEDER_NAME@..."
+msgstr "Ha sioh un praseh conosehte, @BREEDER_NAME@..."
 
 #. Key:	335AC6B54A917B8EBB17218E2A338F3C
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieGreeting01.Default__CassieGreeting01_C.SessionData.Lines(5).Lines
@@ -2795,7 +2795,7 @@ msgstr "Monarch está satisfecha."
 #: /Game/Dialogue/Cassie/Default/CassieDefault01_Meow_ButterStick.Default__CassieDefault01_Meow_ButterStick_C.SessionData.Lines(0).Lines
 msgctxt ",34C104D84D1D1734B9408FA6B2BDA125"
 msgid "Awww... meow... Cassie is sad now."
-msgstr "Ammm... miau... Cassie esta triste ahora."
+msgstr "Ammm... miau... ahora Cassie esta triste."
 
 #. Key:	350B5B304D18A9FD50E44AA8A979877B
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMSoBeIt.Default__DMSoBeIt_C.SessionData.Lines(0).Lines
@@ -2823,7 +2823,7 @@ msgstr "Por lo general, se salen con la suya antes de que pueda terminar."
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_StartSnatchT.Default__MirruDefault01_StartSnatchT_C.SessionData.Lines(0).Lines
 msgctxt ",354E29D445D2F28CFD2E2782082F8D11"
 msgid "Ahhh... come here human!"
-msgstr "Ahhh… ¡ven aquí humano!"
+msgstr "Ahhh... ¡ven aquí, humano!"
 
 #. Key:	3587D87D4538714F62271FBFA1D17FFF
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03_R01.Default__FernDefault03_R01_C.SessionData.Lines(2).Lines
@@ -2837,14 +2837,14 @@ msgstr "Si tuviera que pasar el resto de la eternidad en un lugar, no querría q
 #: /Game/Dialogue/Kybele/Default/KybeleTittyPony_T.Default__KybeleTittyPony_T_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",35908AA04644610D46AB42B909BDD768"
 msgid "That's it human, you have annoyed me long enough. Bend over and prepare to be stuffed with my fat spear!"
-msgstr "Eso es humana, me has molestado lo suficiente. ¡Inclínate y prepárate para ser rellenada con mi gorda lanza!"
+msgstr "Eso es, humano, me has molestado lo suficiente. ¡Inclínate y prepárate para ser rellenada con mi gorda lanza!"
 
 #. Key:	35B0312145CDC987463545B35DBCF219
 #. SourceLocation:	/Game/Dialogue/Mirru/SexScenes/MirruSnatchT.Default__MirruSnatchT_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Mirru/SexScenes/MirruSnatchT.Default__MirruSnatchT_C.SessionData.Lines(0).Lines
 msgctxt ",35B0312145CDC987463545B35DBCF219"
 msgid "Submit human... I cannot control my desires!"
-msgstr "Entrégate humano... ¡no puedo controlar mis deseos!"
+msgstr "Entrégate, humano... ¡no puedo controlar mis deseos!"
 
 #. Key:	35BF63974E330C75B3359E8E1E99F0CB
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(11).Lines
@@ -2998,7 +2998,7 @@ msgstr "¡Tendrás que pasar por encima mío!"
 #: /Game/Dialogue/Fesssi/Default/FesssiTaskFulfilled.Default__FesssiTaskFulfilled_C.SessionData.Lines(0).Lines
 msgctxt ",386696884552AA79E38A38B6CD4C33BA"
 msgid "Freedom! The fresh air feels sssso good. The titan you bred me was so strong, it had no trouble lifting my heavy body. It even smashed a few surrounding rocks too!"
-msgstr "¡Libertad! El aire fressssco sienta tan bien. El titán que me criaste era tan fuerte que no tuvo problemas para levantar mi pesado cuerpo. ¡Incluso aplastó algunas rocas circundantes también!"
+msgstr "¡Libertad! El aire fressssco sienta tan bien. El titán que me criaste era tan fuerte que no tuvo problemas para levantar mi pesado cuerpo. ¡También incluso machacó algunas rocas circundantes!"
 
 #. Key:	3888188240872C25EF9A03B26842C93D
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraTaskFulfilled.Default__PetraTaskFulfilled_C.SessionData.Lines(0).Lines
@@ -3068,7 +3068,7 @@ msgstr "¿Qué sabes del antiguo templo?"
 #: /Game/Dialogue/AmberMae/Default/AmberMaeDefault01_Accent.Default__AmberMaeDefault01_Accent_C.SessionData.Lines(2).Lines
 msgctxt ",39BB76F04901D85036C696B74CA537B3"
 msgid "She can get mighty cold though, ye best fatten up on 'mai milk if yer head'n that way!"
-msgstr "Aunque puede haseh mushísimo frío, ¡será mejoh que engordeh con mi leshe si vah poh eze camino!"
+msgstr "Aunke puede haseh mushízimo frío, ¡será mejoh que engordeh con mi leshe si vah poh eze camino!"
 
 #. Key:	39E4B8C74F24A77B88CFA89F73E896C7
 #. SourceLocation:	/Game/UI/TaskDescriptions.TaskDescriptions.TextEntries(2).TextEntries
@@ -3329,7 +3329,7 @@ msgstr "¿No puedes tomar una siesta en otro lugar?"
 #: /Game/Dialogue/Kybele/Default/KybeleTittyPony.Default__KybeleTittyPony_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",3E5797444DCB450E19730E9C8CB6A4FB"
 msgid "That's it human, you have annoyed me long enough. Bend over and prepare to be stuffed with my fat spear!"
-msgstr "Eso es humana, me has molestado lo suficiente. ¡Inclínate y prepárate para ser llenada con mi gorda lanza!"
+msgstr "Eso es, humano, me has molestado lo suficiente. ¡Inclínate y prepárate para ser rellenada con mi gorda lanza!"
 
 #. Key:	3E5B1CA94E6EB9CC180AE3A6F9EC5439
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryCockblockGates.Default__EmissaryCockblockGates_C.SessionData.Lines(2).Lines
@@ -3442,7 +3442,7 @@ msgstr "Pero lo que realmente queremos es reproducirnos contigo."
 #: /Game/Dialogue/Leylanna/Default/LeylannaDefault01_Emissary.Default__LeylannaDefault01_Emissary_C.SessionData.Lines(3).Lines
 msgctxt ",401903B14D6EBA6B8EC8F699AF4FAF22"
 msgid "Despite my constant attempts to please her and love her, she would not say anything else."
-msgstr "A pesar de mis constantes intentos de complacerla y amarla, ella no dijo nada más."
+msgstr "A pesar de mis constantes intentos de complacerla y amarla, no dijo nada más."
 
 #. Key:	4019AADD47513B243D987E8810645FAD
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryGreeting01.Default__EmissaryGreeting01_C.SessionData.Lines(1).Lines
@@ -3512,7 +3512,7 @@ msgstr "..."
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_AboutKrakens.Default__MirruDefault01_AboutKrakens_C.SessionData.Lines(7).Lines
 msgctxt ",41542C1D49AAE2C08A8E1785C30CC95C"
 msgid "Most Krakens are futas, to maximize our pleasure and breeding potential."
-msgstr "La mayoría de los krakens son futas, para maximizar nuestro placer y potencial de reproducción."
+msgstr "La mayoría de los krakens somos futas, para maximizar nuestro placer y potencial de reproducción."
 
 #. Key:	415BAAD3485DF4862A1042A34A209E90
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMMuchEnergy.Default__DMMuchEnergy_C.SessionData.LinesToFemale(2).LinesToFemale
@@ -3603,7 +3603,7 @@ msgstr "Nos encanta reproducirnos con todos los demás @MONSTER_RACE@."
 #: /Game/Dialogue/AmberMae/SexScenes/AmberMilkyF.Default__AmberMilkyF_C.SessionData.Lines(3).Lines
 msgctxt ",42666B4E478FE544AD7A4B91FD65DE82"
 msgid "Aye don't stop 'lil human! It's thick and creamy... ahhh!"
-msgstr "¡Seh, no pareh peke humano! Eh ehpesa y cremosa... ¡ahhh!"
+msgstr "¡Seh, no pareh peke humano! Eh ehpesa y cremoza... ¡ahhh!"
 
 #. Key:	42E4526948669BCD5AFBD29DC9583D3C
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R06.Default__FaleneDefault01_R06_C.SessionData.Lines(7).Lines
@@ -3624,7 +3624,7 @@ msgstr "Se necesitaba una fuerza para contrastar la luz, por lo que la Diosa ced
 #: /Game/Dialogue/OrcChief/Default/OrcFixOwnGate.Default__OrcFixOwnGate_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",432AB6154EB0FCBABFD45A9F48D948F8"
 msgid "Human fix gate now, or get cock stuffed down gullet!"
-msgstr "¡Ahora arregla el portón humana, o haré que la polla rellene bajando por la garganta!"
+msgstr "¡Ahora arregla el portón, humano, o haré que la polla rellene bajando por la garganta!"
 
 #. Key:	433691C34A0864415618B78808993A0E
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMNapSomewhereElse.Default__DMNapSomewhereElse_C.SessionData.Lines(1).Lines
@@ -3828,7 +3828,7 @@ msgstr "¡Mira el tamaño de esa!"
 #: /Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon2.Default__AmberMaeLockedDungeon2_C.SessionData.Lines(3).Lines
 msgctxt ",46C09FA14157EC1F3D6608BB30F25A60"
 msgid "Them townsfolk loved playing with 'mai soft body... *sigh*"
-msgstr "A la gente der puerblo le encantaba jugah con mi zuave cuerpo... *suspira*"
+msgstr "A la gente der puerblo le encantaba jugah con mi zuave cuehpo... *suspira*"
 
 #. Key:	46D776EB4F6C6F71D802088F7C493A82
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToFuta(6).LinesToFuta
@@ -4132,7 +4132,7 @@ msgstr "A partir de ese momento me fijé en ella... quería complacerla de forma
 #: /Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(3).Lines
 msgctxt ",4C00C7F544226DAA1CBB4781B0CEB82F"
 msgid "Aye, 'mai specialty is all things milk, and a quare good pair on me front. Bless me, hav'n jugs like these can really hurt 'mai back!"
-msgstr "Seh, mih espesialidadeh son toa lah cosah relasionadah con la leshe, y un buen pah cuadrao en mi delantera. ¡Bendita sea, teneh cántaroh de leshe como ehtoh reahmente pueden lahtimarme la ehparda!"
+msgstr "Seh, mih espesialidadeh zon toa lah cosah relasionaah con la leshe, y un buen par cuadrao en mi delantera. ¡Bendita zea, teneh cántaroh de leshe como ehtoh reahmente pueden lahtimarme la ehparda!"
 
 #. Key:	4C1E56854BDDE954FC7ACA99874AB4C3
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaHadSex02.Default__CamillaHadSex02_C.SessionData.LinesToFemale(1).LinesToFemale
@@ -4486,7 +4486,7 @@ msgstr "Por favor, recoge la roca brillante al salir. Siento que el hambre acech
 #: /Game/Dialogue/Emissary/SexScenes/EmissaryAngelGroinLove.Default__EmissaryAngelGroinLove_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",53133AE5461CD4363425BC8B9E8327F4"
 msgid "Indulge yourself human, for I am thy servant."
-msgstr "Deléitate humana, pues soy tu sirviente."
+msgstr "Deléitate, humano, pues soy tu sirviente."
 
 #. Key:	535696214ED031B7F34A458925D0CEA8
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_RL.Default__CamillaDefault01_RL_C.ResponseData(6).ResponseData.BreederPrompt
@@ -4535,7 +4535,7 @@ msgstr "Fern espera que esto complazca mucho a Mastah..."
 #: /Game/Dialogue/AmberMae/Default/AmberMaeSuckJugs_Cancel.Default__AmberMaeSuckJugs_Cancel_C.SessionData.Lines(0).Lines
 msgctxt ",5477799C4F9B5398BECB918C51B6CC44"
 msgid "Forgive me if I was com'n on too strong! I hope I didn't offend ye..."
-msgstr "¡Perdóname si fui demasiao bruhca! Espero no habehte ofendio..."
+msgstr "¡Perdóhame zi fui demaziao bruhca! Ehpero no habehte ofendio..."
 
 #. Key:	5487409C445EEB5B2C699C8A5253DD30
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFemale(2).LinesToFemale
@@ -4563,7 +4563,7 @@ msgstr "Es frustrante, ni siquiera recuerdo cómo llegué aquí, ni ninguno de l
 #: /Game/Dialogue/OrcChief/Default/OrcFixOwnGate.Default__OrcFixOwnGate_C.SessionData.LinesToFuta(3).LinesToFuta
 msgctxt ",54C74A434002CAD60426198FDDCF4B82"
 msgid "Human fix gate now, or your cock is mine!"
-msgstr "¡Ahora arregla el portón humano, o tu polla es mía!"
+msgstr "¡Ahora arregla el portón, humano, o tu polla es mía!"
 
 #. Key:	550D874045EED9CAB4096BB51CD7C32A
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowSpiders.Default__WidowSpiders_C.SessionData.Lines(2).Lines
@@ -4627,7 +4627,7 @@ msgstr "Quítate la ropa y déjame lavarte."
 #: /Game/Dialogue/Petra/Default/PetraHadSex01.Default__PetraHadSex01_C.SessionData.Lines(1).Lines
 msgctxt ",55F0F60A4D567468043EF687B0A22338"
 msgid "You made me feel so good human. We should \"practice\" again sometime!"
-msgstr "Me hiciste sentir tan bien humano. ¡Deberíamos \"practicar\" de nuevo en algún momento!"
+msgstr "Me hiciste sentir tan bien, humano. ¡Deberíamos \"practicar\" de nuevo en algún momento!"
 
 #. Key:	560A29014AB558719DDBF6ABAA67FA3F
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeHadSex01.Default__MegaSlimeHadSex01_C.SessionData.LinesToFemale(5).LinesToFemale
@@ -4726,7 +4726,7 @@ msgstr "Quitaré el panal de miel del portón de las Tierras-Colmena."
 #: /Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon.Default__AmberMaeLockedDungeon_C.SessionData.Lines(5).Lines
 msgctxt ",5881DC0E4C70AE1F56EE70A7C1A4A78A"
 msgid "Yer ask'n the wrong lass though, I'm just a simple milkmaid."
-msgstr "Zin embargo, le ehtah preguntando a la mosa equivocaa, solo zoy una simple leshera."
+msgstr "Zin embargo, le ehtah preguntando a la mosa ekivocaa, zolo zoy una simpre leshera."
 
 #. Key:	589C39424192EF623DC606AE1E6D2D75
 #. SourceLocation:	/Game/Ranch/Upgrades/DemonPool.Default__DemonPool_C.Upgrade.DisplayName
@@ -4924,7 +4924,7 @@ msgstr "¡Allí! Prométeme que si lo abres... ¡tendremos sexo pervertido en el
 #: /Game/Dialogue/Fern/SexScenes/FernMilk_01.Default__FernMilk_01_C.SessionData.Lines(2).Lines
 msgctxt ",5C55705949989D3944ACDD8DE6CAEB1E"
 msgid "Human milky taste so good... ahhhh!"
-msgstr "Sabor lechoso humano tan bueno... ¡ahhhh!"
+msgstr "Sabor lácteo humano tan bueno... ¡ahhhh!"
 
 #. Key:	5C9673D0476DF1FF65CB63B5F142C7FE
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(7).LinesToFemale
@@ -4966,7 +4966,7 @@ msgstr "El Desierto Lascivo ahora es accesible."
 #: /Game/Dialogue/Fesssi/Default/FesssiIdiots.Default__FesssiIdiots_C.SessionData.Lines(1).Lines
 msgctxt ",5DBBC25548CE64C57F539B87D36558A9"
 msgid "Now human, we are going to need a mighty creature in order to free my girthy hindquarters."
-msgstr "Ahora humano, vamos a necesitar una criatura poderosa para liberar mis rollizos cuartos traseros."
+msgstr "Ahora, humano, vamos a necesitar una criatura poderosa para liberar mis rollizos cuartos traseros."
 
 #. Key:	5E27E8A74A30D389BBB939B5142249BB
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiGreeting01.Default__ParvatiGreeting01_C.SessionData.LinesToFuta(7).LinesToFuta
@@ -5121,7 +5121,7 @@ msgstr "¡Ahhh, tan dulce y cremosa! No me había sentido tan bien en décadas."
 #: /Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon.Default__AmberMaeLockedDungeon_C.SessionData.Lines(4).Lines
 msgctxt ",61A8146D43CCAA9D468CCC9D2CB22F42"
 msgid "If I recall... they rigged up some switch 'an pulley system."
-msgstr "Si mar no recuerdo... inhtalaron un sihtema de interrustor y poleah."
+msgstr "Zi mar no recuerdo... ihtalaron un zihtema de interrustoh y poleah."
 
 #. Key:	61C3C47B425E2ACFE03921A38EDBD93D
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.CBGate_Glade.PlaceMessage
@@ -5191,7 +5191,7 @@ msgstr "Tales creaciones vagaban en formas débiles puramente por instinto, lo q
 #: /Game/Dialogue/Kybele/Default/KybeleTaskFulfilled.Default__KybeleTaskFulfilled_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",6272317B4A4AE3E76212F6A3B94CDAAA"
 msgid "Such strength... ahhh!"
-msgstr "Tanta fuerza... ¡ahhh!"
+msgstr "Que fuerza... ¡ahhh!"
 
 #. Key:	62B5CF3C40893752840CAEBF4C8159C3
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault02.Default__EmissaryDefault02_C.SessionData.Lines(4).Lines
@@ -5261,7 +5261,7 @@ msgstr "*Lame* *Sorbe*"
 #: /Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon.Default__AmberMaeLockedDungeon_C.SessionData.Lines(0).Lines
 msgctxt ",63ACAC1E4A5D5DFE164A168EAFEE76BC"
 msgid "Aye, 'tis been countless years since anyone's been down there!"
-msgstr "¡Seh, han pasao incontableh añoh dehde que arguien ehtuvo allí abajo!"
+msgstr "¡Seh, han pasao incontableh añoh dehde ke arguien ehtuvo allí abajo!"
 
 #. Key:	63B540744119014025598C8555237076
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMHadSex01.Default__DMHadSex01_C.SessionData.LinesToFemale(2).LinesToFemale
@@ -5451,7 +5451,7 @@ msgstr "Bañar."
 #: /Game/Dialogue/Fesssi/Default/FesssiIdiots.Default__FesssiIdiots_C.SessionData.Lines(7).Lines
 msgctxt ",6692103B4B53269229DB388B380B520F"
 msgid "Do hurry human, I am very horny and ready to mate with the world... starting with you."
-msgstr "Date prisa humano, estoy muy cachonda y dispuesta a aparearme con el mundo... empezando por ti."
+msgstr "Date prisa, humano, estoy muy cachonda y dispuesta a aparearme con el mundo... empezando por ti."
 
 #. Key:	66E2EA9044A750BB60AD308B87FE3071
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadHaveKeystone.Default__DryadHaveKeystone_C.SessionData.Lines(3).Lines
@@ -5493,7 +5493,7 @@ msgstr "Primero, tengo que estar desnuda."
 #: /Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(2).Lines
 msgctxt ",6779B6F54EA9811CDA01BB899D8E10A4"
 msgid "I'm Amber-Mae, yer Bovaur dairy lass!"
-msgstr "¡Soy Amber-Mae, tu mosa leshera bovaur!"
+msgstr "¡Zoy Amber-Mae, tu mosa leshera bovauh!"
 
 #. Key:	679174774B8AE81A6C98AE933C6D1BF3
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_Formuria.Default__MirruDefault01_Formuria_C.SessionData.Lines(5).Lines
@@ -5514,7 +5514,7 @@ msgstr "Qué lástima... qué hermosos sonidos podríamos hacer."
 #: /Game/Dialogue/Fesssi/Default/FesssiHowLong.Default__FesssiHowLong_C.SessionData.Lines(8).Lines
 msgctxt ",67B0B0EE4398E581F4E9B6AF9761BCCE"
 msgid "Captivated by my buxom behind, they would worship it or stick their fat cocks deep inside. I took more loads in my ass than any other @MONSTER_RACE@. Hiss!"
-msgstr "Cautivados por mi trasero exuberante, lo adorarían o meterían sus gordas pollas hasta el fondo. Tomé más cargas en mi culo que cualquier otro @MONSTER_RACE@. ¡Sss!"
+msgstr "Cautivados por mi trasero exuberante, lo adoraban o clavaban sus gordas pollas hasta el fondo. Recibí más cargas en mi culo que cualquier otro @MONSTER_RACE@. ¡Sss!"
 
 #. Key:	67B51FA5454DB188B081BFACCC583F71
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_RL_F.Default__FernDefault02_RL_F_C.ResponseData(4).ResponseData.BreederPrompt
@@ -5592,7 +5592,7 @@ msgstr ""
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeAboutOrb.Default__MegaSlimeAboutOrb_C.SessionData.Lines(4).Lines
 msgctxt ",694BFC904B3397B73FEBEF836CD65954"
 msgid "We have been best friends ever since, even though she won't tell me her name."
-msgstr "Hemos sido mejores amigos desde entonces, aunque él no me dirá su nombre."
+msgstr "Hemos sido mejores amigos desde entonces, aunque él no me dijo su nombre."
 
 #. Key:	695409264F52725B30031E8F0FB4052C
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_RL_F.Default__FernDefault02_RL_F_C.ResponseData(2).ResponseData.BreederPrompt
@@ -5669,7 +5669,7 @@ msgstr "No se moverá."
 #: /Game/Dialogue/AmberMae/Default/AmberMaeSuckJugs_Start.Default__AmberMaeSuckJugs_Start_C.SessionData.Lines(0).Lines
 msgctxt ",6AD76D124EA5FF55B998D39AD1070F08"
 msgid "Oh my! Ohhhh!"
-msgstr "¡Oh cieloh! ¡Ohhhh!"
+msgstr "¡Oh, sieloh! ¡Ohhhh!"
 
 #. Key:	6AFADD1A416223C71B86159050C16A67
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchShySexT_RL.Default__MonarchShySexT_RL_C.ResponseData(0).ResponseData.BreederPrompt
@@ -5697,7 +5697,7 @@ msgstr "En cierto modo, envidio a mis hermanos menores, no están obligados a em
 #: /Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon.Default__AmberMaeLockedDungeon_C.SessionData.Lines(2).Lines
 msgctxt ",6BC585A94AB919791876E989ABC6AFC2"
 msgid "Didn't get very far though, me jugs 'an buxom hips said no!"
-msgstr "Sin embargo, no llegué muy lejoh, ¡mis cántaroh de leshe y mis caderah ezuberanteh dijeron que no!"
+msgstr "Zin embargo, no llegué muh lejoh, ¡mis cántaroh de leshe y mis caderah ezuberanteh dijeron ke no!"
 
 #. Key:	6BD3487945B18914AE271E871E682D15
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiTaskFulfilled.Default__FesssiTaskFulfilled_C.SessionData.Lines(3).Lines
@@ -5718,7 +5718,7 @@ msgstr "Soy demasiado tímida... así que solo recojo néctar para nuestra reina
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(26).LinesToFemale
 msgctxt ",6C9735694D5FA2594461AF9E28110F5C"
 msgid "Gently of course. To date there has never been an instance where a @MONSTER_RACE@ has intentionally harmed a human."
-msgstr "Gentilmente por supuesto. Hasta la fecha, nunca ha habido un caso en el que un @MONSTER_RACE@ haya lastimado intencionalmente a una humana."
+msgstr "Gentilmente por supuesto. Hasta la fecha, nunca ha habido un caso en el que un @MONSTER_RACE@ haya lastimado intencionalmente a un humano."
 
 #. Key:	6CE8D4CC4972C62CFCB7FE9919BBA235
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleTittyPony.Default__KybeleTittyPony_C.SessionData.LinesToFuta(2).LinesToFuta
@@ -5775,7 +5775,7 @@ msgstr "He escuchado leyendas de las hijas de la Abeja Reina en las Tierras-Colm
 #: /Game/Dialogue/AmberMae/Default/AmberMaeDefault01_SuckJugs.Default__AmberMaeDefault01_SuckJugs_C.SessionData.Lines(4).Lines
 msgctxt ",6D4E481742B09428791263B3A820281E"
 msgid "Oh my... I'm so embarrassed, 'mai urges got the best o' me!"
-msgstr "Oh cieloh... ehtoy tan avergonsaa, ¡mih impursoh se apoderarón de mí!"
+msgstr "Oh sieloh... ehtoy tan avergonsaa, ¡mih impursoh ze apoderarón de mí!"
 
 #. Key:	6D4FCB5345397A3D9726C1AAA8B438D6
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernBeeFlowers2.Default__FernBeeFlowers2_C.SessionData.Lines(0).Lines
@@ -5880,21 +5880,21 @@ msgstr "Sin duda te encontrarás con bendecidos en este mundo que simplemente qu
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R08.Default__CamillaDefault01_R08_C.SessionData.Lines(0).Lines
 msgctxt ",6EA72B844C05F4F77473C38011839AB4"
 msgid "Oh wait... I uh..."
-msgstr "Oh, espera... yo eh..."
+msgstr "Oh, espera... yo, eh..."
 
 #. Key:	6EB1D4054ABCE1E3818FC39FB5A8415A
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMHadSex01.Default__DMHadSex01_C.SessionData.LinesToFemale(1).LinesToFemale
 #: /Game/Dialogue/DragonMatriarch/Default/DMHadSex01.Default__DMHadSex01_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",6EB1D4054ABCE1E3818FC39FB5A8415A"
 msgid "Somehow you took a cock larger than you and still made it feel amazing."
-msgstr "De alguna manera tomaste una polla más grande que tú y aún así haces que se sienta increíble."
+msgstr "De alguna manera recibiste una polla más grande que tú y aún así haces que se sienta increíble."
 
 #. Key:	6ED67799423B871587B12E8DEC3D1BE1
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(0).Lines
 msgctxt ",6ED67799423B871587B12E8DEC3D1BE1"
 msgid "Oh! A cute li'l human! Nary in all me puff did I expect te see such a thing!"
-msgstr "¡Oh! ¡Un lindo peke humano! ¡Ni en toda mi bocanaa ehperaba veh argo así!"
+msgstr "¡Oh! ¡Un lindo peke humano! ¡Ni en toa mi bocanaa ehperaba veh argo asín!"
 
 #. Key:	6F1214E04CFF55C4F15CF6B9593AE091
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToFuta(3).LinesToFuta
@@ -5929,7 +5929,7 @@ msgstr "Pero primero, una donación altísima Diosa. Alabado sea Su nombre."
 #: /Game/Dialogue/AmberMae/SexScenes/AmberMilkyF.Default__AmberMilkyF_C.SessionData.Lines(0).Lines
 msgctxt ",6F5E6DAB49A4FDFA3CF6ADB4F98239E5"
 msgid "Ahhhh! Suck 'em hard, 'mai milk is all for you!"
-msgstr "¡Ahhhh! ¡Chúpalah fuerte, mi leshe es toa pa' ti!"
+msgstr "¡Ahhhh! ¡Chúpalah fuehte, mi leshe es toa pa' ti!"
 
 #. Key:	6F8F41154136EFB2D479DCB4A853DC48
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcBrashDumb.Default__OrcBrashDumb_C.SessionData.Lines(9).Lines
@@ -5986,7 +5986,7 @@ msgstr "¿Qué pasa con la mazmorra junto al templo?"
 #: /Game/Dialogue/DragonMatriarch/Default/DMDefault_RL5_F.Default__DMDefault_RL5_F_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",703D9D7D4CD9D794DDE1929CCE0E5D1C"
 msgid "Bring it on dragon."
-msgstr "Tráela dragón."
+msgstr "Tráela, dragón."
 
 #. Key:	703E8E554AE59D97908541A592216732
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcFixOwnGate.Default__OrcFixOwnGate_C.SessionData.LinesToFemale(0).LinesToFemale
@@ -6028,7 +6028,7 @@ msgstr "Convertimos el semen que se desperdiciaría en una nueva vida, ¡incluso
 #: /Game/Dialogue/DragonMatriarch/Default/DMDefault_RL5_T.Default__DMDefault_RL5_T_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",709579B446D8D4D2C2F3EE98857ED27A"
 msgid "Bring it on dragon."
-msgstr "Tráelo dragón."
+msgstr "Tráelo, dragón."
 
 #. Key:	709C1A4748A9B0773A823DB8EB5B31E0
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeHadSex01.Default__BeeHadSex01_C.SessionData.Lines(2).Lines
@@ -6091,7 +6091,7 @@ msgstr "¡Prepárate, pequeño gatito!"
 #: /Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFuta(7).LinesToFuta
 msgctxt ",717D6D564578FC099110B6899F65067E"
 msgid "That creepy golden seraphim, the one in the temple. She appeared only a few days ago, constantly asking to speak with \"the human\"."
-msgstr "Esa espeluznante serafín dorada, la del templo. Ella apareció hace solo unos días, constantemente pidiendo hablar con \"la humana\"."
+msgstr "Esa espeluznante serafín dorada, la del templo. Ella apareció hace solo unos días, constantemente pidiendo hablar con \"el humano\"."
 
 #. Key:	71914E004F66CB40BEDE07BF85D0FDC5
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcBrashDumb.Default__OrcBrashDumb_C.SessionData.Lines(0).Lines
@@ -6338,7 +6338,7 @@ msgstr "Para el conocimiento de contorsionar el cuerpo poderle conferir."
 #: /Game/Dialogue/Leylanna/Default/LeylannaDefault01_GettingWeird.Default__LeylannaDefault01_GettingWeird_C.SessionData.Lines(0).Lines
 msgctxt ",75848F9C47DF47B57018B9BD12602720"
 msgid "Return to me when you change your mind."
-msgstr "Vuelve a verme cuando cambies de opinión."
+msgstr "Vuelve a verme cuando cambies de idea."
 
 #. Key:	758A181D4F348EDE373A33ADB8F3CB08
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_RL.Default__NeelaDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
@@ -6359,7 +6359,7 @@ msgstr "¿Qué puede hacer esta humilde sirena por ti?"
 #: /Game/Dialogue/Falene/Default/FaleneDefault02.Default__FaleneDefault02_C.SessionData.Lines(1).Lines
 msgctxt ",76389D804BFE8383064F778E692DD2D9"
 msgid "The tiny little adorable nugget over there is my assistant Camilla."
-msgstr "La pequeña y adorable pepita de allí es mi asistente Camilla."
+msgstr "La pequeña y adorable pepita de allí es mi asistente, Camilla."
 
 #. Key:	76894E414F0E86A40CDEB69862E1A67C
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R01.Default__FaleneDefault01_R01_C.SessionData.Lines(1).Lines
@@ -6488,7 +6488,7 @@ msgstr "¡¡¡¿No es eso simplemente fantástico y adorable?!!!"
 #: /Game/Dialogue/Kybele/Default/KybeleHadSex01.Default__KybeleHadSex01_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",7989199A4B0BA24F0B904493FCC965AC"
 msgid "Still... you took my fat horse cock well. That's amazing for one of your size!"
-msgstr "Aún así... tomaste bien mi gorda polla de caballo. ¡Eso es asombroso para alguien de tu tamaño!"
+msgstr "Aún así... recibiste bien mi gorda polla de caballo. ¡Eso es asombroso para alguien de tu tamaño!"
 
 #. Key:	7A0924884575833B8154E88AE733B3E4
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.EM_Keystone_Kybele.FailMessage
@@ -6537,7 +6537,7 @@ msgstr "De hecho, idiotas cachondos y sexys. ¡Sss!"
 #: /Game/Dialogue/OrcChief/Default/OrcBrashDumb.Default__OrcBrashDumb_C.SessionData.Lines(1).Lines
 msgctxt ",7A7EFCC44E743CC63CBCBB86D21C890C"
 msgid "Orcs are strong... maybe dumb, but strong."
-msgstr "Los orcos son fuertes... tal vez tontos, pero fuertes."
+msgstr "Los orcos somos fuertes... tal vez tontos, pero fuertes."
 
 #. Key:	7AE87BF645B6A4B1D35071A966CCF13E
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_RL.Default__EmissaryDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
@@ -6771,7 +6771,7 @@ msgstr "Divergente"
 #: /Game/Dialogue/Kybele/Default/KybeleTaskFulfilled.Default__KybeleTaskFulfilled_C.SessionData.LinesToFemale(4).LinesToFemale
 msgctxt ",7F23CD5A4568538ECF60ED883E7BBAFA"
 msgid "Her large mouth can take a lot of it, and I make sure to shoot loads down her throat."
-msgstr "Su gran boca puede aguantar mucho, y me aseguro de disparar montones bajando por su garganta."
+msgstr "Su gran boca puede aguantar mucho, y me aseguro de disparar cargas bajando por su garganta."
 
 #. Key:	7F6924F64E3D07A056BFC7903542E0AB
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeHaveKeystone.Default__BeeHaveKeystone_C.SessionData.Lines(4).Lines
@@ -6855,7 +6855,7 @@ msgstr "Somos los señores de esta cordillera."
 #: /Game/Dialogue/AmberMae/Default/AmberMaeDefault01_SuckJugs.Default__AmberMaeDefault01_SuckJugs_C.SessionData.Lines(2).Lines
 msgctxt ",8103840A43F7351F6B263C98CC5A6335"
 msgid "Me jugs are get'n full, are ye sure that 'lil body can handle it all?"
-msgstr "Mih cántaroh de leshe están llenoh, ¿estáh seguro de que ese cuerpesín puede manejahlo todo?"
+msgstr "Mih cántaroh de leshe ehtán llenoh, ¿estáh zeguro de que eze cuerpesín puede manejahlo too?"
 
 #. Key:	8169C4CD4FCCAEC60B1417A262737D1E
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleHadSex01.Default__KybeleHadSex01_C.SessionData.LinesToFemale(0).LinesToFemale
@@ -6954,7 +6954,7 @@ msgstr "La mayoría de las veces, termino metida en todos los agujeros."
 #: /Game/Dialogue/Camilla/Default/CamillaHadSex02.Default__CamillaHadSex02_C.SessionData.LinesToFuta(0).LinesToFuta
 msgctxt ",83B1D0DD4F37A2E70289CEAAC491EB74"
 msgid "Wow human, you must have been desperate to give this nugget your love."
-msgstr "Guau, humana, debes haber estado desesperada para darle a esta pepita tu amor."
+msgstr "Guau, humano, debes haber estado desesperado para darle a esta pepita tu amor."
 
 #. Key:	83C8B41F462880323A7E26B8AE678AA1
 #. SourceLocation:	/Game/Dialogue/Mirru/SexScenes/MirruSnatchT.Default__MirruSnatchT_C.SessionData.Lines(6).Lines
@@ -7125,7 +7125,7 @@ msgstr "Mira lo que hiciste, ya estoy cachonda."
 #: /Game/Dialogue/Leylanna/Default/LeylannaDefault01_BlueSmoke2.Default__LeylannaDefault01_BlueSmoke2_C.SessionData.Lines(2).Lines
 msgctxt ",859B4BA447F1B280EC046E90944CED54"
 msgid "Oh... so beautiful... ahhhhhhh."
-msgstr "Oh... tan hermoso... ahhhhhhh."
+msgstr "Oh... que hermoso... ahhhhhhh."
 
 #. Key:	85C0F318409CD0EE03C6A0866A2BC236
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleAnyMeans.Default__KybeleAnyMeans_C.SessionData.LinesToFemale(3).LinesToFemale
@@ -7139,7 +7139,7 @@ msgstr "Mi mayor arma es mi lanza, ¡la inmensa que tengo entre las patas!"
 #: /Game/Dialogue/DragonMatriarch/Default/DMAboutDragons.Default__DMAboutDragons_C.SessionData.Lines(4).Lines
 msgctxt ",85D697914BECD8CA4AD94DB4BE76C00A"
 msgid "Dragons are old, very old. We were the first to claim these mountains."
-msgstr "Los dragones son viejos, muy viejos. Fuimos los primeros en reclamar estas montañas."
+msgstr "Los dragones somos viejos, muy viejos. Fuimos los primeros en reclamar estas montañas."
 
 #. Key:	85E58BD244C80942385F1793A5D30333
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiCave.Default__FesssiCave_C.SessionData.Lines(6).Lines
@@ -7174,7 +7174,7 @@ msgstr "Nuestras rayas y manchas son marcas de nacimiento naturales, ¡y parecen
 #: /Game/Dialogue/OrcChief/Default/OrcHadSex01.Default__OrcHadSex01_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",8608CD3E4A24FE889A9114BB9C69E23E"
 msgid "Human feel very good. Swallowed tons of cum hahaha!"
-msgstr "La humana se siente muy bien. ¡Tragaste toneladas de semen, jajaja!"
+msgstr "El humano se siente muy bien. ¡Tragaste toneladas de semen, jajaja!"
 
 #. Key:	86354AD5497243D13289CF9220240F60
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleDefault01_RL.Default__KybeleDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
@@ -7195,7 +7195,7 @@ msgstr "Dulce y deliciosa semilla humana, ¡déjala ir toda! Ahhh..."
 #: /Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToFemale(4).LinesToFemale
 msgctxt ",863C3850414A8A0B8C0C45907E4898EA"
 msgid "Oh... ah... yes! Human... ohhhh."
-msgstr "¡Oh... ah... sí! Humana... ohhhh."
+msgstr "¡Oh... ah... sí! Humano... ohhhh."
 
 #. Key:	86705CF240B11C01C39F05BA7F02F512
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R02.Default__FaleneDefault01_R02_C.SessionData.Lines(15).Lines
@@ -7356,7 +7356,7 @@ msgstr "Pfff, puedo manejar una poni tetuda."
 #: /Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(5).Lines
 msgctxt ",889D5D974E2DA932F5EAC7B50EC85E50"
 msgid "What do I do with the milk I buy?"
-msgstr "¿Qué hago con la leshe que compro?"
+msgstr "¿Ké hago con la leshe ke compro?"
 
 #. Key:	88B965E0435F9EAD252E91913254E01A
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R04.Default__FaleneDefault01_R04_C.SessionData.Lines(1).Lines
@@ -7391,7 +7391,7 @@ msgstr "¡No!"
 #: /Game/Dialogue/Autumn/Default/DryadAboutDryads.Default__DryadAboutDryads_C.SessionData.Lines(3).Lines
 msgctxt ",88DA748247D4C0C5CE3BEC9851A55E05"
 msgid "Our nature inclines us to plant roots and help life flourish. In my case, I saw so many cows wandering aimlessly here."
-msgstr "Nuestra naturaleza nos inclina a plantar raíces y ayudar a que la vida florezca. En mi caso, vi tantas vacas aquí deambulando sin rumbo fijo."
+msgstr "Nuestra naturaleza nos inclina a plantar raíces y ayudar a que la vida florezca. En mi caso, vi tantas vacas aquí deambulando sin rumbo por aquí."
 
 #. Key:	88E908134B3B56C2274F33974CFB4AE5
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(0).LinesToMale
@@ -7419,7 +7419,7 @@ msgstr "Deseas sentir mi música, lo sabía."
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",89AD310E47680E241C7AEEB5C24A9E59"
 msgid "A chance to mate with a human is making my hearts pound, and my tentacles slick..."
-msgstr "Una oportunidad de aparearme con una humana está haciendo que mi corazón se acelere y que mis tentáculos resbalen..."
+msgstr "Una oportunidad de aparearme con un humano está haciendo que mi corazón se acelere y que mis tentáculos resbalen..."
 
 #. Key:	89B96FEA426FD3ECBA90259F724E6DF2
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadCherryHelp.Default__DryadCherryHelp_C.SessionData.LinesToFemale(2).LinesToFemale
@@ -7736,7 +7736,7 @@ msgstr "*Sorbe* *Lame*"
 #: /Game/Dialogue/AmberMae/Default/AmberMaeDefault01.Default__AmberMaeDefault01_C.SessionData.Lines(2).Lines
 msgctxt ",8F1A20C3401841EB835DBDA94858E823"
 msgid "Oh, mayhaps tis milk ye want?"
-msgstr "Oh, ¿tar veh es leshe lo que quiereh?"
+msgstr "Oh, ¿tar veh es leshe lo que kiereh?"
 
 #. Key:	8F8279FC4A2E364B7CE585981E0279EF
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.SeraphimLoft.ManageActionMessage
@@ -7935,14 +7935,14 @@ msgstr "Oh, ¿el viejo templo?"
 #: /Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToMale(3).LinesToMale
 msgctxt ",92E3821949A8C289A4AAFCA4103F1915"
 msgid "Yes! Ohhhh, so big... keep going human! Ahh..."
-msgstr "¡Si! Ohhhh, tan grande... ¡sigue así humano! Ahh..."
+msgstr "¡Si! Ohhhh, tan grande... ¡sigue así, humano! Ahh..."
 
 #. Key:	92E810794E27E1F318AD0C9D4701705B
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDefault01_Meow.Default__CassieDefault01_Meow_C.SessionData.LinesToFuta(5).LinesToFuta
 #: /Game/Dialogue/Cassie/Default/CassieDefault01_Meow.Default__CassieDefault01_Meow_C.SessionData.LinesToFuta(5).LinesToFuta
 msgctxt ",92E810794E27E1F318AD0C9D4701705B"
 msgid "My fuzzy hands will fix this, but some human love could help too..."
-msgstr "Mis manos vellosas arreglarán esto, pero un poco de amor humano también podría ayudar..."
+msgstr "Mis manos peludas arreglarán esto, pero un poco de amor humano también podría ayudar..."
 
 #. Key:	9309BD074F9B0FFE924A35B157A44C07
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadBossomCherries.Default__DryadBossomCherries_C.SessionData.Lines(5).Lines
@@ -8154,7 +8154,7 @@ msgstr "Soy una alraune en crecimiento, ¿tal vez te sobran fluidos?"
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToFuta(4).LinesToFuta
 msgctxt ",960E85EF4CA91DAAA4DCFF93B84D183E"
 msgid "Imagine all of the places you could slide your dick in human... and I promise I would make them all feel so good..."
-msgstr "Imagina todos los lugares en los que podrías deslizar tu pene dentro, humana... y te prometo que te harán sentir tan bien..."
+msgstr "Imagina todos los lugares en los que podrías deslizar tu pene dentro, humano... y te prometo que te harán sentir tan bien..."
 
 #. Key:	96151D60454DB0FB521DD6A507DA6C07
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_Forgot_RL.Default__ParvatiDefault01_Forgot_RL_C.ResponseData(2).ResponseData.BreederPrompt
@@ -8210,7 +8210,7 @@ msgstr "La llegada de la Emisaria es un presagio, debemos unir nuestras almas en
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_StartSnatchF.Default__MirruDefault01_StartSnatchF_C.SessionData.Lines(0).Lines
 msgctxt ",96CB06FD409452A1B37913AA11EB845B"
 msgid "Ahhh... come here human!"
-msgstr "Ahhh… ¡ven aquí humana!"
+msgstr "Ahhh... ¡ven aquí, humano!"
 
 #. Key:	96D35D8C41748461CFD8F9A9404E42B5
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToFemale(2).LinesToFemale
@@ -8267,7 +8267,7 @@ msgstr "Entonces... bueno, puedes imaginar lo que hacemos."
 #: /Game/Dialogue/QueenBee/Default/BeeDefault01.Default__BeeDefault01_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",9787E49C47227601EF65578F30C5CCA2"
 msgid "Is t-t-there something... you want human?"
-msgstr "¿Hay a-a-algo... que quieras, humana?"
+msgstr "¿Hay a-a-algo... que quieras, humano?"
 
 #. Key:	97A580FD4F8820DD9E8FA09B6B69797A
 #. SourceLocation:	/Game/Ranch/Upgrades/SeraphimLoft.Default__SeraphimLoft_C.Upgrade.DisplayName
@@ -8323,7 +8323,7 @@ msgstr "¡Más miel!"
 #: /Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFemale(8).LinesToFemale
 msgctxt ",97E4D09B44D082B3154FEE94A88EE112"
 msgid "That must have been you, perhaps you should go and talk to her."
-msgstr "Esa debes haber sido tú, quizás deberías ir a hablar con ella."
+msgstr "Ese debes haber sido tú, quizás deberías ir a hablar con ella."
 
 #. Key:	9823997B4369C9710C0858A44B670A9D
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_RL.Default__CamillaDefault01_RL_C.ResponseData(4).ResponseData.BreederPrompt
@@ -8456,7 +8456,7 @@ msgstr "¡Oh! Ejem..."
 #: /Game/Dialogue/Camilla/Default/CamillaHadSex01.Default__CamillaHadSex01_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",9A872CD1493BC95421F01C946AF0F7E4"
 msgid "Wow human, you must have been desperate to give this nugget your love."
-msgstr "Guau, humana, debes haber estado desesperada para darle a esta pepita tu amor."
+msgstr "Guau, humano, debes haber estado desesperado para darle a esta pepita tu amor."
 
 #. Key:	9A9EDF3448107C0855BB35BBD9D849F5
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(23).LinesToFemale
@@ -8526,7 +8526,7 @@ msgstr "La descendencia de la Matriarca Dragón será protegida por cualquier me
 #: /Game/Dialogue/AmberMae/Default/AmberMaeHadSex01.Default__AmberMaeHadSex01_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",9BDBC0EB4511337E7515C89A6620BBA0"
 msgid "Come back and drink up anytime."
-msgstr "Vuerve y bebela cuando quierah."
+msgstr "Vuerve y bebela cuando kierah."
 
 #. Key:	9BF2AD09410781A66302329DB25BA0EC
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_Forgot.Default__ParvatiDefault01_Forgot_C.SessionData.Lines(5).Lines
@@ -8667,7 +8667,7 @@ msgstr "Enorme: aproximadamente 10 pies (3 m) de altura."
 #: /Game/Dialogue/Autumn/Default/DryadAboutDryads.Default__DryadAboutDryads_C.SessionData.Lines(8).Lines
 msgctxt ",9ECDE7F64C28F7F9624081B927CA3030"
 msgid "Compared to other Alraunes, dryads are wise and mobile. We use our pleasure to help others."
-msgstr "En comparación con otras alraunes, las dríadas son sabias y móviles. Usamos nuestro placer para ayudar a los demás."
+msgstr "En comparación con otras alraunes, las dríadas somos sabias y móviles. Usamos nuestro placer para ayudar a los demás."
 
 #. Key:	9EEBDB0446F2AAFA8F605E8A3DE83534
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_YourMusic.Default__RomyDefault01_YourMusic_C.SessionData.LinesToFuta(2).LinesToFuta
@@ -8688,7 +8688,7 @@ msgstr "Gestiona tus Formurians"
 #: /Game/Dialogue/Cassie/Default/CassieHadSex01.Default__CassieHadSex01_C.SessionData.LinesToFuta(5).LinesToFuta
 msgctxt ",9F2120194C14A491202338AEB2C05883"
 msgid "I want to release again already... you humans have it so easy."
-msgstr "Quiero descargar de nuevo ya... vosotros, los humanos, lo tenéis muy fácil."
+msgstr "Quiero descargar de nuevo ya... vosotros los humanos lo tenéis muy fácil."
 
 #. Key:	9F25BEB847378BA942933C8A503B4F1A
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(22 - Value).TraitIcons.HelpText
@@ -8726,7 +8726,7 @@ msgstr "Inmenso: aproximadamente 15 pies (4,5 m) de altura."
 #: /Game/Dialogue/Kybele/Default/KybeleTittyPony_T.Default__KybeleTittyPony_T_C.SessionData.LinesToFuta(0).LinesToFuta
 msgctxt ",9F883FFA4CA5D4B34A5726989E26C6C5"
 msgid "That's it human, you have annoyed me long enough. Get against that rock and prepare to be smashed."
-msgstr "Eso es humana, me has molestado lo suficiente. Ponte contra esa roca y prepárate para ser aplastada."
+msgstr "Eso es, humano, me has molestado lo suficiente. Ponte contra esa roca y prepárate para ser aplastado."
 
 #. Key:	9F8F75924886323A16353D90FDCB1B1C
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernBeeFlowers.Default__FernBeeFlowers_C.SessionData.Lines(0).Lines
@@ -8768,7 +8768,7 @@ msgstr "Sabía que a los humanos les gustaba sentir este poderoso cuerpo."
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(20).LinesToFemale
 msgctxt ",9FE7AADC4372F0B32E971C838E6554EA"
 msgid "Since you're a breeder, it's your job to catch and mate as many @MONSTER_RACE@ as possible!"
-msgstr "Ya que eres una criadora, ¡es tu trabajo atrapar y aparearte con tantos @MONSTER_RACE@ como sea posible!"
+msgstr "Ya que eres un criador, ¡es tu trabajo atrapar y aparearte con tantos @MONSTER_RACE@ como sea posible!"
 
 #. Key:	9FF8B7CE43E6A9321DDB60919962BBB7
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(17).LinesToMale
@@ -8859,7 +8859,7 @@ msgstr "Granero de Nephelym"
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(28).LinesToFemale
 msgctxt ",A2DA50B44D0A24E096AF488F787D4928"
 msgid "Well I must be off, good luck breeder!"
-msgstr "Bueno, debo irme, ¡buena suerte criadora!"
+msgstr "Bueno, debo irme, ¡buena suerte criador!"
 
 #. Key:	A2EE900942F55DC4C6AA92BC44E482E4
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R03.Default__CamillaDefault01_R03_C.SessionData.Lines(2).Lines
@@ -8993,7 +8993,7 @@ msgstr "¡No puedo esperar hasta mi próxima lección con Pawsmaati!"
 #: /Game/Dialogue/DragonMatriarch/Default/DMWantHuman.Default__DMWantHuman_C.SessionData.Lines(0).Lines
 msgctxt ",A59547D94C2E8733CA14998734EBC002"
 msgid "Haha! You joke human, my genitals are too big for you."
-msgstr "¡Jaja! Bromeas humano, mis genitales son demasiado grandes para ti."
+msgstr "¡Jaja! Bromeas, humano, mis genitales son demasiado grandes para ti."
 
 #. Key:	A5B9250C4C49694C624437927A399459
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeHaveKeystone1.Default__BeeHaveKeystone1_C.SessionData.Lines(2).Lines
@@ -9140,7 +9140,7 @@ msgstr "Si debes complacer tus deseos, busca a la Iluminada en la Meseta Bochorn
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeDefault01.Default__MegaSlimeDefault01_C.SessionData.Lines(0).Lines
 msgctxt ",A913B249494A32A6AF263BAE0962E781"
 msgid "Slime slime slime... I can play with my slime all day!"
-msgstr "Limo, limo, limo... ¡Puedo jugar con mi limo todo el día!"
+msgstr "Limo, limo, limo... ¡puedo jugar con mi limo todo el día!"
 
 #. Key:	A91571364DFC6A4FA3772D9FCBDB52AA
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMYourChildren.Default__DMYourChildren_C.SessionData.LinesToFemale(1).LinesToFemale
@@ -9182,7 +9182,7 @@ msgstr "¿Cuánto tiempo has estado atascada?"
 #: /Game/Dialogue/Cassie/Default/CassieDefault01_Meow_StartSplinters.Default__CassieDefault01_Meow_StartSplinters_C.SessionData.Lines(0).Lines
 msgctxt ",A97AEF8E47499B2AEB627CAE711C36BC"
 msgid "MEOW!!! Penetrate me human!"
-msgstr "¡¡¡MIAU!!! ¡Penétrame humano!"
+msgstr "¡¡¡MIAU!!! ¡Penétrame, humano!"
 
 #. Key:	A9AE4A3A494201CBF1191DA42CD01CA8
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(0).LinesToFemale
@@ -9217,7 +9217,7 @@ msgstr "Los demonios se aprovecharon de esto y comenzaron a usarlos como juguete
 #: /Game/Dialogue/OrcChief/Default/OrcGreeting01.Default__OrcGreeting01_C.SessionData.Lines(4).Lines
 msgctxt ",AA14311148FE8C6A89D0DE953790D7E7"
 msgid "Human fix gate now!"
-msgstr "¡Ahora humano repara el portón!"
+msgstr "¡Ahora, humano, repara el portón!"
 
 #. Key:	AA16BE3B4732F407329ED6B450557C71
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyGreeting01.Default__RomyGreeting01_C.SessionData.Lines(0).Lines
@@ -9329,7 +9329,7 @@ msgstr "Los elfos son blandos y fáciles, les gusta tener descendencia con nosot
 #: /Game/Dialogue/Kybele/Default/KybeleTittyPony_T.Default__KybeleTittyPony_T_C.SessionData.LinesToMale(0).LinesToMale
 msgctxt ",AC30709F43155DB485B91FA519412629"
 msgid "That's it human, you have annoyed me long enough. Get against that rock and prepare to be smashed."
-msgstr "Eso es humano, me has molestado lo suficiente. Ponte contra esa roca y prepárate para ser aplastado."
+msgstr "Eso es, humano, me has molestado lo suficiente. Ponte contra esa roca y prepárate para ser aplastado."
 
 #. Key:	AC4DD54E4585ECFF9E20A9806DEDCEE4
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadGreeting01.Default__DryadGreeting01_C.SessionData.Lines(5).Lines
@@ -9371,7 +9371,7 @@ msgstr "¡Blossom necesssita fluidosss!"
 #: /Game/Dialogue/Kybele/Default/KybeleCentaur.Default__KybeleCentaur_C.SessionData.Lines(3).Lines
 msgctxt ",AD478B234D74F4166BEDE6A5C70593F6"
 msgid "And believe me human... it has been awhile."
-msgstr "Y créeme humano... ha pasado un tiempo."
+msgstr "Y créeme, humano... ha pasado un tiempo."
 
 #. Key:	AD4B293B4D8F1432446C92924F59456E
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(22).LinesToFemale
@@ -9590,7 +9590,7 @@ msgstr "Ha pasado algún tiempo desde que me montaron, ¡así que podría ponerm
 #: /Game/Dialogue/Autumn/Default/DryadCherryHelp.Default__DryadCherryHelp_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",B17C429C4AE53B8CA98F5E8166D598D2"
 msgid "Come closer human..."
-msgstr "Acércate humano..."
+msgstr "Acércate, humano..."
 
 #. Key:	B18F6EA040A16FCFD95EB3894A067B79
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeAboutOrb.Default__MegaSlimeAboutOrb_C.SessionData.Lines(5).Lines
@@ -9618,7 +9618,7 @@ msgstr "Te amamos demasiado y, a veces, ¡nuestros deseos se descontrolan!"
 #: /Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(1).Lines
 msgctxt ",B1BEC3C54841F5611ED8E1A3547AD05F"
 msgid "Awww! I could just squeeze ye between 'mai jugs 'til ye climax!"
-msgstr "¡Ammm! ¡Podría zimplemente ehtrujarte entre mih cántaroh de leshe hahta que llegueh al clímah!"
+msgstr "¡Ammm! ¡Podría zimpremente ehtrujahte entre mih cántaroh de leshe hahta ke llegueh ar clímah!"
 
 #. Key:	B1E706104468BBBC8C481498B5352B8D
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaHadSex01.Default__LeylannaHadSex01_C.SessionData.LinesToFemale(2).LinesToFemale
@@ -9654,7 +9654,7 @@ msgstr "La cueva conduce a las Reliquias Amorosas. ¡Sss!"
 #: /Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(7).Lines
 msgctxt ",B2323665415F7EE8A74204A9FD52D914"
 msgid "Ye can consider me a connoisseur of @MONSTER_RACE@ milk. Each race's milk has a distinct and delicious flavor, so it is."
-msgstr "Puedeh considerahme una conosedora de la leshe @MONSTER_RACE@. La leshe de cada rasa tiene un saboh distinto y delisioso, asín eh."
+msgstr "Puedeh considerahme una conosedora de la leshe @MONSTER_RACE@. La leshe de cada rasa tiene un zaboh dihtinto y derisiozo, asín eh."
 
 #. Key:	B235542C44D65B1D62C721A3C4CD289F
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_StartForgotten.Default__ParvatiDefault01_StartForgotten_C.SessionData.Lines(2).Lines
@@ -9682,7 +9682,7 @@ msgstr "Mi culo es producto de años de trabajo \"duro\"."
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFuta(1).LinesToFuta
 msgctxt ",B2DF6AC642DDC3C552F43290DCBE4EA7"
 msgid "A human! A super cute human... this is my lucky day. I've been waiting for this phenomenon for... huh. Well as long as I can remember!"
-msgstr "¡Una humana! Una humana super linda... este es mi día de suerte. He estado esperando este fenómeno desde... eh. Bueno, ¡desde que puedo recordar!"
+msgstr "¡Un humano! Un humano super lindo... este es mi día de suerte. He estado esperando este fenómeno desde... eh. Bueno, ¡desde que puedo recordar!"
 
 #. Key:	B2E660614B8D73E10C0B2194E4C87529
 #. SourceLocation:	/Game/Ranch/Upgrades/HarpyAviary.Default__HarpyAviary_C.Upgrade.DisplayName
@@ -9809,7 +9809,7 @@ msgstr "Ah, pequeño... ahora eres mío. No temas, pues solo deseo complacer."
 #: /Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(10).Lines
 msgctxt ",B5B8312540B0C71F1DDBCEADEF6C3E02"
 msgid "I meant what I said about ye between 'mai jugs. Mayhaps we can have a li'l fun in the future?"
-msgstr "Quise desih lo que dije sobre ti entre mih cántaroh de leshe. ¿Quisáh podamoh divertirnoh un poco en er futuro?"
+msgstr "Kise desih lo ke dije zobre ti entre mih cántaroh de leshe. ¿Kisáh poamoh divertirnoh un poko en er futuro?"
 
 #. Key:	B5C876DA4DBA230757C412BE4612735C
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcHaveKeystone.Default__OrcHaveKeystone_C.SessionData.Lines(4).Lines
@@ -9893,7 +9893,7 @@ msgstr "Puedo sentir las raíces de muchas flores de cuminus, pero no de ejaculu
 #: /Game/Dialogue/AmberMae/Default/AmberMaeDefault01_SuckJugs.Default__AmberMaeDefault01_SuckJugs_C.SessionData.Lines(0).Lines
 msgctxt ",B740BA7F4ADFB18E32DFE99606B483B3"
 msgid "Bless me for say'n so, but I was wish'n you'd ask that!"
-msgstr "Bendíseme poh desirlo, ¡pero ehtaba deseando que me preguntarah eso!"
+msgstr "Bendíseme poh desirlo, ¡pero ehtaba dezeando ke me preguntarah ezo!"
 
 #. Key:	B792D83B44DC1E7BF9DAE08B4D4A3E70
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_UpHere.Default__RomyDefault01_UpHere_C.SessionData.Lines(0).Lines
@@ -9935,7 +9935,7 @@ msgstr "Ah, la roca brillante atrapada en mi telaraña."
 #: /Game/Dialogue/Camilla/Default/CamillaHadSex02.Default__CamillaHadSex02_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",B7A8AD6E44A41AB54281548D1A882FFC"
 msgid "Wow human, you must have been desperate to give this nugget your love."
-msgstr "Guau, humana, debes haber estado desesperada para darle a esta pepita tu amor."
+msgstr "Guau, humano, debes haber estado desesperado para darle a esta pepita tu amor."
 
 #. Key:	B7AB851641C9ABEE4A178B9DFFD50B0B
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(33 - Value).TraitIcons.DisplayName
@@ -10056,7 +10056,7 @@ msgstr "*Bosteza*"
 #: /Game/Dialogue/Fesssi/Default/FesssiTaskFulfilled.Default__FesssiTaskFulfilled_C.SessionData.Lines(2).Lines
 msgctxt ",B87369D344C73AFA3F04D49BC07D8BE3"
 msgid "My ass can once again sway in the breeze, and trust me human, it will."
-msgstr "Mi culo puede mecerse con la brisa una vez más, y confía en mí humano, lo hará."
+msgstr "Mi culo puede mecerse con la brisa una vez más y confía en mí, humano, lo hará."
 
 #. Key:	B87B8D5E4C3F16D731F4EA884051A1FD
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_StartButterfly.Default__ParvatiDefault01_StartButterfly_C.SessionData.Lines(0).Lines
@@ -10112,7 +10112,7 @@ msgstr "Para cosecharla, una reina producirá hijas abejas obreras que luego mez
 #: /Game/Dialogue/Emissary/SexScenes/EmissaryAngelGroinLove.Default__EmissaryAngelGroinLove_C.SessionData.LinesToFuta(0).LinesToFuta
 msgctxt ",B98DBFC944D984D0B00D708EE1B9AB94"
 msgid "Indulge yourself human, for I am thy servant."
-msgstr "Deléitate humana, pues soy tu sirviente."
+msgstr "Deléitate, humano, pues soy tu sirviente."
 
 #. Key:	B9D395FA4457763F84E8BD94863D5FBD
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadFlowers.Default__DryadFlowers_C.SessionData.Lines(6).Lines
@@ -10147,7 +10147,7 @@ msgstr "Sin embargo, siéntete libre de intentarlo... lo consideraré un juego p
 #: /Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",BABE7B1340FA36AADAE0E596C6FC1721"
 msgid "How I envy this tall sexy body of yours, but ohhhhh it feels so good!"
-msgstr "Cómo envidio este cuerpo alto y sexy tuyo, ¡pero ohhhhh se siente tan bien!"
+msgstr "Cómo envidio este cuerpo alto y sexy tuyo, ¡pero ohhhhh, se siente tan bien!"
 
 #. Key:	BAEE9CCB4074E077BFF0FBAE275D41CD
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(1).Lines
@@ -10224,7 +10224,7 @@ msgstr "Algo mítico... algo prohibido... algo... ¡humano!"
 #: /Game/Dialogue/AmberMae/SexScenes/AmberMilkyF.Default__AmberMilkyF_C.SessionData.Lines(5).Lines
 msgctxt ",BC8D18A04D5B0C96E407F884999310E6"
 msgid "Eeek I'm a sensitve gal! Yer gonna make me pop... ohhh."
-msgstr "¡Eeek, soy una shica sensibre! Me vah a aseh explotah... ohhh."
+msgstr "¡Eeek, zoy una shica zenzibre! Me vah a aseh ehprotah... ohhh."
 
 #. Key:	BCB1A0F54609C871293D96B90F2E8B8E
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_UpHere.Default__RomyDefault01_UpHere_C.SessionData.Lines(2).Lines
@@ -10301,7 +10301,7 @@ msgstr "Son para las ayrshires que deambulan por aquí, ¡y oh cielos, lo que pu
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",BDF9214F4D266A69032FE9921524969C"
 msgid "You have just become @WORLD_NAME@'s newest resident!"
-msgstr "¡Te acabas de convertir en la residente más nueva de @WORLD_NAME@!"
+msgstr "¡Te acabas de convertir en el residente más nuevo de @WORLD_NAME@!"
 
 #. Key:	BDFBF2444482EC9CA1B83B92138A12DD
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(35 - Value).TraitIcons.HelpText
@@ -10386,7 +10386,7 @@ msgstr "Ahora las hermanas de la tribu están teniendo descendencia con ella. Es
 #: /Game/Dialogue/QueenBee/Default/BeeDefault01.Default__BeeDefault01_C.SessionData.LinesToFemale(4).LinesToFemale
 msgctxt ",BF75C6BF46495EB7F48CD398677B4B16"
 msgid "Is t-t-there something... you want human?"
-msgstr "¿Hay a-a-algo... que quieras, humana?"
+msgstr "¿Hay a-a-algo... que quieras, humano?"
 
 #. Key:	BF7F7E1041AD5B8267C70694F83985F6
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R03.Default__CamillaDefault01_R03_C.SessionData.Lines(0).Lines
@@ -10660,7 +10660,7 @@ msgstr "Maldigo a esa dríada, ella seguía trayendo su dulce fruta, y antes de 
 #: /Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon2.Default__AmberMaeLockedDungeon2_C.SessionData.Lines(4).Lines
 msgctxt ",C544F8824FC4DDC6DBEFE084C3987F32"
 msgid "How I miss the old days."
-msgstr "Cómo ertraño los viejoh tiempos."
+msgstr "Cómo ehtraño los viejoh tiempoh."
 
 #. Key:	C55370A04CAE38FD1D15A9AC46E99FBD
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaHadSex02.Default__CamillaHadSex02_C.SessionData.LinesToFemale(2).LinesToFemale
@@ -10744,7 +10744,7 @@ msgstr "¡Si! Puedo sentir que estás a punto de correrte... lo quiero todo. Mmm
 #: /Game/Dialogue/Autumn/Default/DryadHaveKeystone2.Default__DryadHaveKeystone2_C.SessionData.Lines(0).Lines
 msgctxt ",C6E5F355439A82543536AA974313674B"
 msgid "It's yours now, I hope it serves you well."
-msgstr "Es tuya ahora, espero que te sirva bien."
+msgstr "Ahora es tuya, espero que te sirva bien."
 
 #. Key:	C720F2B64D81061E9D1CC7A3ACD4F0BB
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R02.Default__FaleneDefault01_R02_C.SessionData.Lines(12).Lines
@@ -10908,7 +10908,7 @@ msgstr "Starfallen"
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",CAB7654B473208B56B23F8857B8CBCA0"
 msgid "Careful human, a Kraken's lust is not to be underestimated."
-msgstr "Cuidado humana, la lujuria de un kraken no debe ser subestimada."
+msgstr "Cuidado, humano, la lujuria de un kraken no debe ser subestimada."
 
 #. Key:	CAC37D3345B82EE95615E0BB5C42ED5B
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleTittyPony_T.Default__KybeleTittyPony_T_C.SessionData.LinesToMale(1).LinesToMale
@@ -10985,7 +10985,7 @@ msgstr "Por supuesto, tan pronto como apareció ella hicimos el amor... durante 
 #: /Game/Dialogue/DragonMatriarch/Default/DMHadSex01.Default__DMHadSex01_C.SessionData.LinesToFuta(3).LinesToFuta
 msgctxt ",CC453F864879B9206AA86C866817E4F7"
 msgid "Do come back... my deep dragon pussy yearns for more."
-msgstr "Vuelve... mi profundo coño de dragón anhela más."
+msgstr "Vuelve... mi profundo coño de dragón ansía más."
 
 #. Key:	CC8A60E34A4F302BEBD0CCB8D0F5B282
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiDefault03_RL_T.Default__FesssiDefault03_RL_T_C.ResponseData(3).ResponseData.BreederPrompt
@@ -11006,7 +11006,7 @@ msgstr "Luego me poso seductoramente frente a lo que ella trajo, y ella registra
 #: /Game/Dialogue/AmberMae/Default/AmberMaeHadSex01.Default__AmberMaeHadSex01_C.SessionData.LinesToMale(0).LinesToMale
 msgctxt ",CCBE2DF04F273EE3D33DE583845CB545"
 msgid "Ye drank so much for a wee lad!"
-msgstr "¡Bebihte musho para un moso pequeñito!"
+msgstr "¡Bebihte musho para un moso pekeñito!"
 
 #. Key:	CCFE0CB04C0DD4BC550FE6AF03BFABB3
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R05.Default__FaleneDefault01_R05_C.SessionData.Lines(1).Lines
@@ -11020,7 +11020,7 @@ msgstr "¡Los elfos son parte de la raza silvana, una gran familia @MONSTER_RACE
 #: /Game/Dialogue/Emissary/SexScenes/EmissaryAngelGroinLove.Default__EmissaryAngelGroinLove_C.SessionData.LinesToMale(0).LinesToMale
 msgctxt ",CD24CE384C0548CF493A43A0F88CB7A2"
 msgid "Indulge yourself human, for I am thy servant."
-msgstr "Deléitate humano, pues soy tu sirviente."
+msgstr "Deléitate, humano, pues soy tu sirviente."
 
 #. Key:	CD8C53FE4EAFB9508679088ACC31A4CD
 #. SourceLocation:	/Game/Breeding/Positions/Cowgirl.Default__Cowgirl_C.SessionData.Description
@@ -11217,7 +11217,7 @@ msgstr "Estanque de Formurians"
 #: /Game/Dialogue/Kybele/Default/KybeleCentaur.Default__KybeleCentaur_C.SessionData.Lines(2).Lines
 msgctxt ",D05595AA4F7337C7E43FD59874E5E624"
 msgid "Centaurs can get aggressive when we haven't released for an extended period of time."
-msgstr "Los centauros pueden volverse agresivos cuando no hemos descargado durante un período de tiempo prolongado."
+msgstr "Los centauros podemos volvernos agresivos cuando no hemos descargado durante un período de tiempo prolongado."
 
 #. Key:	D066439244AFE855B06F90AB1A4A0829
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TravelShrines(8 - Value).TravelShrines.ShrineName
@@ -11402,7 +11402,7 @@ msgstr "*Suspira* Como puedes ver, nosotros los @MONSTER_RACE@ tenemos deseos se
 #: /Game/Dialogue/Autumn/Default/DryadHaveKeystone2.Default__DryadHaveKeystone2_C.SessionData.Lines(1).Lines
 msgctxt ",D3EBA5FE4F8C935CB40680BE9D7ED27E"
 msgid "I see I've been slacking off and let my roots overtake the gate to the cove."
-msgstr "Veo que me he estado holgazaneando y dejado que mis raíces sobrepasen el portón de la ensenada."
+msgstr "Veo que he estado holgazaneando y dejado que mis raíces sobrepasen el portón de la ensenada."
 
 #. Key:	D3EBB7904D4648D8930D5B98189AC73D
 #. SourceLocation:	/Game/Characters/Procedural/Variants/Hybrid/Harvest/HybridHarvest.Default__HybridHarvest_C.Harvest.RaceName
@@ -11444,7 +11444,7 @@ msgstr "Ahh... oh... tan delicioso."
 #: /Game/Dialogue/Mirru/SexScenes/MirruSnatchF.Default__MirruSnatchF_C.SessionData.Lines(4).Lines
 msgctxt ",D4BAFDEE4340A6062B18808C4CB9ABF1"
 msgid "Soon... ahhh... you will be covered and impregnated by sticky Kraken pleasure..."
-msgstr "Pronto... ahhh... estarás cubierta e impregnada por el pegajoso placer de kraken..."
+msgstr "Pronto... ahhh... estarás cubierta e impregnada por el pegajoso placer kraken..."
 
 #. Key:	D4E7C4CC40DA7F02F81C91A5CFBF13E8
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMClimaxPeak.Default__DMClimaxPeak_C.SessionData.Lines(5).Lines
@@ -11515,14 +11515,14 @@ msgstr "A diario sexo con Ella mentalmente he tenido."
 #: /Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToFuta(3).LinesToFuta
 msgctxt ",D5C1EFC54081F21A6C1F538839E450A2"
 msgid "Yes! Ohhhh, so big... keep going human! Ahh..."
-msgstr "¡Si! Ohhhh, tan grande... ¡sigue así humana! Ahh..."
+msgstr "¡Si! Ohhhh, tan grande... ¡sigue así, humano! Ahh..."
 
 #. Key:	D5CB7ED64FDBBF8094BDFE9F5271E39E
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_RL.Default__RomyDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 #: /Game/Dialogue/Romy/Default/RomyDefault01_RL.Default__RomyDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",D5CB7ED64FDBBF8094BDFE9F5271E39E"
 msgid "You hear my uh... music?"
-msgstr "¿Escuchas mi eh... música?"
+msgstr "¿Escuchas mi, eh... música?"
 
 #. Key:	D5E48FA54813F998B6D165A5B2F04BF7
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(11).LinesToMale
@@ -12006,14 +12006,14 @@ msgstr "Aún así... me complaciste como un semental. ¡Eso es asombroso para al
 #: /Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFemale(7).LinesToFemale
 msgctxt ",DC59A07E4D2FC78409E32EA7A64B7007"
 msgid "That creepy golden seraphim, the one in the temple. She appeared only a few days ago, constantly asking to speak with \"the human\"."
-msgstr "Esa espeluznante serafín dorada, la del templo. Ella apareció hace solo unos días, constantemente pidiendo hablar con \"la humana\"."
+msgstr "Esa espeluznante serafín dorada, la del templo. Ella apareció hace solo unos días, constantemente pidiendo hablar con \"el humano\"."
 
 #. Key:	DC843E8A4828B0881624D494C080BC2B
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeDefault01_SuckJugs.Default__AmberMaeDefault01_SuckJugs_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeDefault01_SuckJugs.Default__AmberMaeDefault01_SuckJugs_C.SessionData.Lines(1).Lines
 msgctxt ",DC843E8A4828B0881624D494C080BC2B"
 msgid "Awww... I'm blushing something heavy."
-msgstr "Ammm... me ehtoy sonrojahdo una barbaridah."
+msgstr "Ammm... me ehtoy zonrojahdo una barbaridah."
 
 #. Key:	DC85F26F423721D07495E3AB892F86CC
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R01.Default__FaleneDefault01_R01_C.SessionData.Lines(4).Lines
@@ -12027,7 +12027,7 @@ msgstr "Son muy diferentes a sus contrapartidas humanas."
 #: /Game/Dialogue/Mirru/SexScenes/MirruSnatchF.Default__MirruSnatchF_C.SessionData.Lines(0).Lines
 msgctxt ",DC880E904973CDED818EF58F9949FB40"
 msgid "Submit human... I cannot control my desires!"
-msgstr "Entrégate humana... ¡no puedo controlar mis deseos!"
+msgstr "Entrégate, humano... ¡no puedo controlar mis deseos!"
 
 #. Key:	DC956C0949E5CA05486F1583CEACA3ED
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(24 - Value).TraitIcons.DisplayName
@@ -12238,7 +12238,7 @@ msgstr "Como tal, con frecuencia nos encontramos en el extremo receptor del sexo
 #: /Game/Dialogue/Autumn/Default/DryadAboutDryads.Default__DryadAboutDryads_C.SessionData.Lines(6).Lines
 msgctxt ",E0CB0262419C2D4379873799FB2844BC"
 msgid "I guess I do spoil them..."
-msgstr "Supongo que las mimo..."
+msgstr "Supongo que las malcrío..."
 
 #. Key:	E0E93AA54E36B2C3F876CEBE1F52C2FC
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_Emissary.Default__LeylannaDefault01_Emissary_C.SessionData.Lines(4).Lines
@@ -12266,7 +12266,7 @@ msgstr "..."
 #: /Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon.Default__AmberMaeLockedDungeon_C.SessionData.Lines(1).Lines
 msgctxt ",E17B89624E06BB5038FB7A90A70FFD12"
 msgid "As Hedon's oldest citizen, I remember trying to fit in there ages ago."
-msgstr "Como la ziudadana máh antigua de Hedon, recuerdo habeh intentao cabeh allí hase musho tiempo."
+msgstr "Como la ziudadana máh antirgua de Hedon, recuehdo habeh intentao cabeh allí hase musho tiempo."
 
 #. Key:	E1AA64794D412D85279E1C928CB75EFF
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_RL.Default__FaleneDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
@@ -12294,7 +12294,7 @@ msgstr "¡Ahh... ohhhh... sí! Por favor, ambas puntas de mis tentáculos..."
 #: /Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon.Default__AmberMaeLockedDungeon_C.SessionData.Lines(3).Lines
 msgctxt ",E1FD0C3A455475E0E474A0A50646DBA8"
 msgid "Once they built that new temple, the door was sealed... golly 'twas well over 1000 years ago now."
-msgstr "Una veh que construyeron ese nuevo templo, la puerta fue sellaa... Caramba, fue hase máh de 1000 añoh."
+msgstr "Una veh ke cohtruyeron ese nuervo templo, la puerta fue sellaa... Caramba, fue hase máh de 1000 añoh."
 
 #. Key:	E20511A746C7BFEF4C46D5A2F2586CD0
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(28 - Value).TraitIcons.HelpText
@@ -12351,14 +12351,14 @@ msgstr "Eso debería enseñarte a cruzarte con esta poni tet-: ¡otra vez, me re
 #: /Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",E29F5BAA40F6C8758245C58555D4F73E"
 msgid "Ahhhh, your fingers are magical, go deeper! Deeper human, oh yesss."
-msgstr "Ahhhh, tus dedos son mágicos, ¡ve más profundo! Humana más profundo, oh sííí."
+msgstr "Ahhhh, tus dedos son mágicos, ¡ve más profundo! Humano, más profundo, oh sííí."
 
 #. Key:	E2D78DC6488712103CF0A59E6DE95E47
 #. SourceLocation:	/Game/Dialogue/AmberMae/SexScenes/AmberMilkyF.Default__AmberMilkyF_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/AmberMae/SexScenes/AmberMilkyF.Default__AmberMilkyF_C.SessionData.Lines(1).Lines
 msgctxt ",E2D78DC6488712103CF0A59E6DE95E47"
 msgid "Oh yer hand feels so good. Don't stop strok'n me box!"
-msgstr "Oh, tu mano se siente tan bien. ¡No dejeh de acarisiarme el ehtushe!"
+msgstr "Oh, tu mano ze ziente tan bien. ¡No dejeh de acariziarme er ehtushe!"
 
 #. Key:	E2F13B714EEE6046C9069A8F6F71DA0B
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMAboutDragons.Default__DMAboutDragons_C.SessionData.Lines(5).Lines
@@ -12690,7 +12690,7 @@ msgstr "Exótico: heredó mas rasgos de monstruo."
 #: /Game/Dialogue/Kybele/Default/KybeleDefault01.Default__KybeleDefault01_C.SessionData.Lines(0).Lines
 msgctxt ",E884B8E5410C3C8C00BFC3AFDA4097F9"
 msgid "By any means necessary, I will not let you pass human."
-msgstr "Por cualquier medio necesario, no dejaré que pases humano."
+msgstr "Por cualquier medio necesario, no dejaré que pases, humano."
 
 #. Key:	E887131048CFFB8EF5A2E0A1DA1194FE
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraTaskFulfilled.Default__PetraTaskFulfilled_C.SessionData.Lines(2).Lines
@@ -12762,7 +12762,7 @@ msgstr "Conejera de Risus"
 #: /Game/Dialogue/Autumn/Default/DryadFatAssLamia.Default__DryadFatAssLamia_C.SessionData.Lines(3).Lines
 msgctxt ",E999DFEA4E92B84DC1426192191A75AA"
 msgid "As she turned to face me, her massive ass jiggled and settled into place."
-msgstr "Cuando se volvió para mirarme, su inmenso culo se sacudió y se colocó en su lugar."
+msgstr "Cuando se volvió para mirarme, su inmenso culo se sacudió y volvió a su sitio."
 
 #. Key:	E9A374BB46F94E4B206A549D48B4D6FD
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMNap_RL.Default__DMNap_RL_C.ResponseData(0).ResponseData.BreederPrompt
@@ -12931,14 +12931,14 @@ msgstr "Arrodíllate ante tu reina... ahhh... ohhh..."
 #: /Game/Dialogue/Neela/SexScenes/NeelaSnakeCuddleF.Default__NeelaSnakeCuddleF_C.SessionData.Lines(4).Lines
 msgctxt ",EC9757E141CD427BCC7326B974A16B82"
 msgid "Oh human, your thighs are soft... ahhh..."
-msgstr "Oh, humana, tus muslos son suaves... ahhh..."
+msgstr "Oh, humano, tus muslos son suaves... ahhh..."
 
 #. Key:	ECA6FC524716FE3EA1D0A181491FCFC8
 #. SourceLocation:	/Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",ECA6FC524716FE3EA1D0A181491FCFC8"
 msgid "Feel my tongue as it glides between your labia human. Ohhh..."
-msgstr "Siente mi lengua mientras se desliza entre tus labios, humana. Ohhh..."
+msgstr "Siente mi lengua mientras se desliza entre tus labios, humano. Ohhh..."
 
 #. Key:	ECE1ACB84FCF8F8A06C64385D7909E98
 #. SourceLocation:	/Game/UI/TaskDescriptions.TaskDescriptions.TextEntries(0).TextEntries
@@ -13248,7 +13248,7 @@ msgstr "Entonces los @MONSTER_RACE@ son realmente cachondos..."
 #: /Game/Dialogue/AmberMae/Default/AmberMaeHadSex01.Default__AmberMaeHadSex01_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",F2106FBD47C33358DD8CBE9C4F4ABE40"
 msgid "Ahhh... I sure do appreciate tak'n yer time to please this old milkmaid."
-msgstr "Ahhh... rearmente apresio que te tomeh tu tiempo para complaseh a esta vieja leshera."
+msgstr "Ahhh... rearmente apresio que te tomeh tu tiempo para compraseh a ehta vieja leshera."
 
 #. Key:	F21C5AFA463E6FCE44980EAAEE23498C
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchDefault01_RL.Default__MonarchDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
@@ -13444,7 +13444,7 @@ msgstr "¡Los @MONSTER_RACE@ que atrapes no serán bendecidos como yo!"
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToFuta(0).LinesToFuta
 msgctxt ",F7A6401147093A75B20588870BFA39C7"
 msgid "Careful human, a Kraken's lust is not to be underestimated."
-msgstr "Cuidado humana, la lujuria de un kraken no debe ser subestimada."
+msgstr "Cuidado, humano, la lujuria de un kraken no debe ser subestimada."
 
 #. Key:	F7B920EC4CAAD4CD4E61C8915489F45C
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiIdiots.Default__FesssiIdiots_C.SessionData.Lines(3).Lines
@@ -13600,7 +13600,7 @@ msgstr "¡¡Y yo tengo!! Durante casi 1000 años, aquí abajo todo para mi misma
 #: /Game/Dialogue/AmberMae/Default/AmberMaeDefault01_MilkyProducts.Default__AmberMaeDefault01_MilkyProducts_C.SessionData.Lines(0).Lines
 msgctxt ",FAA5B41940157F8963E69CB4ACE814A4"
 msgid "Indulge yerself in 'mai milk!"
-msgstr "¡Deléitate con mi leshe!"
+msgstr "¡Deréitate con mi leshe!"
 
 #. Key:	FAA922F744CCD015043333AD26B1B5AF
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03_RL_F.Default__FernDefault03_RL_F_C.ResponseData(1).ResponseData.BreederPrompt
@@ -13656,7 +13656,7 @@ msgstr "¿Hay a-a-algo... que quieras, humano?"
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToMale(0).LinesToMale
 msgctxt ",FB2BB3B44297DAF2860982BAD6C1819A"
 msgid "Careful human, a Kraken's lust is not to be underestimated."
-msgstr "Cuidado humano, la lujuria de un kraken no debe ser subestimada."
+msgstr "Cuidado, humano, la lujuria de un kraken no debe ser subestimada."
 
 #. Key:	FB4D6F564D28EE26BC34658F3C9B1F73
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimePlay.Default__MegaSlimePlay_C.SessionData.LinesToFemale(2).LinesToFemale
@@ -13684,7 +13684,7 @@ msgstr "¡Ahh... se siente tan bien! Me voy a correr."
 #: /Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(6).Lines
 msgctxt ",FB8D2D144CB9249F47237B94F66E71F1"
 msgid "Why I drink it and use it to make magic treats of course! I ain't a wee lass mind you--I drink lots o' the stuff! Also, me treats are famous world wide!"
-msgstr "¡Pueh la bebo y la uso para haceh deliciah mágicah, poh zupuehto! No zoy una moza pequeñita sabeh: ¡bebo mushah cosah! ¡Ademáh, mih deliciah son famozah en to' el mundo!"
+msgstr "¡Pueh la bebo y la uso para haceh derisiah mágicah, poh zupuehto! No zoy una mosa pekeñita zabeh: ¡bebo mushah cosah! ¡Ademáh, mih derisiah zon famozah en to' er mundo!"
 
 #. Key:	FBA6175C45D9F4E3E3CD7F85021561C6
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_Pregnancy.Default__FaleneDefault01_Pregnancy_C.SessionData.Lines(0).Lines
@@ -13775,7 +13775,7 @@ msgstr "Sucede cada vez que me abro, crees que ya habría aprendido."
 #: /Game/Dialogue/QueenBee/Default/BeeMoreHoney.Default__BeeMoreHoney_C.SessionData.Lines(1).Lines
 msgctxt ",FD102648460B4847C187CA85C454705B"
 msgid "Kneel and suck human. Engorge yourself on my honey, for it pleases me greatly."
-msgstr "Arrodíllate y chupa humano. Atibórrate de mi miel, pues eso me complace inmensamente."
+msgstr "Arrodíllate y chupa, humano. Atibórrate de mi miel, pues eso me complace inmensamente."
 
 #. Key:	FD257CB04C6B3AB420244298D2C33047
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(14 - Value).TraitIcons.DisplayName
@@ -13918,7 +13918,7 @@ msgstr "*Bosteza* Puede que necesite una siesta después de que hagamos el amor 
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeVerySad.Default__MegaSlimeVerySad_C.SessionData.Lines(2).Lines
 msgctxt ",FEB3BE874AC81C2B63FD03953371A656"
 msgid "Who would... after years of loneliness... *sniff*"
-msgstr "¿Quién lo haría... después de años de soledad... *sniff*"
+msgstr "Quién lo haría... después de años de soledad... *sniff*"
 
 #. Key:	FEE6416B44C40270EC8167ADD51EA060
 #. SourceLocation:	/Game/Dialogue/Mirru/SexScenes/MirruKrakVag.Default__MirruKrakVag_C.SessionData.Lines(0).Lines

--- a/spanish.po
+++ b/spanish.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Radiant\n"
 "POT-Creation-Date: 2021-06-14 02:04\n"
-"PO-Revision-Date: 2022-02-22 03:28+0100\n"
+"PO-Revision-Date: 2022-03-08 21:33+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: es_ES\n"
@@ -68,7 +68,7 @@ msgstr "¿Formuria?"
 #: /Game/Dialogue/AmberMae/Default/AmberMaeDefault01_SuckJugs.Default__AmberMaeDefault01_SuckJugs_C.SessionData.Lines(3).Lines
 msgctxt ",014BFFCA4F173DACEC2A00A8398888F4"
 msgid "Aye, yer not leaving 'til you suck every last drop!"
-msgstr "¡Seh, no te iráh hahta que shupeh hahta la úrtima gota!"
+msgstr "¡Seh, no te irás hasta que chupes hasta la última gota!"
 
 #. Key:	0169F2A34BA4C1104CDDEE99B3A3B50E
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchStartShySex.Default__MonarchStartShySex_C.SessionData.LinesToMale(3).LinesToMale
@@ -279,7 +279,7 @@ msgstr "Ese viejo y oxidado juego de engranajes sobre la entrada del pueblo prob
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R07.Default__CamillaDefault01_R07_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",0522652344116C917836F4A1A78C8815"
 msgid "Don't waste your beautiful tall body on me human. Just wait for Falene to come back, or go suck on Amber's tits."
-msgstr "No desperdicies tu hermoso y alto cuerpo en mi, humano. Solo espera a que vuelva Falene o ve a chupar las tetas de Amber."
+msgstr "No desperdicies tu hermoso y alto cuerpo en mi, humana. Solo espera a que vuelva Falene o ve a chupar las tetas de Amber."
 
 #. Key:	052657834F6DBDBBC49BDAADA6E5E88A
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_RL.Default__NeelaDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
@@ -356,7 +356,7 @@ msgstr "¡Fern ayuda a Mastah! ¡Fern recolecta fluidossss para ti!"
 #: /Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(8).Lines
 msgctxt ",06F45D04453307E37897C89FC16861F0"
 msgid "Well, I'm sure you best be get'n off!"
-msgstr "Bueno, ¡ehtoy zegura de ke eh mejoh ke te vayah!"
+msgstr "Bueno, ¡estoy segura de que es mejor que te vayas!"
 
 #. Key:	070169104C3375DAB052E18982B50AE4
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(3).LinesToMale
@@ -454,7 +454,7 @@ msgstr "Créeme, humano, he dado a luz a muchos descendientes."
 #: /Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon2.Default__AmberMaeLockedDungeon2_C.SessionData.Lines(1).Lines
 msgctxt ",093760FD4181D0AA284C4D96884A3801"
 msgid "Took me love for milk too far, 'an the 'ol bovaur genes kicked in."
-msgstr "Me llevó mi amoh poh la leshe demasiao lejoh, y loh viejoh geneh bovauh entraron en arsión."
+msgstr "Me llevó el amor por la leche demasiao lejos, y los viejos genes bovaur entraron en acción."
 
 #. Key:	094AB3854E6DACE10C94B28ADCB83FE0
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaFaleneWeek.Default__CamillaFaleneWeek_C.SessionData.Lines(2).Lines
@@ -468,7 +468,7 @@ msgstr "Lo mejor que encuentra, lo trae aquí para examinarlo."
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R07.Default__FaleneDefault01_R07_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",0968DD0D4744523D6AFCEABE502C530F"
 msgid "I'm so horny I can't stand it anymore! Spread 'em human because here I come!"
-msgstr "¡Estoy tan caliente que no puedo soportarlo más! ¡Sepáralas, humano, porque aquí voy!"
+msgstr "¡Estoy tan caliente que no puedo soportarlo más! ¡Sepáralas, humana, porque aquí voy!"
 
 #. Key:	099488164DB48F48395E94B86F3EE565
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruHadSex01.Default__MirruHadSex01_C.SessionData.LinesToFemale(4).LinesToFemale
@@ -552,7 +552,7 @@ msgstr "Pasemos el día juntos, porque aquí, en el calor de estas aguas, podemo
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",0BB0A695454FD69DAA129F82F023EB23"
 msgid "A human! A super cute human, this is my lucky day. I've been waiting for this phenomenon for... huh. Well as long as I can remember!"
-msgstr "¡Un humano! Un humano super lindo... este es mi día de suerte. He estado esperando este fenómeno desde... eh. Bueno, ¡desde que puedo recordar!"
+msgstr "¡Una humana! Una humana super linda... este es mi día de suerte. He estado esperando este fenómeno desde... eh. Bueno, ¡desde que puedo recordar!"
 
 #. Key:	0BBD00B64AD7488CC6A8008C2BAF8B41
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.VulwargKennel.ManageActionMessage
@@ -736,7 +736,7 @@ msgstr "Rechazar"
 #: /Game/Dialogue/Emissary/Default/EmissaryHadSex01.Default__EmissaryHadSex01_C.SessionData.LinesToMale(3).LinesToMale
 msgctxt ",0EC0E30B4EEFEC910A9F1D90DC5AB286"
 msgid "Judging by the mess on the temple floor, quite good."
-msgstr "A juzgar por el desorden en el suelo del templo, bastante bueno."
+msgstr "A juzgar por el desastre en el suelo del templo, bastante bueno."
 
 #. Key:	0EEEC9A34AD6162338FCA699384590D4
 #. SourceLocation:	/Game/Ranch/Upgrades/BovaurShed.Default__BovaurShed_C.Upgrade.TypeDisplay
@@ -939,7 +939,7 @@ msgstr "¿Puedo... montarte?"
 #: /Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon2.Default__AmberMaeLockedDungeon2_C.SessionData.Lines(2).Lines
 msgctxt ",11C0FBB845185DFCD5E67DA5B758B432"
 msgid "At me peak I could barely walk! The jugs 'an belly were mighty heavy."
-msgstr "¡En mi cumbre apenah podía caminah! Loh cántaroh de leshe y la barriga pezaban mushízimo."
+msgstr "¡En mi cumbre apenas podía caminar! Los cántaros de leche y la barriga pesaban muchísimo."
 
 #. Key:	12036FB64912193341380BA267A64971
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernGreeting03.Default__FernGreeting03_C.SessionData.LinesToFemale(4).LinesToFemale
@@ -1263,7 +1263,7 @@ msgstr "Valioso: el Valor se incrementa en un 35%."
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",193F948E4333F3741026EABB87402DD3"
 msgid "A chance to mate with a human is making my hearts pound, and my tentacles slick..."
-msgstr "Una oportunidad de aparearme con un humano está haciendo que mi corazón se acelere y que mis tentáculos resbalen..."
+msgstr "Una oportunidad de aparearme con una humana está haciendo que mis corazones se aceleren y que mis tentáculos resbalen..."
 
 #. Key:	195D4E38448666E82EA5BEA6A446E98A
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeSad_RL2.Default__MegaSlimeSad_RL2_C.ResponseData(0).ResponseData.BreederPrompt
@@ -1277,7 +1277,7 @@ msgstr "Qué he hecho..."
 #: /Game/Dialogue/AmberMae/Default/AmberMaeDefault01.Default__AmberMaeDefault01_C.SessionData.Lines(0).Lines
 msgctxt ",19A2E9D044587CE3E0AC5B8D366B6974"
 msgid "Have ye come back to feel 'mai jugs?"
-msgstr "¿Hah vuerto pa' zentih mih cántaroh de leshe?"
+msgstr "¿Has vuelto pa' sentir mis cántaros de leche?"
 
 #. Key:	19AB0BB8417E1310F35D1D922EF9CFD5
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadFatAssLamia.Default__DryadFatAssLamia_C.SessionData.Lines(5).Lines
@@ -1312,14 +1312,14 @@ msgstr "Pronto mi colección de néctar estará completa y podré regresar a las
 #: /Game/Dialogue/AmberMae/SexScenes/AmberMilkyF.Default__AmberMilkyF_C.SessionData.Lines(4).Lines
 msgctxt ",1A66A5974B5893066D25B7A93AD8BA38"
 msgid "Does it taste good?"
-msgstr "¿Zabe bieh?"
+msgstr "¿Sabe bien?"
 
 #. Key:	1A7572BD4073E9E25BE3D1889A08E000
 #. SourceLocation:	/Game/Dialogue/Cassie/SexScenes/CassieButterButtF.Default__CassieButterButtF_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Cassie/SexScenes/CassieButterButtF.Default__CassieButterButtF_C.SessionData.Lines(2).Lines
 msgctxt ",1A7572BD4073E9E25BE3D1889A08E000"
 msgid "Experience my amazing butter stick human! Ahhhh..."
-msgstr "¡Experimenta mi increíble barra de mantequilla, humano! Ahhhh..."
+msgstr "¡Experimenta mi increíble barra de mantequilla, humana! Ahhhh..."
 
 #. Key:	1A7B16814705FD34BE5FF69AB7855D7B
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiGreeting01.Default__ParvatiGreeting01_C.SessionData.LinesToFuta(3).LinesToFuta
@@ -1515,7 +1515,7 @@ msgstr "Las sirenas somos formurians únicas, escuchamos frecuencias que la mayo
 #: /Game/Dialogue/AmberMae/Default/AmberMaeHadSex01.Default__AmberMaeHadSex01_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",1DB7FBDD4A80D06FCF9019965B0E0008"
 msgid "Ye drank so much for a wee lass!"
-msgstr "¡Bebihte musho para una mosa pekeñita!"
+msgstr "¡Bebiste muchísimo pa' una muchachita!"
 
 #. Key:	1E0C491A43E8C2F67FA568B20B5A6743
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_Teach.Default__ParvatiDefault01_Teach_C.SessionData.Lines(5).Lines
@@ -1691,7 +1691,7 @@ msgstr "Fern espera que esto complazca mucho a Mastah..."
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",20A752DD41AFEBDD2A4852BD029B894E"
 msgid "You have just become @WORLD_NAME@'s newest resident!"
-msgstr "¡Te acabas de convertir en el residente más nuevo de @WORLD_NAME@!"
+msgstr "¡Te acabas de convertir en la residente más nueva de @WORLD_NAME@!"
 
 #. Key:	20BEB0FA47066DBAB732F68642C6BAC3
 #. SourceLocation:	/Game/Breeding/Positions/Test5.Default__Test5_C.SessionData.PositionName
@@ -1930,7 +1930,7 @@ msgstr "*Gruñe*"
 #: /Game/Dialogue/AmberMae/Default/AmberMaeDefault01_Accent.Default__AmberMaeDefault01_Accent_C.SessionData.Lines(0).Lines
 msgctxt ",240A4A634DB7018141BD60B5A94B716C"
 msgid "Oh no! Me hopes ye can understand."
-msgstr "¡Oh, no! Ehpero ke lo entiendah."
+msgstr "¡Oh, no! Espero que lo entiendas."
 
 #. Key:	240E4A09421F907A3C7714B84A5BF051
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiHowLong.Default__FesssiHowLong_C.SessionData.Lines(1).Lines
@@ -2473,7 +2473,7 @@ msgstr "Vete humano, este es mi sitio confortable y no puedes tomarlo."
 #: /Game/Dialogue/Kybele/Default/KybeleTittyPony.Default__KybeleTittyPony_C.SessionData.LinesToFuta(0).LinesToFuta
 msgctxt ",2EF1966C455529B6A75289AD5EF81C2E"
 msgid "That's it human, you have annoyed me long enough. Get against that rock and prepare to be smashed."
-msgstr "Eso es, humano, me has molestado lo suficiente. Ponte contra esa roca y prepárate para ser aplastado."
+msgstr "Eso es, humana, me has molestado lo suficiente. Ponte contra esa roca y prepárate para ser aplastada."
 
 #. Key:	2EF454D94FCEA805F55F20A94627C808
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiGreeting01.Default__ParvatiGreeting01_C.SessionData.LinesToFuta(6).LinesToFuta
@@ -2494,7 +2494,7 @@ msgstr "El poder de una dríada alcanza su cumbre en el momento del orgasmo."
 #: /Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(4).Lines
 msgctxt ",2F5513164D00080A441C1292E501C786"
 msgid "If ye have @MONSTER_RACE@ milk to sell, or if ye want te buy some then I'm yer gal!"
-msgstr "Zi tieneh leshe de @MONSTER_RACE@ pa' vendeh, o zi kiereh comprah argo, en eze cazo ¡zoy tu shica!"
+msgstr "Si tienes leche de @MONSTER_RACE@ pa' vender, o si quieres comprar algo, en ese caso ¡soy tu chica!"
 
 #. Key:	2F7D02EE4B2C5C30E72919BE9D83BD1F
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleDragonMatriarch.Default__KybeleDragonMatriarch_C.SessionData.Lines(5).Lines
@@ -2515,7 +2515,7 @@ msgstr "Primero, Ella hizo el amor con Ella misma para traer a luz y los serafin
 #: /Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon2.Default__AmberMaeLockedDungeon2_C.SessionData.Lines(0).Lines
 msgctxt ",2FA4621047A86335175276AF22BFDE52"
 msgid "If ye think I'm a big cow today, 'mai goodness was I larger in me younger days!"
-msgstr "Si piensah ke zoy una vaca grande hoy, ¡zanto sielo, era máh grande en mih díah de juventuh!"
+msgstr "Si piensas que soy una vaca grande hoy en día, ¡cielo santo, era más grande en mi juventud!"
 
 #. Key:	2FA59C8A48A63BD0FE6D0289A8AF9587
 #. SourceLocation:	/Game/Dialogue/Yasmine/Default/YasmineDefault02_RL.Default__YasmineDefault02_RL_C.ResponseData(0).ResponseData.BreederPrompt
@@ -2711,7 +2711,7 @@ msgstr "La magia de Monarch te lo impide."
 #: /Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(9).Lines
 msgctxt ",330EAC0C483DA43FAFCBCBB789D5AB9E"
 msgid "'Twas nice meet'n ye @BREEDER_NAME@..."
-msgstr "Ha sioh un praseh conosehte, @BREEDER_NAME@..."
+msgstr "Ha sio un placer conocerte, @BREEDER_NAME@..."
 
 #. Key:	335AC6B54A917B8EBB17218E2A338F3C
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieGreeting01.Default__CassieGreeting01_C.SessionData.Lines(5).Lines
@@ -2837,14 +2837,14 @@ msgstr "Si tuviera que pasar el resto de la eternidad en un lugar, no querría q
 #: /Game/Dialogue/Kybele/Default/KybeleTittyPony_T.Default__KybeleTittyPony_T_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",35908AA04644610D46AB42B909BDD768"
 msgid "That's it human, you have annoyed me long enough. Bend over and prepare to be stuffed with my fat spear!"
-msgstr "Eso es, humano, me has molestado lo suficiente. ¡Inclínate y prepárate para ser rellenada con mi gorda lanza!"
+msgstr "Eso es, humana, me has molestado lo suficiente. ¡Inclínate y prepárate para ser rellenada con mi gorda lanza!"
 
 #. Key:	35B0312145CDC987463545B35DBCF219
 #. SourceLocation:	/Game/Dialogue/Mirru/SexScenes/MirruSnatchT.Default__MirruSnatchT_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/Mirru/SexScenes/MirruSnatchT.Default__MirruSnatchT_C.SessionData.Lines(0).Lines
 msgctxt ",35B0312145CDC987463545B35DBCF219"
 msgid "Submit human... I cannot control my desires!"
-msgstr "Entrégate, humano... ¡no puedo controlar mis deseos!"
+msgstr "Entrégate, humana... ¡no puedo controlar mis deseos!"
 
 #. Key:	35BF63974E330C75B3359E8E1E99F0CB
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(11).Lines
@@ -2949,7 +2949,7 @@ msgstr "Imagina lo bien que se sentirán mis tentáculos entre tus labios... y t
 #: /Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToMale(4).LinesToMale
 msgctxt ",37BE82A749B75C694B68B3856342C2A7"
 msgid "Mmmm... so hard! Ohhh... ahhh!"
-msgstr "Mmmm... ¡tan duro! ¡Ohhh... ahhh!"
+msgstr "Mmmm... ¡que duro! ¡Ohhh... ahhh!"
 
 #. Key:	37E6B83D46955FAADDF215966CCB5A8B
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R03.Default__CamillaDefault01_R03_C.SessionData.Lines(1).Lines
@@ -3068,7 +3068,7 @@ msgstr "¿Qué sabes del antiguo templo?"
 #: /Game/Dialogue/AmberMae/Default/AmberMaeDefault01_Accent.Default__AmberMaeDefault01_Accent_C.SessionData.Lines(2).Lines
 msgctxt ",39BB76F04901D85036C696B74CA537B3"
 msgid "She can get mighty cold though, ye best fatten up on 'mai milk if yer head'n that way!"
-msgstr "Aunke puede haseh mushízimo frío, ¡será mejoh que engordeh con mi leshe si vah poh eze camino!"
+msgstr "Aunque puede hacer muchísimo frío, ¡será mejor que engordes con mi leche si vas por esa ruta!"
 
 #. Key:	39E4B8C74F24A77B88CFA89F73E896C7
 #. SourceLocation:	/Game/UI/TaskDescriptions.TaskDescriptions.TextEntries(2).TextEntries
@@ -3329,7 +3329,7 @@ msgstr "¿No puedes tomar una siesta en otro lugar?"
 #: /Game/Dialogue/Kybele/Default/KybeleTittyPony.Default__KybeleTittyPony_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",3E5797444DCB450E19730E9C8CB6A4FB"
 msgid "That's it human, you have annoyed me long enough. Bend over and prepare to be stuffed with my fat spear!"
-msgstr "Eso es, humano, me has molestado lo suficiente. ¡Inclínate y prepárate para ser rellenada con mi gorda lanza!"
+msgstr "Eso es, humana, me has molestado lo suficiente. ¡Inclínate y prepárate para ser rellenada con mi gorda lanza!"
 
 #. Key:	3E5B1CA94E6EB9CC180AE3A6F9EC5439
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryCockblockGates.Default__EmissaryCockblockGates_C.SessionData.Lines(2).Lines
@@ -3498,7 +3498,7 @@ msgstr "¡Deberías quedarte aquí abajo y darme más! Podemos ser amigos para s
 #: /Game/Dialogue/AmberMae/Default/AmberMaeDefault01.Default__AmberMaeDefault01_C.SessionData.Lines(1).Lines
 msgctxt ",410012DF43FE2AB2B4B74FA7EE1CB85E"
 msgid "Come 'an put yerself betwixt them--I don't mind none!"
-msgstr "Ven y ponte entre ellah: ¡no me importa na'!"
+msgstr "Ven y ponte entre ellos: ¡no me importa na'!"
 
 #. Key:	41480BAC414E8393545F14A5AF5C1CBD
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernGreeting01.Default__FernGreeting01_C.SessionData.Lines(3).Lines
@@ -3561,7 +3561,7 @@ msgstr "Te sentirás tan bien mientras inundo tu útero con mi limo..."
 #: /Game/Dialogue/AmberMae/Default/AmberMaeSuckJugs_Start.Default__AmberMaeSuckJugs_Start_C.SessionData.Lines(1).Lines
 msgctxt ",41D4E33A4F278EEAC8E03DBD1A9618E5"
 msgid "I'm get'n wet, milk me 'lil human! Drink it all!"
-msgstr "¡Me ehtoy mojando, ordéñame peke humano! ¡Bébetela toa!"
+msgstr "¡Me estoy mojando, ordéñame humanito! ¡Bébela toda!"
 
 #. Key:	42094BD145964827266556B272FD2005
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernGreeting03.Default__FernGreeting03_C.SessionData.LinesToMale(4).LinesToMale
@@ -3603,7 +3603,7 @@ msgstr "Nos encanta reproducirnos con todos los demás @MONSTER_RACE@."
 #: /Game/Dialogue/AmberMae/SexScenes/AmberMilkyF.Default__AmberMilkyF_C.SessionData.Lines(3).Lines
 msgctxt ",42666B4E478FE544AD7A4B91FD65DE82"
 msgid "Aye don't stop 'lil human! It's thick and creamy... ahhh!"
-msgstr "¡Seh, no pareh peke humano! Eh ehpesa y cremoza... ¡ahhh!"
+msgstr "¡Seh, no pares humanito! Es espesa y cremosa... ¡ahhh!"
 
 #. Key:	42E4526948669BCD5AFBD29DC9583D3C
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R06.Default__FaleneDefault01_R06_C.SessionData.Lines(7).Lines
@@ -3624,7 +3624,7 @@ msgstr "Se necesitaba una fuerza para contrastar la luz, por lo que la Diosa ced
 #: /Game/Dialogue/OrcChief/Default/OrcFixOwnGate.Default__OrcFixOwnGate_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",432AB6154EB0FCBABFD45A9F48D948F8"
 msgid "Human fix gate now, or get cock stuffed down gullet!"
-msgstr "¡Ahora arregla el portón, humano, o haré que la polla rellene bajando por la garganta!"
+msgstr "¡Ahora arregla el portón, humana, o haré que la polla te rellene bajando por la garganta!"
 
 #. Key:	433691C34A0864415618B78808993A0E
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMNapSomewhereElse.Default__DMNapSomewhereElse_C.SessionData.Lines(1).Lines
@@ -3828,7 +3828,7 @@ msgstr "¡Mira el tamaño de esa!"
 #: /Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon2.Default__AmberMaeLockedDungeon2_C.SessionData.Lines(3).Lines
 msgctxt ",46C09FA14157EC1F3D6608BB30F25A60"
 msgid "Them townsfolk loved playing with 'mai soft body... *sigh*"
-msgstr "A la gente der puerblo le encantaba jugah con mi zuave cuehpo... *suspira*"
+msgstr "A la gente del pueblo le encantaba jugar con mi suave cuerpo... *suspira*"
 
 #. Key:	46D776EB4F6C6F71D802088F7C493A82
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToFuta(6).LinesToFuta
@@ -4132,7 +4132,7 @@ msgstr "A partir de ese momento me fijé en ella... quería complacerla de forma
 #: /Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(3).Lines
 msgctxt ",4C00C7F544226DAA1CBB4781B0CEB82F"
 msgid "Aye, 'mai specialty is all things milk, and a quare good pair on me front. Bless me, hav'n jugs like these can really hurt 'mai back!"
-msgstr "Seh, mih espesialidadeh zon toa lah cosah relasionaah con la leshe, y un buen par cuadrao en mi delantera. ¡Bendita zea, teneh cántaroh de leshe como ehtoh reahmente pueden lahtimarme la ehparda!"
+msgstr "Seh, mis especialidades son todas las cosas relacionadas con la leche, y un buen par cuadrao en mi delantera. ¡Bendita sea, tener cántaros de leche como estos realmente pueden lastimarme la espalda!"
 
 #. Key:	4C1E56854BDDE954FC7ACA99874AB4C3
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaHadSex02.Default__CamillaHadSex02_C.SessionData.LinesToFemale(1).LinesToFemale
@@ -4486,7 +4486,7 @@ msgstr "Por favor, recoge la roca brillante al salir. Siento que el hambre acech
 #: /Game/Dialogue/Emissary/SexScenes/EmissaryAngelGroinLove.Default__EmissaryAngelGroinLove_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",53133AE5461CD4363425BC8B9E8327F4"
 msgid "Indulge yourself human, for I am thy servant."
-msgstr "Deléitate, humano, pues soy tu sirviente."
+msgstr "Deléitate, humana, pues soy tu sirviente."
 
 #. Key:	535696214ED031B7F34A458925D0CEA8
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_RL.Default__CamillaDefault01_RL_C.ResponseData(6).ResponseData.BreederPrompt
@@ -4535,7 +4535,7 @@ msgstr "Fern espera que esto complazca mucho a Mastah..."
 #: /Game/Dialogue/AmberMae/Default/AmberMaeSuckJugs_Cancel.Default__AmberMaeSuckJugs_Cancel_C.SessionData.Lines(0).Lines
 msgctxt ",5477799C4F9B5398BECB918C51B6CC44"
 msgid "Forgive me if I was com'n on too strong! I hope I didn't offend ye..."
-msgstr "¡Perdóhame zi fui demaziao bruhca! Ehpero no habehte ofendio..."
+msgstr "¡Perdóname si fui demasiao brusca! Espero no haberte ofendio..."
 
 #. Key:	5487409C445EEB5B2C699C8A5253DD30
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFemale(2).LinesToFemale
@@ -4726,7 +4726,7 @@ msgstr "Quitaré el panal de miel del portón de las Tierras-Colmena."
 #: /Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon.Default__AmberMaeLockedDungeon_C.SessionData.Lines(5).Lines
 msgctxt ",5881DC0E4C70AE1F56EE70A7C1A4A78A"
 msgid "Yer ask'n the wrong lass though, I'm just a simple milkmaid."
-msgstr "Zin embargo, le ehtah preguntando a la mosa ekivocaa, zolo zoy una simpre leshera."
+msgstr "Sin embargo, le preguntas a la moza equivoca', solo soy una simple lechera."
 
 #. Key:	589C39424192EF623DC606AE1E6D2D75
 #. SourceLocation:	/Game/Ranch/Upgrades/DemonPool.Default__DemonPool_C.Upgrade.DisplayName
@@ -4924,7 +4924,7 @@ msgstr "¡Allí! Prométeme que si lo abres... ¡tendremos sexo pervertido en el
 #: /Game/Dialogue/Fern/SexScenes/FernMilk_01.Default__FernMilk_01_C.SessionData.Lines(2).Lines
 msgctxt ",5C55705949989D3944ACDD8DE6CAEB1E"
 msgid "Human milky taste so good... ahhhh!"
-msgstr "Sabor lácteo humano tan bueno... ¡ahhhh!"
+msgstr "El sabor lácteo humano tan bueno... ¡ahhhh!"
 
 #. Key:	5C9673D0476DF1FF65CB63B5F142C7FE
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(7).LinesToFemale
@@ -5051,7 +5051,7 @@ msgstr "Ah, bueno, podría concederte acceso, pero... hay algo que quiero a camb
 #: /Game/Dialogue/Emissary/Default/EmissaryHadSex01.Default__EmissaryHadSex01_C.SessionData.LinesToFuta(3).LinesToFuta
 msgctxt ",604FA2154312C173E208F3949C0C0A75"
 msgid "Judging by the mess on the temple floor, quite good."
-msgstr "A juzgar por el desorden en el suelo del templo, bastante bueno."
+msgstr "A juzgar por el desastre en el suelo del templo, bastante bueno."
 
 #. Key:	60635C454CEF8341039602B6529EEE22
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowSpiders.Default__WidowSpiders_C.SessionData.Lines(6).Lines
@@ -5114,14 +5114,14 @@ msgstr "¿Qué es la Gran Concepción?"
 #: /Game/Dialogue/DragonMatriarch/Default/DMTaskFulfilled.Default__DMTaskFulfilled_C.SessionData.Lines(0).Lines
 msgctxt ",613E368A449069B472AC11842731C6AB"
 msgid "Ahhh so sweet and creamy! I haven't felt this good in decades."
-msgstr "¡Ahhh, tan dulce y cremosa! No me había sentido tan bien en décadas."
+msgstr "¡Ahhh, que dulce y cremosa! No me había sentido tan bien en décadas."
 
 #. Key:	61A8146D43CCAA9D468CCC9D2CB22F42
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon.Default__AmberMaeLockedDungeon_C.SessionData.Lines(4).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon.Default__AmberMaeLockedDungeon_C.SessionData.Lines(4).Lines
 msgctxt ",61A8146D43CCAA9D468CCC9D2CB22F42"
 msgid "If I recall... they rigged up some switch 'an pulley system."
-msgstr "Zi mar no recuerdo... ihtalaron un zihtema de interrustoh y poleah."
+msgstr "Si mal no recuerdo... instalaron un sistema de interruptor y poleas."
 
 #. Key:	61C3C47B425E2ACFE03921A38EDBD93D
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.CBGate_Glade.PlaceMessage
@@ -5261,7 +5261,7 @@ msgstr "*Lame* *Sorbe*"
 #: /Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon.Default__AmberMaeLockedDungeon_C.SessionData.Lines(0).Lines
 msgctxt ",63ACAC1E4A5D5DFE164A168EAFEE76BC"
 msgid "Aye, 'tis been countless years since anyone's been down there!"
-msgstr "¡Seh, han pasao incontableh añoh dehde ke arguien ehtuvo allí abajo!"
+msgstr "¡Seh, han pasao incontables años desde que alguien estuvo allí abajo!"
 
 #. Key:	63B540744119014025598C8555237076
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMHadSex01.Default__DMHadSex01_C.SessionData.LinesToFemale(2).LinesToFemale
@@ -5493,7 +5493,7 @@ msgstr "Primero, tengo que estar desnuda."
 #: /Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(2).Lines
 msgctxt ",6779B6F54EA9811CDA01BB899D8E10A4"
 msgid "I'm Amber-Mae, yer Bovaur dairy lass!"
-msgstr "¡Zoy Amber-Mae, tu mosa leshera bovauh!"
+msgstr "¡Soy Amber-Mae, tu moza lechera bovaur!"
 
 #. Key:	679174774B8AE81A6C98AE933C6D1BF3
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_Formuria.Default__MirruDefault01_Formuria_C.SessionData.Lines(5).Lines
@@ -5669,7 +5669,7 @@ msgstr "No se moverá."
 #: /Game/Dialogue/AmberMae/Default/AmberMaeSuckJugs_Start.Default__AmberMaeSuckJugs_Start_C.SessionData.Lines(0).Lines
 msgctxt ",6AD76D124EA5FF55B998D39AD1070F08"
 msgid "Oh my! Ohhhh!"
-msgstr "¡Oh, sieloh! ¡Ohhhh!"
+msgstr "¡Oh cielos! ¡Ohhhh!"
 
 #. Key:	6AFADD1A416223C71B86159050C16A67
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchShySexT_RL.Default__MonarchShySexT_RL_C.ResponseData(0).ResponseData.BreederPrompt
@@ -5697,7 +5697,7 @@ msgstr "En cierto modo, envidio a mis hermanos menores, no están obligados a em
 #: /Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon.Default__AmberMaeLockedDungeon_C.SessionData.Lines(2).Lines
 msgctxt ",6BC585A94AB919791876E989ABC6AFC2"
 msgid "Didn't get very far though, me jugs 'an buxom hips said no!"
-msgstr "Zin embargo, no llegué muh lejoh, ¡mis cántaroh de leshe y mis caderah ezuberanteh dijeron ke no!"
+msgstr "Sin embargo, no llegué mu' lejos, ¡mis cántaros de leche y mis caderas exuberantes dijeron que no!"
 
 #. Key:	6BD3487945B18914AE271E871E682D15
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiTaskFulfilled.Default__FesssiTaskFulfilled_C.SessionData.Lines(3).Lines
@@ -5775,7 +5775,7 @@ msgstr "He escuchado leyendas de las hijas de la Abeja Reina en las Tierras-Colm
 #: /Game/Dialogue/AmberMae/Default/AmberMaeDefault01_SuckJugs.Default__AmberMaeDefault01_SuckJugs_C.SessionData.Lines(4).Lines
 msgctxt ",6D4E481742B09428791263B3A820281E"
 msgid "Oh my... I'm so embarrassed, 'mai urges got the best o' me!"
-msgstr "Oh sieloh... ehtoy tan avergonsaa, ¡mih impursoh ze apoderarón de mí!"
+msgstr "Oh cielos... estoy tan avergonza', ¡mis impulsos se adueñaron de mí!"
 
 #. Key:	6D4FCB5345397A3D9726C1AAA8B438D6
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernBeeFlowers2.Default__FernBeeFlowers2_C.SessionData.Lines(0).Lines
@@ -5887,14 +5887,14 @@ msgstr "Oh, espera... yo, eh..."
 #: /Game/Dialogue/DragonMatriarch/Default/DMHadSex01.Default__DMHadSex01_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",6EB1D4054ABCE1E3818FC39FB5A8415A"
 msgid "Somehow you took a cock larger than you and still made it feel amazing."
-msgstr "De alguna manera recibiste una polla más grande que tú y aún así haces que se sienta increíble."
+msgstr "De alguna manera tomaste una polla más grande que tú y aún así haces que se sienta increíble."
 
 #. Key:	6ED67799423B871587B12E8DEC3D1BE1
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(0).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(0).Lines
 msgctxt ",6ED67799423B871587B12E8DEC3D1BE1"
 msgid "Oh! A cute li'l human! Nary in all me puff did I expect te see such a thing!"
-msgstr "¡Oh! ¡Un lindo peke humano! ¡Ni en toa mi bocanaa ehperaba veh argo asín!"
+msgstr "¡Oh! ¡Un lindo humanito! ¡Ni en to' mi resoplio esperaba ver algo así!"
 
 #. Key:	6F1214E04CFF55C4F15CF6B9593AE091
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToFuta(3).LinesToFuta
@@ -5929,7 +5929,7 @@ msgstr "Pero primero, una donación altísima Diosa. Alabado sea Su nombre."
 #: /Game/Dialogue/AmberMae/SexScenes/AmberMilkyF.Default__AmberMilkyF_C.SessionData.Lines(0).Lines
 msgctxt ",6F5E6DAB49A4FDFA3CF6ADB4F98239E5"
 msgid "Ahhhh! Suck 'em hard, 'mai milk is all for you!"
-msgstr "¡Ahhhh! ¡Chúpalah fuehte, mi leshe es toa pa' ti!"
+msgstr "¡Ahhhh! ¡Chúpalas fuerte, mi leche es toda tuya!"
 
 #. Key:	6F8F41154136EFB2D479DCB4A853DC48
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcBrashDumb.Default__OrcBrashDumb_C.SessionData.Lines(9).Lines
@@ -6091,7 +6091,7 @@ msgstr "¡Prepárate, pequeño gatito!"
 #: /Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFuta(7).LinesToFuta
 msgctxt ",717D6D564578FC099110B6899F65067E"
 msgid "That creepy golden seraphim, the one in the temple. She appeared only a few days ago, constantly asking to speak with \"the human\"."
-msgstr "Esa espeluznante serafín dorada, la del templo. Ella apareció hace solo unos días, constantemente pidiendo hablar con \"el humano\"."
+msgstr "Esa espeluznante serafín dorada, la del templo. Ella apareció hace solo unos días, constantemente pidiendo hablar con \"la humana\"."
 
 #. Key:	71914E004F66CB40BEDE07BF85D0FDC5
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcBrashDumb.Default__OrcBrashDumb_C.SessionData.Lines(0).Lines
@@ -6488,7 +6488,7 @@ msgstr "¡¡¡¿No es eso simplemente fantástico y adorable?!!!"
 #: /Game/Dialogue/Kybele/Default/KybeleHadSex01.Default__KybeleHadSex01_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",7989199A4B0BA24F0B904493FCC965AC"
 msgid "Still... you took my fat horse cock well. That's amazing for one of your size!"
-msgstr "Aún así... recibiste bien mi gorda polla de caballo. ¡Eso es asombroso para alguien de tu tamaño!"
+msgstr "Aún así... tomaste bien mi gorda polla de caballo. ¡Eso es asombroso para alguien de tu tamaño!"
 
 #. Key:	7A0924884575833B8154E88AE733B3E4
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.EM_Keystone_Kybele.FailMessage
@@ -6855,7 +6855,7 @@ msgstr "Somos los señores de esta cordillera."
 #: /Game/Dialogue/AmberMae/Default/AmberMaeDefault01_SuckJugs.Default__AmberMaeDefault01_SuckJugs_C.SessionData.Lines(2).Lines
 msgctxt ",8103840A43F7351F6B263C98CC5A6335"
 msgid "Me jugs are get'n full, are ye sure that 'lil body can handle it all?"
-msgstr "Mih cántaroh de leshe ehtán llenoh, ¿estáh zeguro de que eze cuerpesín puede manejahlo too?"
+msgstr "Mis cántaros de leche están llenos, ¿estás seguro de que ese cuerpecito puede manejarlo to'?"
 
 #. Key:	8169C4CD4FCCAEC60B1417A262737D1E
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleHadSex01.Default__KybeleHadSex01_C.SessionData.LinesToFemale(0).LinesToFemale
@@ -6954,7 +6954,7 @@ msgstr "La mayoría de las veces, termino metida en todos los agujeros."
 #: /Game/Dialogue/Camilla/Default/CamillaHadSex02.Default__CamillaHadSex02_C.SessionData.LinesToFuta(0).LinesToFuta
 msgctxt ",83B1D0DD4F37A2E70289CEAAC491EB74"
 msgid "Wow human, you must have been desperate to give this nugget your love."
-msgstr "Guau, humano, debes haber estado desesperado para darle a esta pepita tu amor."
+msgstr "Guau, humana, debes haber estado desesperada para darle a esta pepita tu amor."
 
 #. Key:	83C8B41F462880323A7E26B8AE678AA1
 #. SourceLocation:	/Game/Dialogue/Mirru/SexScenes/MirruSnatchT.Default__MirruSnatchT_C.SessionData.Lines(6).Lines
@@ -7174,7 +7174,7 @@ msgstr "Nuestras rayas y manchas son marcas de nacimiento naturales, ¡y parecen
 #: /Game/Dialogue/OrcChief/Default/OrcHadSex01.Default__OrcHadSex01_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",8608CD3E4A24FE889A9114BB9C69E23E"
 msgid "Human feel very good. Swallowed tons of cum hahaha!"
-msgstr "El humano se siente muy bien. ¡Tragaste toneladas de semen, jajaja!"
+msgstr "La humana se siente muy bien. ¡Tragaste toneladas de semen, jajaja!"
 
 #. Key:	86354AD5497243D13289CF9220240F60
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleDefault01_RL.Default__KybeleDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
@@ -7195,7 +7195,7 @@ msgstr "Dulce y deliciosa semilla humana, ¡déjala ir toda! Ahhh..."
 #: /Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToFemale(4).LinesToFemale
 msgctxt ",863C3850414A8A0B8C0C45907E4898EA"
 msgid "Oh... ah... yes! Human... ohhhh."
-msgstr "¡Oh... ah... sí! Humano... ohhhh."
+msgstr "¡Oh... ah... sí! Humana... ohhhh."
 
 #. Key:	86705CF240B11C01C39F05BA7F02F512
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R02.Default__FaleneDefault01_R02_C.SessionData.Lines(15).Lines
@@ -7356,7 +7356,7 @@ msgstr "Pfff, puedo manejar una poni tetuda."
 #: /Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(5).Lines
 msgctxt ",889D5D974E2DA932F5EAC7B50EC85E50"
 msgid "What do I do with the milk I buy?"
-msgstr "¿Ké hago con la leshe ke compro?"
+msgstr "¿Qué hago con la leche que compro?"
 
 #. Key:	88B965E0435F9EAD252E91913254E01A
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R04.Default__FaleneDefault01_R04_C.SessionData.Lines(1).Lines
@@ -7419,7 +7419,7 @@ msgstr "Deseas sentir mi música, lo sabía."
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",89AD310E47680E241C7AEEB5C24A9E59"
 msgid "A chance to mate with a human is making my hearts pound, and my tentacles slick..."
-msgstr "Una oportunidad de aparearme con un humano está haciendo que mi corazón se acelere y que mis tentáculos resbalen..."
+msgstr "Una oportunidad de aparearme con una humana está haciendo que mis corazones se aceleren y que mis tentáculos resbalen..."
 
 #. Key:	89B96FEA426FD3ECBA90259F724E6DF2
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadCherryHelp.Default__DryadCherryHelp_C.SessionData.LinesToFemale(2).LinesToFemale
@@ -7603,7 +7603,7 @@ msgstr "Una vez que los serafines comenzaron a propagarse, la Diosa les ordenó 
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToMale(2).LinesToMale
 msgctxt ",8CD67FB74B2E43F406AB5B932B717B19"
 msgid "A chance to mate with a human is making my hearts pound, and my tentacles slick..."
-msgstr "Una oportunidad de aparearme con un humano está haciendo que mi corazón se acelere y que mis tentáculos resbalen..."
+msgstr "Una oportunidad de aparearme con un humano está haciendo que mis corazones se aceleren y que mis tentáculos resbalen..."
 
 #. Key:	8CDBFE6141B0505672CA5BAAD842B1B4
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeAboutBees.Default__BeeAboutBees_C.SessionData.Lines(4).Lines
@@ -7736,7 +7736,7 @@ msgstr "*Sorbe* *Lame*"
 #: /Game/Dialogue/AmberMae/Default/AmberMaeDefault01.Default__AmberMaeDefault01_C.SessionData.Lines(2).Lines
 msgctxt ",8F1A20C3401841EB835DBDA94858E823"
 msgid "Oh, mayhaps tis milk ye want?"
-msgstr "Oh, ¿tar veh es leshe lo que kiereh?"
+msgstr "Oh, ¿tal vez es leche lo que quieres?"
 
 #. Key:	8F8279FC4A2E364B7CE585981E0279EF
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.SeraphimLoft.ManageActionMessage
@@ -7935,7 +7935,7 @@ msgstr "Oh, ¿el viejo templo?"
 #: /Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToMale(3).LinesToMale
 msgctxt ",92E3821949A8C289A4AAFCA4103F1915"
 msgid "Yes! Ohhhh, so big... keep going human! Ahh..."
-msgstr "¡Si! Ohhhh, tan grande... ¡sigue así, humano! Ahh..."
+msgstr "¡Si! Ohhhh, que grande... ¡sigue así, humano! Ahh..."
 
 #. Key:	92E810794E27E1F318AD0C9D4701705B
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDefault01_Meow.Default__CassieDefault01_Meow_C.SessionData.LinesToFuta(5).LinesToFuta
@@ -8154,7 +8154,7 @@ msgstr "Soy una alraune en crecimiento, ¿tal vez te sobran fluidos?"
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToFuta(4).LinesToFuta
 msgctxt ",960E85EF4CA91DAAA4DCFF93B84D183E"
 msgid "Imagine all of the places you could slide your dick in human... and I promise I would make them all feel so good..."
-msgstr "Imagina todos los lugares en los que podrías deslizar tu pene dentro, humano... y te prometo que te harán sentir tan bien..."
+msgstr "Imagina todos los lugares en los que podrías deslizar tu pene dentro, humana... y te prometo que te harán sentir tan bien..."
 
 #. Key:	96151D60454DB0FB521DD6A507DA6C07
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_Forgot_RL.Default__ParvatiDefault01_Forgot_RL_C.ResponseData(2).ResponseData.BreederPrompt
@@ -8210,7 +8210,7 @@ msgstr "La llegada de la Emisaria es un presagio, debemos unir nuestras almas en
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_StartSnatchF.Default__MirruDefault01_StartSnatchF_C.SessionData.Lines(0).Lines
 msgctxt ",96CB06FD409452A1B37913AA11EB845B"
 msgid "Ahhh... come here human!"
-msgstr "Ahhh... ¡ven aquí, humano!"
+msgstr "Ahhh... ¡ven aquí, humana!"
 
 #. Key:	96D35D8C41748461CFD8F9A9404E42B5
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToFemale(2).LinesToFemale
@@ -8323,7 +8323,7 @@ msgstr "¡Más miel!"
 #: /Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFemale(8).LinesToFemale
 msgctxt ",97E4D09B44D082B3154FEE94A88EE112"
 msgid "That must have been you, perhaps you should go and talk to her."
-msgstr "Ese debes haber sido tú, quizás deberías ir a hablar con ella."
+msgstr "Esa debes haber sido tú, quizás deberías ir a hablar con ella."
 
 #. Key:	9823997B4369C9710C0858A44B670A9D
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_RL.Default__CamillaDefault01_RL_C.ResponseData(4).ResponseData.BreederPrompt
@@ -8526,7 +8526,7 @@ msgstr "La descendencia de la Matriarca Dragón será protegida por cualquier me
 #: /Game/Dialogue/AmberMae/Default/AmberMaeHadSex01.Default__AmberMaeHadSex01_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",9BDBC0EB4511337E7515C89A6620BBA0"
 msgid "Come back and drink up anytime."
-msgstr "Vuerve y bebela cuando kierah."
+msgstr "Vuelve y bébela cuando quieras."
 
 #. Key:	9BF2AD09410781A66302329DB25BA0EC
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_Forgot.Default__ParvatiDefault01_Forgot_C.SessionData.Lines(5).Lines
@@ -8547,7 +8547,7 @@ msgstr "¡La raza dragón reinará sobre toda @WORLD_NAME@!"
 #: /Game/Dialogue/Fesssi/Default/FesssiHadSex01.Default__FesssiHadSex01_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",9C25CF834B78D0D105D4C98D2D869441"
 msgid "Sssso tasty. Hiss!"
-msgstr "Tan ssssabroso. ¡Sss!"
+msgstr "Que ssssabroso. ¡Sss!"
 
 #. Key:	9C2CBDE44BB47D22C9F6A5AFB2316748
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcDefault01.Default__OrcDefault01_C.SessionData.Lines(3).Lines
@@ -8726,7 +8726,9 @@ msgstr "Inmenso: aproximadamente 15 pies (4,5 m) de altura."
 #: /Game/Dialogue/Kybele/Default/KybeleTittyPony_T.Default__KybeleTittyPony_T_C.SessionData.LinesToFuta(0).LinesToFuta
 msgctxt ",9F883FFA4CA5D4B34A5726989E26C6C5"
 msgid "That's it human, you have annoyed me long enough. Get against that rock and prepare to be smashed."
-msgstr "Eso es, humano, me has molestado lo suficiente. Ponte contra esa roca y prepárate para ser aplastado."
+msgstr ""
+"Eso es, humana, me has molestado lo suficiente. Ponte contra esa roca y prepárate para ser aplastada\n"
+"."
 
 #. Key:	9F8F75924886323A16353D90FDCB1B1C
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernBeeFlowers.Default__FernBeeFlowers_C.SessionData.Lines(0).Lines
@@ -8768,7 +8770,7 @@ msgstr "Sabía que a los humanos les gustaba sentir este poderoso cuerpo."
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(20).LinesToFemale
 msgctxt ",9FE7AADC4372F0B32E971C838E6554EA"
 msgid "Since you're a breeder, it's your job to catch and mate as many @MONSTER_RACE@ as possible!"
-msgstr "Ya que eres un criador, ¡es tu trabajo atrapar y aparearte con tantos @MONSTER_RACE@ como sea posible!"
+msgstr "Ya que eres una criadora, ¡es tu trabajo atrapar y aparearte con tantos @MONSTER_RACE@ como sea posible!"
 
 #. Key:	9FF8B7CE43E6A9321DDB60919962BBB7
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(17).LinesToMale
@@ -8859,7 +8861,7 @@ msgstr "Granero de Nephelym"
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(28).LinesToFemale
 msgctxt ",A2DA50B44D0A24E096AF488F787D4928"
 msgid "Well I must be off, good luck breeder!"
-msgstr "Bueno, debo irme, ¡buena suerte criador!"
+msgstr "Bueno, debo irme, ¡buena suerte criadora!"
 
 #. Key:	A2EE900942F55DC4C6AA92BC44E482E4
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R03.Default__CamillaDefault01_R03_C.SessionData.Lines(2).Lines
@@ -9112,7 +9114,7 @@ msgstr "¿Cuál es el origen del nombre \"@MONSTER_RACE@\"?"
 #: /Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToFuta(4).LinesToFuta
 msgctxt ",A87432C446A6D9C7528A67B94431B712"
 msgid "Mmmm... so hard! Ohhh... ahhh!"
-msgstr "Mmmm... ¡tan duro! ¡Ohhh... ahhh!"
+msgstr "Mmmm... ¡que duro! ¡Ohhh... ahhh!"
 
 #. Key:	A897C9924C36C6F2E58C379611A2B01C
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R05.Default__FaleneDefault01_R05_C.SessionData.Lines(0).Lines
@@ -9441,7 +9443,7 @@ msgstr "¡Te espera un mundo de sexo y aventuras!"
 #: /Game/Dialogue/DragonMatriarch/Default/DMYourChildren.Default__DMYourChildren_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",AE940C0E4203F3605E98088D0827EA0B"
 msgid "Believe me human, I have sired many offspring."
-msgstr "Créeme, humano, he dado a luz a muchos descendientes."
+msgstr "Créeme, humana, he dado a luz a muchos descendientes."
 
 #. Key:	AE9DC6E246625CE553B669ADBD1EB570
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDefault01_Meow_RL_F.Default__CassieDefault01_Meow_RL_F_C.ResponseData(0).ResponseData.BreederPrompt
@@ -9604,7 +9606,7 @@ msgstr "¡Él me habla! Historias tan maravillosas sobre sus aventuras rodando p
 #: /Game/Dialogue/AmberMae/Default/AmberMaeDefault01_Accent.Default__AmberMaeDefault01_Accent_C.SessionData.Lines(1).Lines
 msgctxt ",B1A4C4984540058620CA09A3FC603DBE"
 msgid "Hail from the Northern Isles I do! Aye what a beauty 'mai homeland is..."
-msgstr "¡Sarve dehde lah Irlah der Norte! Seh, qué bellesa eh mi tierra natah..."
+msgstr "¡Salve desde las Islas del Norte! Seh, qué bella es mi tierra natal..."
 
 #. Key:	B1BCFA034FBA8483F5D2578BABDDE685
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(27).LinesToMale
@@ -9618,7 +9620,7 @@ msgstr "Te amamos demasiado y, a veces, ¡nuestros deseos se descontrolan!"
 #: /Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(1).Lines
 msgctxt ",B1BEC3C54841F5611ED8E1A3547AD05F"
 msgid "Awww! I could just squeeze ye between 'mai jugs 'til ye climax!"
-msgstr "¡Ammm! ¡Podría zimpremente ehtrujahte entre mih cántaroh de leshe hahta ke llegueh ar clímah!"
+msgstr "¡Ammm! ¡Podría estrujarte entre mis cántaros de leche hasta que llegues al clímax!"
 
 #. Key:	B1E706104468BBBC8C481498B5352B8D
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaHadSex01.Default__LeylannaHadSex01_C.SessionData.LinesToFemale(2).LinesToFemale
@@ -9654,7 +9656,7 @@ msgstr "La cueva conduce a las Reliquias Amorosas. ¡Sss!"
 #: /Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(7).Lines
 msgctxt ",B2323665415F7EE8A74204A9FD52D914"
 msgid "Ye can consider me a connoisseur of @MONSTER_RACE@ milk. Each race's milk has a distinct and delicious flavor, so it is."
-msgstr "Puedeh considerahme una conosedora de la leshe @MONSTER_RACE@. La leshe de cada rasa tiene un zaboh dihtinto y derisiozo, asín eh."
+msgstr "Puedes considerarme una conocedora de la leche @MONSTER_RACE@. La leche de cada raza tiene un sabor distinto y delicioso, así es."
 
 #. Key:	B235542C44D65B1D62C721A3C4CD289F
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_StartForgotten.Default__ParvatiDefault01_StartForgotten_C.SessionData.Lines(2).Lines
@@ -9682,7 +9684,7 @@ msgstr "Mi culo es producto de años de trabajo \"duro\"."
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFuta(1).LinesToFuta
 msgctxt ",B2DF6AC642DDC3C552F43290DCBE4EA7"
 msgid "A human! A super cute human... this is my lucky day. I've been waiting for this phenomenon for... huh. Well as long as I can remember!"
-msgstr "¡Un humano! Un humano super lindo... este es mi día de suerte. He estado esperando este fenómeno desde... eh. Bueno, ¡desde que puedo recordar!"
+msgstr "¡Una humana! Una humana super linda... este es mi día de suerte. He estado esperando este fenómeno desde... eh. Bueno, ¡desde que puedo recordar!"
 
 #. Key:	B2E660614B8D73E10C0B2194E4C87529
 #. SourceLocation:	/Game/Ranch/Upgrades/HarpyAviary.Default__HarpyAviary_C.Upgrade.DisplayName
@@ -9809,7 +9811,7 @@ msgstr "Ah, pequeño... ahora eres mío. No temas, pues solo deseo complacer."
 #: /Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(10).Lines
 msgctxt ",B5B8312540B0C71F1DDBCEADEF6C3E02"
 msgid "I meant what I said about ye between 'mai jugs. Mayhaps we can have a li'l fun in the future?"
-msgstr "Kise desih lo ke dije zobre ti entre mih cántaroh de leshe. ¿Kisáh poamoh divertirnoh un poko en er futuro?"
+msgstr "Me refería a lo que dije sobre ti entre mis cántaros de leche. ¿Tal vez podamos divertirnos un poco en el futuro?"
 
 #. Key:	B5C876DA4DBA230757C412BE4612735C
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcHaveKeystone.Default__OrcHaveKeystone_C.SessionData.Lines(4).Lines
@@ -9893,7 +9895,7 @@ msgstr "Puedo sentir las raíces de muchas flores de cuminus, pero no de ejaculu
 #: /Game/Dialogue/AmberMae/Default/AmberMaeDefault01_SuckJugs.Default__AmberMaeDefault01_SuckJugs_C.SessionData.Lines(0).Lines
 msgctxt ",B740BA7F4ADFB18E32DFE99606B483B3"
 msgid "Bless me for say'n so, but I was wish'n you'd ask that!"
-msgstr "Bendíseme poh desirlo, ¡pero ehtaba dezeando ke me preguntarah ezo!"
+msgstr "Bendíceme por decirlo, ¡pero estaba deseando que me preguntaras eso!"
 
 #. Key:	B792D83B44DC1E7BF9DAE08B4D4A3E70
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_UpHere.Default__RomyDefault01_UpHere_C.SessionData.Lines(0).Lines
@@ -9935,7 +9937,7 @@ msgstr "Ah, la roca brillante atrapada en mi telaraña."
 #: /Game/Dialogue/Camilla/Default/CamillaHadSex02.Default__CamillaHadSex02_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",B7A8AD6E44A41AB54281548D1A882FFC"
 msgid "Wow human, you must have been desperate to give this nugget your love."
-msgstr "Guau, humano, debes haber estado desesperado para darle a esta pepita tu amor."
+msgstr "Guau, humana, debes haber estado desesperada para darle a esta pepita tu amor."
 
 #. Key:	B7AB851641C9ABEE4A178B9DFFD50B0B
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(33 - Value).TraitIcons.DisplayName
@@ -10112,7 +10114,7 @@ msgstr "Para cosecharla, una reina producirá hijas abejas obreras que luego mez
 #: /Game/Dialogue/Emissary/SexScenes/EmissaryAngelGroinLove.Default__EmissaryAngelGroinLove_C.SessionData.LinesToFuta(0).LinesToFuta
 msgctxt ",B98DBFC944D984D0B00D708EE1B9AB94"
 msgid "Indulge yourself human, for I am thy servant."
-msgstr "Deléitate, humano, pues soy tu sirviente."
+msgstr "Deléitate, humana, pues soy tu sirviente."
 
 #. Key:	B9D395FA4457763F84E8BD94863D5FBD
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadFlowers.Default__DryadFlowers_C.SessionData.Lines(6).Lines
@@ -10224,7 +10226,7 @@ msgstr "Algo mítico... algo prohibido... algo... ¡humano!"
 #: /Game/Dialogue/AmberMae/SexScenes/AmberMilkyF.Default__AmberMilkyF_C.SessionData.Lines(5).Lines
 msgctxt ",BC8D18A04D5B0C96E407F884999310E6"
 msgid "Eeek I'm a sensitve gal! Yer gonna make me pop... ohhh."
-msgstr "¡Eeek, zoy una shica zenzibre! Me vah a aseh ehprotah... ohhh."
+msgstr "¡Eeek, soy una chica sensible! Me vas a reventar... ohhh."
 
 #. Key:	BCB1A0F54609C871293D96B90F2E8B8E
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_UpHere.Default__RomyDefault01_UpHere_C.SessionData.Lines(2).Lines
@@ -10301,7 +10303,7 @@ msgstr "Son para las ayrshires que deambulan por aquí, ¡y oh cielos, lo que pu
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",BDF9214F4D266A69032FE9921524969C"
 msgid "You have just become @WORLD_NAME@'s newest resident!"
-msgstr "¡Te acabas de convertir en el residente más nuevo de @WORLD_NAME@!"
+msgstr "¡Te acabas de convertir en la residente más nueva de @WORLD_NAME@!"
 
 #. Key:	BDFBF2444482EC9CA1B83B92138A12DD
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(35 - Value).TraitIcons.HelpText
@@ -10660,7 +10662,7 @@ msgstr "Maldigo a esa dríada, ella seguía trayendo su dulce fruta, y antes de 
 #: /Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon2.Default__AmberMaeLockedDungeon2_C.SessionData.Lines(4).Lines
 msgctxt ",C544F8824FC4DDC6DBEFE084C3987F32"
 msgid "How I miss the old days."
-msgstr "Cómo ehtraño los viejoh tiempoh."
+msgstr "Cómo extraño los viejos tiempos."
 
 #. Key:	C55370A04CAE38FD1D15A9AC46E99FBD
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaHadSex02.Default__CamillaHadSex02_C.SessionData.LinesToFemale(2).LinesToFemale
@@ -11006,7 +11008,7 @@ msgstr "Luego me poso seductoramente frente a lo que ella trajo, y ella registra
 #: /Game/Dialogue/AmberMae/Default/AmberMaeHadSex01.Default__AmberMaeHadSex01_C.SessionData.LinesToMale(0).LinesToMale
 msgctxt ",CCBE2DF04F273EE3D33DE583845CB545"
 msgid "Ye drank so much for a wee lad!"
-msgstr "¡Bebihte musho para un moso pekeñito!"
+msgstr "¡Bebiste muchísimo pa' un muchachito!"
 
 #. Key:	CCFE0CB04C0DD4BC550FE6AF03BFABB3
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R05.Default__FaleneDefault01_R05_C.SessionData.Lines(1).Lines
@@ -11437,7 +11439,7 @@ msgstr "Mira mi hermosa flor, ¡floreció! Oh cielos, se sintió raro..."
 #: /Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToFemale(6).LinesToFemale
 msgctxt ",D4B876E04002BC56FF720D829DA04785"
 msgid "Ahh... oh... so delicious."
-msgstr "Ahh... oh... tan delicioso."
+msgstr "Ahh... oh... que delicioso."
 
 #. Key:	D4BAFDEE4340A6062B18808C4CB9ABF1
 #. SourceLocation:	/Game/Dialogue/Mirru/SexScenes/MirruSnatchF.Default__MirruSnatchF_C.SessionData.Lines(4).Lines
@@ -11515,7 +11517,7 @@ msgstr "A diario sexo con Ella mentalmente he tenido."
 #: /Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToFuta(3).LinesToFuta
 msgctxt ",D5C1EFC54081F21A6C1F538839E450A2"
 msgid "Yes! Ohhhh, so big... keep going human! Ahh..."
-msgstr "¡Si! Ohhhh, tan grande... ¡sigue así, humano! Ahh..."
+msgstr "¡Si! Ohhhh, que grande... ¡sigue así, humana! Ahh..."
 
 #. Key:	D5CB7ED64FDBBF8094BDFE9F5271E39E
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_RL.Default__RomyDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
@@ -11746,7 +11748,7 @@ msgstr "*Ronronea*"
 #: /Game/Dialogue/AmberMae/Default/AmberMaeHadSex01.Default__AmberMaeHadSex01_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",D9124E55481B91E85A0884AA58197D19"
 msgid "'Mai milk was tasty aye? Plenty more where that came from!"
-msgstr "Mi leshe ehtaba zabrosa, ¿no? ¡Toavía queda musha máh!"
+msgstr "Mi leche estaba sabrosa, ¿no? ¡Todavía queda mucha más!"
 
 #. Key:	D913C6254D30AA08E8B01787AE3D1B68
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TravelShrines(4 - Value).TravelShrines.ShrineName
@@ -12006,14 +12008,14 @@ msgstr "Aún así... me complaciste como un semental. ¡Eso es asombroso para al
 #: /Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFemale(7).LinesToFemale
 msgctxt ",DC59A07E4D2FC78409E32EA7A64B7007"
 msgid "That creepy golden seraphim, the one in the temple. She appeared only a few days ago, constantly asking to speak with \"the human\"."
-msgstr "Esa espeluznante serafín dorada, la del templo. Ella apareció hace solo unos días, constantemente pidiendo hablar con \"el humano\"."
+msgstr "Esa espeluznante serafín dorada, la del templo. Ella apareció hace solo unos días, constantemente pidiendo hablar con \"la humana\"."
 
 #. Key:	DC843E8A4828B0881624D494C080BC2B
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeDefault01_SuckJugs.Default__AmberMaeDefault01_SuckJugs_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeDefault01_SuckJugs.Default__AmberMaeDefault01_SuckJugs_C.SessionData.Lines(1).Lines
 msgctxt ",DC843E8A4828B0881624D494C080BC2B"
 msgid "Awww... I'm blushing something heavy."
-msgstr "Ammm... me ehtoy zonrojahdo una barbaridah."
+msgstr "Ammm... me estoy sonrojando una barbaridad."
 
 #. Key:	DC85F26F423721D07495E3AB892F86CC
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R01.Default__FaleneDefault01_R01_C.SessionData.Lines(4).Lines
@@ -12027,7 +12029,7 @@ msgstr "Son muy diferentes a sus contrapartidas humanas."
 #: /Game/Dialogue/Mirru/SexScenes/MirruSnatchF.Default__MirruSnatchF_C.SessionData.Lines(0).Lines
 msgctxt ",DC880E904973CDED818EF58F9949FB40"
 msgid "Submit human... I cannot control my desires!"
-msgstr "Entrégate, humano... ¡no puedo controlar mis deseos!"
+msgstr "Entrégate, humana... ¡no puedo controlar mis deseos!"
 
 #. Key:	DC956C0949E5CA05486F1583CEACA3ED
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(24 - Value).TraitIcons.DisplayName
@@ -12266,7 +12268,7 @@ msgstr "..."
 #: /Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon.Default__AmberMaeLockedDungeon_C.SessionData.Lines(1).Lines
 msgctxt ",E17B89624E06BB5038FB7A90A70FFD12"
 msgid "As Hedon's oldest citizen, I remember trying to fit in there ages ago."
-msgstr "Como la ziudadana máh antirgua de Hedon, recuehdo habeh intentao cabeh allí hase musho tiempo."
+msgstr "Como la ciudadana más antigua de Hedon, hace mucho tiempo recuerdo haber intentao caber allí."
 
 #. Key:	E1AA64794D412D85279E1C928CB75EFF
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_RL.Default__FaleneDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
@@ -12294,7 +12296,7 @@ msgstr "¡Ahh... ohhhh... sí! Por favor, ambas puntas de mis tentáculos..."
 #: /Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon.Default__AmberMaeLockedDungeon_C.SessionData.Lines(3).Lines
 msgctxt ",E1FD0C3A455475E0E474A0A50646DBA8"
 msgid "Once they built that new temple, the door was sealed... golly 'twas well over 1000 years ago now."
-msgstr "Una veh ke cohtruyeron ese nuervo templo, la puerta fue sellaa... Caramba, fue hase máh de 1000 añoh."
+msgstr "Una vez que construyeron ese nuevo templo, la puerta fue sella'... Caramba, fue hace más de 1000 años."
 
 #. Key:	E20511A746C7BFEF4C46D5A2F2586CD0
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(28 - Value).TraitIcons.HelpText
@@ -12351,14 +12353,14 @@ msgstr "Eso debería enseñarte a cruzarte con esta poni tet-: ¡otra vez, me re
 #: /Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",E29F5BAA40F6C8758245C58555D4F73E"
 msgid "Ahhhh, your fingers are magical, go deeper! Deeper human, oh yesss."
-msgstr "Ahhhh, tus dedos son mágicos, ¡ve más profundo! Humano, más profundo, oh sííí."
+msgstr "Ahhhh, tus dedos son mágicos, ¡ve más profundo! Humana, más profundo, oh sííí."
 
 #. Key:	E2D78DC6488712103CF0A59E6DE95E47
 #. SourceLocation:	/Game/Dialogue/AmberMae/SexScenes/AmberMilkyF.Default__AmberMilkyF_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/AmberMae/SexScenes/AmberMilkyF.Default__AmberMilkyF_C.SessionData.Lines(1).Lines
 msgctxt ",E2D78DC6488712103CF0A59E6DE95E47"
 msgid "Oh yer hand feels so good. Don't stop strok'n me box!"
-msgstr "Oh, tu mano ze ziente tan bien. ¡No dejeh de acariziarme er ehtushe!"
+msgstr "Oh, tu mano se siente tan bien. ¡No dejes de acariciarme el estuche!"
 
 #. Key:	E2F13B714EEE6046C9069A8F6F71DA0B
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMAboutDragons.Default__DMAboutDragons_C.SessionData.Lines(5).Lines
@@ -12612,7 +12614,7 @@ msgstr "Los elfos silvestres no son tan comunes como otros @MONSTER_RACE@, los e
 #: /Game/Ranch/Upgrades/DragonHoard.Default__DragonHoard_C.Upgrade.DisplayName
 msgctxt ",E6EFAF84489D0FE3730843AEC3483A12"
 msgid "Dragon Hoard"
-msgstr "Tesoro Escondido del Dragón"
+msgstr "Tesoro Oculto de Dragones"
 
 #. Key:	E71D6B9A4400127440C060AAD55FB07B
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiWantAss.Default__FesssiWantAss_C.SessionData.Lines(0).Lines
@@ -12931,7 +12933,7 @@ msgstr "Arrodíllate ante tu reina... ahhh... ohhh..."
 #: /Game/Dialogue/Neela/SexScenes/NeelaSnakeCuddleF.Default__NeelaSnakeCuddleF_C.SessionData.Lines(4).Lines
 msgctxt ",EC9757E141CD427BCC7326B974A16B82"
 msgid "Oh human, your thighs are soft... ahhh..."
-msgstr "Oh, humano, tus muslos son suaves... ahhh..."
+msgstr "Oh, humana, tus muslos son suaves... ahhh..."
 
 #. Key:	ECA6FC524716FE3EA1D0A181491FCFC8
 #. SourceLocation:	/Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToFemale(0).LinesToFemale
@@ -13248,7 +13250,7 @@ msgstr "Entonces los @MONSTER_RACE@ son realmente cachondos..."
 #: /Game/Dialogue/AmberMae/Default/AmberMaeHadSex01.Default__AmberMaeHadSex01_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",F2106FBD47C33358DD8CBE9C4F4ABE40"
 msgid "Ahhh... I sure do appreciate tak'n yer time to please this old milkmaid."
-msgstr "Ahhh... rearmente apresio que te tomeh tu tiempo para compraseh a ehta vieja leshera."
+msgstr "Ahhh... realmente aprecio que te tomes tu tiempo pa' complacer a esta vieja lechera."
 
 #. Key:	F21C5AFA463E6FCE44980EAAEE23498C
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchDefault01_RL.Default__MonarchDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
@@ -13444,7 +13446,7 @@ msgstr "¡Los @MONSTER_RACE@ que atrapes no serán bendecidos como yo!"
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToFuta(0).LinesToFuta
 msgctxt ",F7A6401147093A75B20588870BFA39C7"
 msgid "Careful human, a Kraken's lust is not to be underestimated."
-msgstr "Cuidado, humano, la lujuria de un kraken no debe ser subestimada."
+msgstr "Cuidado, humana, la lujuria de un kraken no debe ser subestimada."
 
 #. Key:	F7B920EC4CAAD4CD4E61C8915489F45C
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiIdiots.Default__FesssiIdiots_C.SessionData.Lines(3).Lines
@@ -13600,7 +13602,7 @@ msgstr "¡¡Y yo tengo!! Durante casi 1000 años, aquí abajo todo para mi misma
 #: /Game/Dialogue/AmberMae/Default/AmberMaeDefault01_MilkyProducts.Default__AmberMaeDefault01_MilkyProducts_C.SessionData.Lines(0).Lines
 msgctxt ",FAA5B41940157F8963E69CB4ACE814A4"
 msgid "Indulge yerself in 'mai milk!"
-msgstr "¡Deréitate con mi leshe!"
+msgstr "¡Deléitate con mi leche!"
 
 #. Key:	FAA922F744CCD015043333AD26B1B5AF
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03_RL_F.Default__FernDefault03_RL_F_C.ResponseData(1).ResponseData.BreederPrompt
@@ -13684,7 +13686,7 @@ msgstr "¡Ahh... se siente tan bien! Me voy a correr."
 #: /Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(6).Lines
 msgctxt ",FB8D2D144CB9249F47237B94F66E71F1"
 msgid "Why I drink it and use it to make magic treats of course! I ain't a wee lass mind you--I drink lots o' the stuff! Also, me treats are famous world wide!"
-msgstr "¡Pueh la bebo y la uso para haceh derisiah mágicah, poh zupuehto! No zoy una mosa pekeñita zabeh: ¡bebo mushah cosah! ¡Ademáh, mih derisiah zon famozah en to' er mundo!"
+msgstr "¡Pues la bebo y la uso para hacer delicias mágicas, por supuesto! No soy una niñita sabes: ¡bebo muchas cosas! ¡Además, mis delicias son famosas en to' el mundo!"
 
 #. Key:	FBA6175C45D9F4E3E3CD7F85021561C6
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_Pregnancy.Default__FaleneDefault01_Pregnancy_C.SessionData.Lines(0).Lines

--- a/spanish.po
+++ b/spanish.po
@@ -4,15 +4,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Radiant\n"
 "POT-Creation-Date: 2021-06-14 02:04\n"
-"PO-Revision-Date: 2021-12-01 00:25+0100\n"
+"PO-Revision-Date: 2021-12-13 19:14+0100\n"
+"Last-Translator: \n"
 "Language-Team: \n"
 "Language: es_ES\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Last-Translator: \n"
-"X-Generator: Poedit 3.0\n"
+"X-Generator: Poedit 3.0.1\n"
 
 #. Key:	0009BEE346934010A7F79C8CF23B20D5
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03_R02.Default__FernDefault03_R02_C.SessionData.Lines(1).Lines
@@ -209,7 +209,7 @@ msgstr "¿Por qué me llamaste, Master?"
 #: /Game/Dialogue/Cassie/SexScenes/CassieSplintersT.Default__CassieSplintersT_C.SessionData.Lines(3).Lines
 msgctxt ",03FDE484412EB5432BA89A9FF52176AD"
 msgid "Meow! It feels so good! I'm going to get kitty cum all over myself!"
-msgstr "¡Miau! ¡Se siente tan bien! ¡Voy a hacer que el gatito se corra por todas partes!"
+msgstr "¡Miau! ¡Se siente tan bien! ¡Voy a hacer que la gatita se corra por todas partes!"
 
 #. Key:	0417FF204F76BA02C95525915D7673A9
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowKeystone.Default__WidowKeystone_C.SessionData.Lines(1).Lines
@@ -244,7 +244,7 @@ msgstr "¡Dejaré tu rancho pronto! Pero no te preocupes, puedes encontrarme en 
 #: /Game/Dialogue/QueenBee/Default/BeeHaveKeystone.Default__BeeHaveKeystone_C.SessionData.Lines(0).Lines
 msgctxt ",047A2B2C4D533C816757C8B486F04CC0"
 msgid "Of course not. It's been a symbol of my hive for ages."
-msgstr "Por supuesto no. Ha sido un símbolo de mi colmena durante años."
+msgstr "Por supuesto que no. Ha sido un símbolo de mi colmena durante años."
 
 #. Key:	04809803498EAC7920E3F09D8A29F0BF
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernGreeting01.Default__FernGreeting01_C.SessionData.Lines(4).Lines
@@ -293,7 +293,7 @@ msgstr "Háblame de las lamias."
 #: /Game/Dialogue/QueenBee/Default/BeeTaskFulfilled.Default__BeeTaskFulfilled_C.SessionData.Lines(0).Lines
 msgctxt ",0529D0BB4C3047950C7EE496E1F0E5BC"
 msgid "Rejoice, for the flowers have returned!"
-msgstr "¡Alégrate, porque las flores han vuelto!"
+msgstr "¡Alégrate, las flores han vuelto!"
 
 #. Key:	0559493D46F48B86A2683FB3AC087112
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_FutaBalls.Default__CamillaDefault01_FutaBalls_C.SessionData.Lines(0).Lines
@@ -356,7 +356,7 @@ msgstr "¡Fern ayuda a Mastah! ¡Fern recolecta fluidossss para ti!"
 #: /Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(8).Lines
 msgctxt ",06F45D04453307E37897C89FC16861F0"
 msgid "Well, I'm sure you best be get'n off!"
-msgstr "Bueno ¡ehtoy segura de que eh mejoh que te vayah!"
+msgstr "Bueno, ¡ehtoy segura de que eh mejoh que te vayah!"
 
 #. Key:	070169104C3375DAB052E18982B50AE4
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(3).LinesToMale
@@ -370,7 +370,7 @@ msgstr "Este mundo es el hogar de los @MONSTER_RACE@, una raza enigmática de h�
 #: /Game/Dialogue/Autumn/Default/DryadBossomCherries.Default__DryadBossomCherries_C.SessionData.Lines(3).Lines
 msgctxt ",07035EA54B778F47897F278270889BBF"
 msgid "Aww... it's so adorable watching them figure out how to reach the fruit on the high branches."
-msgstr "Amm... es tan adorable verlos descubrir cómo alcanzar la fruta en las ramas altas."
+msgstr "Amm... es tan adorable verlas descubrir cómo alcanzar la fruta en las ramas altas."
 
 #. Key:	075A16DA4BA7F51C3A07099921F7F1B3
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyHadSex01.Default__RomyHadSex01_C.SessionData.LinesGrungy(1).LinesGrungy
@@ -419,7 +419,7 @@ msgstr "¡Puedes tener mi semen!"
 #: /Game/Dialogue/OrcChief/Default/OrcDefault03_RL.Default__OrcDefault03_RL_C.ResponseData(4).ResponseData.BreederPrompt
 msgctxt ",085EF70E45D784AFAEFB07BC461A23D9"
 msgid "Are all orcs as brash and dumb as you?"
-msgstr "¿Son todos los orcos tan impetuosos y tontos como tú?"
+msgstr "¿Todos los orcos son tan impetuosos y tontos como tú?"
 
 #. Key:	08A1991945921B46D9EF9A94894EF846
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeDefault01.Default__BeeDefault01_C.SessionData.LinesToMale(0).LinesToMale
@@ -552,7 +552,7 @@ msgstr "Pasemos el día juntos, porque aquí, en el calor de esta agua, podemos 
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",0BB0A695454FD69DAA129F82F023EB23"
 msgid "A human! A super cute human, this is my lucky day. I've been waiting for this phenomenon for... huh. Well as long as I can remember!"
-msgstr "¡Una humana! Una humana super linda... este es mi día de suerte. He estado esperando este fenómeno desde... eh, bueno, ¡desde que puedo recordarlo!"
+msgstr "¡Una humana! Una humana super linda, este es mi día de suerte. He estado esperando este fenómeno desde... eh. Bueno, ¡desde que puedo recordar!"
 
 #. Key:	0BBD00B64AD7488CC6A8008C2BAF8B41
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.VulwargKennel.ManageActionMessage
@@ -566,7 +566,7 @@ msgstr "Gestiona tus Vulwargs"
 #: /Game/Dialogue/Widow/Default/WidowKeystone.Default__WidowKeystone_C.SessionData.Lines(4).Lines
 msgctxt ",0BC94BF94437671AAC651EBA39693570"
 msgid "Long I have wished to taste an elf, but they never come up this way."
-msgstr "Hace mucho que deseaba probar una elfa, pero nunca vienen de esta manera."
+msgstr "Hace mucho que deseaba probar un elfo, pero nunca vienen de esta manera."
 
 #. Key:	0BD52B434C91C8F5172BC0BB8C1B00BA
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_Leylanna.Default__EmissaryDefault01_Leylanna_C.SessionData.Lines(0).Lines
@@ -700,7 +700,7 @@ msgstr "Ninfómano"
 #: /Game/Dialogue/Parvati/Default/ParvatiHadSex01.Default__ParvatiHadSex01_C.SessionData.Lines(3).Lines
 msgctxt ",0E3AF3704D88CDB26D17458852A1792E"
 msgid "Using our bodies in ways all too perverse."
-msgstr "Utilizando nuestros cuerpos de formas demasiado perversas."
+msgstr "Usando nuestros cuerpos de formas demasiado perversas."
 
 #. Key:	0E4B3CBA440B587A805453A5FAC01859
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDungeon2.Default__CassieDungeon2_C.SessionData.Lines(1).Lines
@@ -820,7 +820,7 @@ msgstr "Ahhhh..."
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFuta(30).LinesToFuta
 msgctxt ",1019EEE14B67704DE6DE0B9FD7D0D596"
 msgid "If you want to learn about how to catch @MONSTER_RACE@, head to the town located up the plateau ahead and speak to my assistant Camilla. You can't miss her... actually wait you might, she's so tiny and cute hehehe."
-msgstr "Si quieres aprender cómo atrapar @MONSTER_RACE@, dirígete a la ciudad ubicada en la meseta más adelante y habla con mi asistente Camilla. No puedes perderla... en realidad, espera, es posible, es tan pequeña y linda jejeje."
+msgstr "Si quieres aprender cómo atrapar @MONSTER_RACE@, dirígete a la ciudad ubicada en la meseta más adelante y habla con mi asistente Camilla. No puedes fallarle... en realidad, espera, es posible, es tan pequeña y linda jejeje."
 
 #. Key:	106EA6A747A0901892BD12A925DA79A5
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy_RL_F.Default__MirruDefault01_BodySexToy_RL_F_C.ResponseData(0).ResponseData.BreederPrompt
@@ -918,7 +918,7 @@ msgstr "Mete ese encantador pene humano profundamente en mi cuerpo de lamia... s
 #: /Game/World/Overworld.Overworld:PersistentLevel.CBGate_Jungle.PlaceMessage
 msgctxt ",11A9B90644E91677CD9DEFB4CC831C2C"
 msgid "Sultry Plateau is now accessible."
-msgstr "La Meseta Sensual ahora es accesible."
+msgstr "La Meseta Bochornosa ahora es accesible."
 
 #. Key:	11B6FBE746EB52494E5B6E83052E0D98
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiCave.Default__FesssiCave_C.SessionData.Lines(4).Lines
@@ -939,7 +939,7 @@ msgstr "¿Puedo... montarte?"
 #: /Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon2.Default__AmberMaeLockedDungeon2_C.SessionData.Lines(2).Lines
 msgctxt ",11C0FBB845185DFCD5E67DA5B758B432"
 msgid "At me peak I could barely walk! The jugs 'an belly were mighty heavy."
-msgstr "¡En mi pico apenah podía caminar! Loh cántaroh de leshe y la barriga pesaban muchísimo."
+msgstr "¡En mi cumbre apenah podía caminar! Loh cántaroh de leshe y la barriga pesaban muchísimo."
 
 #. Key:	12036FB64912193341380BA267A64971
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernGreeting03.Default__FernGreeting03_C.SessionData.LinesToFemale(4).LinesToFemale
@@ -968,7 +968,7 @@ msgstr "¡Realmente somos buscadores de placer en el corazón!"
 #: [Script Bytecode]
 msgctxt ",1276E5EB4781A0238A9705AC9FEE680E"
 msgid "Keystone acquired."
-msgstr "Piedra-llave adquirida."
+msgstr "Keystone adquirida."
 
 #. Key:	129A33314E1BA60BA7698394A0DEDCD7
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieHadSex01.Default__CassieHadSex01_C.SessionData.LinesToFuta(3).LinesToFuta
@@ -1045,7 +1045,7 @@ msgstr "¿Qué es el Vacío?"
 #: /Game/Dialogue/OrcChief/Default/OrcAkabekoCheck.Default__OrcAkabekoCheck_C.SessionData.Lines(4).Lines
 msgctxt ",13523F8143CE0377FC6658A757678D38"
 msgid "Take stupid keystone if you haven't already."
-msgstr "Toma la estúpida piedra-llave si aún no lo has hecho."
+msgstr "Toma la estúpida Keystone si aún no lo has hecho."
 
 #. Key:	1375B52C45BC0C13C5B21D954838AE4B
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchQueen.Default__MonarchQueen_C.SessionData.Lines(3).Lines
@@ -1094,7 +1094,7 @@ msgstr "Tú eres... el que complació a madre Fern."
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_FloatRhyme.Default__ParvatiDefault01_FloatRhyme_C.SessionData.Lines(3).Lines
 msgctxt ",1494AA5040692D75A2E458AE890541FA"
 msgid "Allow me to show you what She shared, if I may."
-msgstr "Permítame mostrarte lo que Ella compartió, si se me permite."
+msgstr "Permíteme mostrarte lo que Ella compartió, si me permites."
 
 #. Key:	1495FB154E5C773C51452295CAF9F467
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R02.Default__FaleneDefault01_R02_C.SessionData.Lines(10).Lines
@@ -1115,7 +1115,7 @@ msgstr "Quítate tus prendas, debes estar desnuda."
 #: /Game/Dialogue/Neela/Default/NeelaGreeting01.Default__NeelaGreeting01_C.SessionData.Lines(1).Lines
 msgctxt ",14F5C7E34772BFD4F5E7039EF72ACF9E"
 msgid "Through all of my long years and endless travels, I never thought to cross paths with a human."
-msgstr "A través de todos mis largos años y viajes interminables, nunca pensé cruzarme con un humano."
+msgstr "A través de todos mis largos años y viajes interminables, nunca pensé en cruzarme con un humano."
 
 #. Key:	1558B86B4DAABB7D51D53FB9D3508EBD
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiCave.Default__FesssiCave_C.SessionData.Lines(5).Lines
@@ -1333,14 +1333,14 @@ msgstr "Buscas aprender una nueva forma de usar un agujero del placer."
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_Formuria.Default__MirruDefault01_Formuria_C.SessionData.Lines(4).Lines
 msgctxt ",1AF544224BFAECD89C2CE99B8EE6EB2D"
 msgid "It is custom for future queens to make pilgrimage to the dry lands and..."
-msgstr "Es costumbre que las futuras reinas peregrinen a suelo firme y..."
+msgstr "Es costumbre que las futuras reinas peregrinen a tierra firme y..."
 
 #. Key:	1B5A3D3E4B34533CC5E7E599C01B1A38
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(30).LinesToFemale
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(30).LinesToFemale
 msgctxt ",1B5A3D3E4B34533CC5E7E599C01B1A38"
 msgid "If you want to learn about how to catch @MONSTER_RACE@, head to the town located up the plateau ahead and speak to my assistant Camilla. You can't miss her... actually wait you might, she's so tiny and cute hehehe."
-msgstr "Si quieres aprender cómo atrapar @MONSTER_RACE@, dirígete a la ciudad ubicada en la meseta más adelante y habla con mi asistente Camilla. No puedes perderla... en realidad, espera, es posible, es tan pequeña y linda jejeje."
+msgstr "Si quieres aprender cómo atrapar @MONSTER_RACE@, dirígete a la ciudad ubicada en la meseta más adelante y habla con mi asistente Camilla. No puedes fallarle... en realidad, espera, es posible, es tan pequeña y linda jejeje."
 
 #. Key:	1B9EA938413881EEDE041F85884A4BC3
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_RL.Default__FaleneDefault01_RL_C.ResponseData(8).ResponseData.BreederPrompt
@@ -1396,7 +1396,7 @@ msgstr "Tanta emoción por un día, me está dando sueño."
 #: /Game/Dialogue/DragonMatriarch/Default/DMMuchEnergy.Default__DMMuchEnergy_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",1C71641945A1D7E57E40EEB16FB66E75"
 msgid "The lucky Titan will not expect such a massive load!"
-msgstr "¡El afortunado titán no esperará una carga tan enorme!"
+msgstr "¡El afortunado titán no esperará una carga tan inmensa!"
 
 #. Key:	1C771B6F4DD1FF210888A5BB37418D44
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMYourChildren.Default__DMYourChildren_C.SessionData.LinesToFemale(0).LinesToFemale
@@ -1417,7 +1417,7 @@ msgstr "Luego se aparearon con las criaturas naturales del mundo. Sí... lo prim
 #: /Game/Dialogue/Leylanna/Default/LeylannaDefault01_RechargeSpiritForm.Default__LeylannaDefault01_RechargeSpiritForm_C.SessionData.Lines(2).Lines
 msgctxt ",1C9CDC1147105A3D3F0A43BB6C94695C"
 msgid "Alternatively, you can recharge your spirit form partially by engaging in sex with blessed ones."
-msgstr "Alternativamente, puedes recargar tu forma espiritual parcialmente teniendo sexo con bendecidos."
+msgstr "Alternativamente, puedes recargar tu forma espiritual parcialmente al tener sexo con los bendecidos."
 
 #. Key:	1CB51DBE4D43642F605E479B59AC73A0
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.EM_HedonDungeonSwitch.Message
@@ -1508,7 +1508,7 @@ msgstr "¡Esta lujuria me está volviendo loca humano! No tienes idea."
 #: /Game/Dialogue/Romy/Default/RomyDefault01_AboutMusic.Default__RomyDefault01_AboutMusic_C.SessionData.Lines(2).Lines
 msgctxt ",1DA742CA40AC6A3A7EC5B6834EEA93B8"
 msgid "Mermaids are unique Formurians, we hear frequencies most others cannot."
-msgstr "Las sirenas son Formurianas únicas, escuchamos frecuencias que la mayoría no pueden."
+msgstr "Las sirenas son formurians únicas, escuchamos frecuencias que la mayoría no pueden."
 
 #. Key:	1DB7FBDD4A80D06FCF9019965B0E0008
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeHadSex01.Default__AmberMaeHadSex01_C.SessionData.LinesToFemale(0).LinesToFemale
@@ -1585,7 +1585,7 @@ msgstr "*Bosteza*"
 #: /Game/Dialogue/Emissary/Default/EmissaryBlessedInquiry01_R01.Default__EmissaryBlessedInquiry01_R01_C.SessionData.Lines(1).Lines
 msgctxt ",1EC1BDF8474319018DE2CBA3602448F1"
 msgid "I have overcome all desire and emotion. Such is a requirement to become an archangel of the Goddess, for she wants nothing to distract me from my task."
-msgstr "He superado todo deseo y emoción. Tal es un requisito para convertirme en arcángel de la Diosa, porque ella no quiere que nada me distraiga de mi tarea."
+msgstr "He superado todo deseo y emoción. Tal es un requisito para convertirme en arcángel de la Diosa, pues Ella no quiere que nada me distraiga de mi tarea."
 
 #. Key:	1EC307F7473EF201F5433B8DCF40B401
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeTaskFulfilled.Default__BeeTaskFulfilled_C.SessionData.Lines(1).Lines
@@ -1613,21 +1613,21 @@ msgstr "¡Mariposa!"
 #: /Game/World/Events/EM_Keystone.Default__EM_Keystone_C.ActivateMessage
 msgctxt ",1F1CAEA0490338B83DFFE19139FBE3C2"
 msgid "Take Keystone"
-msgstr "Toma la piedra-llave"
+msgstr "Toma la Keystone"
 
 #. Key:	1F2830D14059782BF943B5BD1F8A5942
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleTaskFulfilled.Default__KybeleTaskFulfilled_C.SessionData.LinesToFemale(0).LinesToFemale
 #: /Game/Dialogue/Kybele/Default/KybeleTaskFulfilled.Default__KybeleTaskFulfilled_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",1F2830D14059782BF943B5BD1F8A5942"
 msgid "Ah such a glorious mate you have given me!"
-msgstr "¡Ah, una pareja tan gloriosa que me has dado!"
+msgstr "¡Ah, que pareja tan gloriosa me has dado!"
 
 #. Key:	1F39C5E04BCD3150F989F3994E948682
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeHaveKeystone.Default__BeeHaveKeystone_C.SessionData.Lines(7).Lines
 #: /Game/Dialogue/QueenBee/Default/BeeHaveKeystone.Default__BeeHaveKeystone_C.SessionData.Lines(7).Lines
 msgctxt ",1F39C5E04BCD3150F989F3994E948682"
 msgid "We shall continue to wait for our savior. Someone who is one with the soil itself, a true maiden of nature."
-msgstr "Seguiremos esperando a nuestra salvadora. Alguien que es una con el suelo mismo, una verdadera doncella de la naturaleza."
+msgstr "Seguiremos esperando a nuestro salvador. Alguien que es uno con el suelo mismo, una verdadera doncella de la naturaleza."
 
 #. Key:	1F41165A452FBA12C2CF81A71C1DE5AC
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadFatAssLamia.Default__DryadFatAssLamia_C.SessionData.Lines(1).Lines
@@ -1754,7 +1754,7 @@ msgstr "Este cuerpo de flor es genial, espero que lo hayas disfrutado también M
 #: /Game/Dialogue/DragonMatriarch/Default/DMGreeting01.Default__DMGreeting01_C.SessionData.Lines(6).Lines
 msgctxt ",213C826F44FC31430F08EE8F97663F9A"
 msgid "Go play with the wild dragons, I'm sure they would love to get to know you better."
-msgstr "Ve a jugar con los dragones silvestres, estoy seguro de que les encantaría conocerte mejor."
+msgstr "Ve a jugar con los dragones silvestres, estoy segura de que les encantaría conocerte mejor."
 
 #. Key:	214776AF4C822D0B66293DB4BC1D955C
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiDefault03_RL_F.Default__FesssiDefault03_RL_F_C.ResponseData(1).ResponseData.BreederPrompt
@@ -1860,7 +1860,7 @@ msgstr "Gestiona tus Bovaurs"
 #: /Game/Dialogue/Leylanna/Default/LeylannaOldTempleDungeon1.Default__LeylannaOldTempleDungeon1_C.SessionData.Lines(0).Lines
 msgctxt ",233ACAAA4B9A80E38B57579ACF78F5DF"
 msgid "Sooooo very high human."
-msgstr "Taaaaan muy alto humano."
+msgstr "Taaaaan alto humano."
 
 #. Key:	2341F9304FDFA81B77486F840A0E749C
 #. SourceLocation:	/Game/Ranch/Upgrades/MuttHut.Default__MuttHut_C.Upgrade.Description
@@ -1951,14 +1951,14 @@ msgstr "Ohhh... Mastah... ahhh... el sabor de tus fluidos por favor. Fern los si
 #: /Game/Dialogue/OrcChief/Default/OrcDefault03_RL.Default__OrcDefault03_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",244C8E5D4982978D00C8C4AD305CB067"
 msgid "I'm still not fixing your damn gate."
-msgstr "Todavía no estoy arreglando tu maldito portón."
+msgstr "Todavía no he arreglando tu maldito portón."
 
 #. Key:	245BCC9A45EB7B47E46534A6AE4EE9CF
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowDefault01.Default__WidowDefault01_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Widow/Default/WidowDefault01.Default__WidowDefault01_C.SessionData.Lines(3).Lines
 msgctxt ",245BCC9A45EB7B47E46534A6AE4EE9CF"
 msgid "In exchange for your fluids that is... oh how delicious you look."
-msgstr "A cambio de tus fluidos eso es... oh qué delicioso te ves."
+msgstr "A cambio de tus fluidos eso es... oh, qué delicioso te ves."
 
 #. Key:	24679A7147C3C737DE65DBA1F7CE9FAB
 #. SourceLocation:	/Game/Ranch/Upgrades/NekoCondo.Default__NekoCondo_C.Upgrade.DisplayName
@@ -1980,7 +1980,7 @@ msgstr "Estoico: aumenta la lujuria máxima en un 20%."
 #: /Game/Dialogue/Autumn/Default/DryadDefault01_RL.Default__DryadDefault01_RL_C.ResponseData(5).ResponseData.BreederPrompt
 msgctxt ",2501139743DDD3B68A226FB25573A87A"
 msgid "Yum... can I have the keystone now?"
-msgstr "Hum... ¿puedo tener la piedra-llave ahora?"
+msgstr "Hum... ¿puedo tener la Keystone ahora?"
 
 #. Key:	25085F2F407D8D979CA1B39E030426E5
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_RL.Default__LeylannaDefault01_RL_C.ResponseData(3).ResponseData.BreederPrompt
@@ -2199,7 +2199,7 @@ msgstr "Exuberante: heredó un culo muy grande."
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_RL.Default__EmissaryDefault01_RL_C.ResponseData(8).ResponseData.BreederPrompt
 msgctxt ",29D016C340DC8B3F658D1A81BD0D7C54"
 msgid "Are you a Blessed @MONSTER_RACE@?"
-msgstr "¿Eres una @MONSTER_RACE@ Bendecida?"
+msgstr "¿Eres una @MONSTER_RACE@ bendecida?"
 
 #. Key:	2A2C90CA4F62D70955E3F3A98524FEAA
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDungeon.Default__CassieDungeon_C.SessionData.Lines(5).Lines
@@ -2277,7 +2277,7 @@ msgstr "La Diosa está complacida y te concederá Su favor."
 #: /Game/Dialogue/OrcChief/Default/OrcDefault03_RL.Default__OrcDefault03_RL_C.ResponseData(2).ResponseData.BreederPrompt
 msgctxt ",2BB3415840A0FA9A2D3EF98079751D8D"
 msgid "Can I have your keystone?"
-msgstr "¿Puedo tener tu piedra-llave?"
+msgstr "¿Puedo tener tu Keystone?"
 
 #. Key:	2BCA631C4BEC509E1B1DAC824001A31A
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_YourMusic_RL.Default__RomyDefault01_YourMusic_RL_C.ResponseData(1).ResponseData.BreederPrompt
@@ -2452,14 +2452,14 @@ msgstr "Una de extraordinaria soledad y autodesprecio."
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(4).Lines
 msgctxt ",2E8D7983446334A29BB4E0BCEFBBC092"
 msgid "Soon She realized something was missing, for the light had no meaning in the universe."
-msgstr "Pronto Ella se dio cuenta de que faltaba algo, porque la luz no tenía ningún significado en el universo."
+msgstr "Pronto Ella se dio cuenta de que faltaba algo, ya que la luz no tenía ningún significado en el universo."
 
 #. Key:	2E926B8847D675F1C4CAAFAC2732930B
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01_R04.Default__FernDefault01_R04_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Fern/Default/FernDefault01_R04.Default__FernDefault01_R04_C.SessionData.Lines(1).Lines
 msgctxt ",2E926B8847D675F1C4CAAFAC2732930B"
 msgid "Fern need human milk to grow into big Alraune! Hissss, Fern suck nipples now!"
-msgstr "¡Fern necesita leche materna para convertirse en una gran alraune! ¡Sssss, Fern ahora chupa pezones!"
+msgstr "¡Fern necesita leche humana para convertirse en una gran alraune! ¡Sssss, Fern ahora chupa pezones!"
 
 #. Key:	2EDA99CC46CBEB3206A527B95F55FAB9
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMDefault01.Default__DMDefault01_C.SessionData.Lines(1).Lines
@@ -2473,7 +2473,7 @@ msgstr "Vete humano, este es mi sitio confortable y no puedes tomarlo."
 #: /Game/Dialogue/Kybele/Default/KybeleTittyPony.Default__KybeleTittyPony_C.SessionData.LinesToFuta(0).LinesToFuta
 msgctxt ",2EF1966C455529B6A75289AD5EF81C2E"
 msgid "That's it human, you have annoyed me long enough. Get against that rock and prepare to be smashed."
-msgstr "Eso es humano, me has molestado lo suficiente. Ponte contra esa roca y prepárate para ser aplastado."
+msgstr "Eso es humana, me has molestado lo suficiente. Ponte contra esa roca y prepárate para ser aplastada."
 
 #. Key:	2EF454D94FCEA805F55F20A94627C808
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiGreeting01.Default__ParvatiGreeting01_C.SessionData.LinesToFuta(6).LinesToFuta
@@ -2515,7 +2515,7 @@ msgstr "Primero, Ella hizo el amor con Ella misma para dar a luz y las serafines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon2.Default__AmberMaeLockedDungeon2_C.SessionData.Lines(0).Lines
 msgctxt ",2FA4621047A86335175276AF22BFDE52"
 msgid "If ye think I'm a big cow today, 'mai goodness was I larger in me younger days!"
-msgstr "Si piensah que soy una vaca grande hoy, ¡Santo cielo, era máh grande en mi juventuh!"
+msgstr "Si piensah que soy una vaca grande hoy, ¡santo cielo, era máh grande en mi juventuh!"
 
 #. Key:	2FA59C8A48A63BD0FE6D0289A8AF9587
 #. SourceLocation:	/Game/Dialogue/Yasmine/Default/YasmineDefault02_RL.Default__YasmineDefault02_RL_C.ResponseData(0).ResponseData.BreederPrompt
@@ -2543,7 +2543,7 @@ msgstr "*Está profundamente dormida, su limo se ha relajado*"
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02_R01.Default__FernDefault02_R01_C.SessionData.Lines(2).Lines
 msgctxt ",3002153B48BD52898AEAE78030617CF7"
 msgid "Once an Alraune has consumed enough reproductive fluid, she will grow into a massive stationary flower."
-msgstr "Una vez que una alraune ha consumido suficiente fluido reproductivo, crecerá hasta convertirse en una enorme flor estacionaria."
+msgstr "Una vez que una alraune ha consumido suficiente fluido reproductivo, crecerá hasta convertirse en una inmensa flor estacionaria."
 
 #. Key:	3033B03F4617AF302335059B87E769FB
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_TheVoid.Default__NeelaDefault01_TheVoid_C.SessionData.Lines(1).Lines
@@ -2557,14 +2557,14 @@ msgstr "El espacio y el tiempo son diferentes allí, pero esto ya lo sabes como 
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R06.Default__FaleneDefault01_R06_C.SessionData.Lines(3).Lines
 msgctxt ",30642B1B484E9B1A506A4C8AA641CE01"
 msgid "Can't say I blame 'em!"
-msgstr "¡No puedo decir que las culpe!"
+msgstr "¡No puedo decir que los culpe!"
 
 #. Key:	3075ABF441EF5686A57E81971B67D55E
 #. SourceLocation:	/Game/Breeding/Positions/LapDance.Default__LapDance_C.SessionData.Description
 #: /Game/Breeding/Positions/LapDance.Default__LapDance_C.SessionData.Description
 msgctxt ",3075ABF441EF5686A57E81971B67D55E"
 msgid "The receiver bounces on the giver's lap while getting nice and close with her breasts."
-msgstr "La receptora rebota en el regazo del donante mientras se pone simpática y se cerca con sus pechos."
+msgstr "La receptora rebota en el regazo del donante mientras se pone bonita y se acerca con sus pechos."
 
 #. Key:	307B12694EA9D8B0251B9D86E3760DB8
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMWantHuman.Default__DMWantHuman_C.SessionData.Lines(1).Lines
@@ -2578,7 +2578,7 @@ msgstr "..."
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimeHowLong.Default__MegaSlimeHowLong_C.SessionData.Lines(4).Lines
 msgctxt ",308622B94E5A8BC25F1160888147CB16"
 msgid "The stuff in the water is always cold... oh the slime I could make with a fresh hot load."
-msgstr "La materia en el agua siempre está fría... oh, el limo que podría hacer con una carga fresca y caliente."
+msgstr "El material en el agua siempre está frío... oh, el limo que podría hacer con una carga fresca y caliente."
 
 #. Key:	308B8DB245EC118210674A84BB3AFDC3
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleRideYou_RL_T.Default__KybeleRideYou_RL_T_C.ResponseData(0).ResponseData.BreederPrompt
@@ -2655,7 +2655,7 @@ msgstr "Bueno, ciertamente puedo decir que el papel que usamos para escribir est
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_Pregnancy.Default__FaleneDefault01_Pregnancy_C.SessionData.Lines(3).Lines
 msgctxt ",31E2065041FFF628ED41DEB3E33F080F"
 msgid "It lets the mother know when the offspring will be summoned into this world, upon which the belly will return to normal."
-msgstr "Le permite a la madre saber cuándo la descendencia se convocará a este mundo, tras lo cual su barriga volverá a la normalidad."
+msgstr "Le permite a la madre saber cuándo la descendencia será convocada en este mundo, tras lo cual su vientre volverá a la normalidad."
 
 #. Key:	3214B32B4A49DA94E7D6779180228EC0
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01.Default__NeelaDefault01_C.SessionData.Lines(0).Lines
@@ -2690,7 +2690,7 @@ msgstr "Te sientes tan bien humano... ahhhh."
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_Forgot.Default__ParvatiDefault01_Forgot_C.SessionData.Lines(4).Lines
 msgctxt ",325B057D42B7367B320C54941EEE0BA6"
 msgid "I will show again how to move your body beyond all measure."
-msgstr "Volveré a mostrarte cómo mover tu cuerpo más allá de todo límite."
+msgstr "Te mostraré de nuevo cómo mover tu cuerpo más allá de todo límite."
 
 #. Key:	32E74CA64F7C6339A9D526A19496DD86
 #. SourceLocation:	/Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToFemale(0).LinesToFemale
@@ -2970,7 +2970,7 @@ msgstr "Me diste tanta leche, ¡y la consumí toda!"
 #: /Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToFuta(6).LinesToFuta
 msgctxt ",382D95F84EE60493751368AE5D1FFE56"
 msgid "Yes! I can feel you're about to cum... I want it all. Mmmm..."
-msgstr "¡Sí! Puedo sentir que estás a punto de correrte... Lo quiero todo. Mmmm..."
+msgstr "¡Sí! Puedo sentir que estás a punto de correrte... lo quiero todo. Mmmm..."
 
 #. Key:	3834BEFA49DCF9700CF52A8776CAE288
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowKeystone.Default__WidowKeystone_C.SessionData.Lines(5).Lines
@@ -3026,7 +3026,7 @@ msgstr "Se puede decir lo mucho que me vine por el tamaño de la fruta. Las más
 #: /Game/Dialogue/Autumn/Default/DryadAboutDryads.Default__DryadAboutDryads_C.SessionData.Lines(4).Lines
 msgctxt ",38CC526548FEE9E798647C9C32B75ECE"
 msgid "I decided to use my dryad power to produce fruit for them, and they love it."
-msgstr "Decidí usar mi poder de dríada para producir fruta para ellos, y les encanta."
+msgstr "Decidí usar mi poder de dríada para producir fruta para ellas, y les encanta."
 
 #. Key:	38F493C44D198004851E1399B9B3A835
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleTittyPony.Default__KybeleTittyPony_C.SessionData.LinesToMale(1).LinesToMale
@@ -3082,7 +3082,7 @@ msgstr "¡Miau! Sí, escribo eso tan a menudo como lo suelto. Hmmmm... quiero...
 #: /Game/World/Overworld.Overworld:PersistentLevel.MutHut.ManageActionMessage
 msgctxt ",39E5F4F34604E8D146FCCBA395551EFA"
 msgid "Manage your Hybrids"
-msgstr "Gestiona tus Hybrids"
+msgstr "Gestiona tus Híbridos"
 
 #. Key:	39EB8468458A5DE6DD323B9399883245
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(8).LinesToMale
@@ -3110,7 +3110,7 @@ msgstr "Seguro que hicimos una fruta gigante, pero te falta la lujuria que neces
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R01.Default__CamillaDefault01_R01_C.SessionData.Lines(7).Lines
 msgctxt ",3A5C7D5342118BA87B8C6595C9B5D200"
 msgid "The massive set of tits called Amber sells milk. You can find Amber across the way, but be warned: the only thing thicker than her accent is her body. Good luck with that."
-msgstr "El enorme conjunto de tetas llamado Amber vende leche. Puedes encontrar a Amber al otro lado del camino, pero ten cuidado: lo único más grueso que su acento es su cuerpo. Buena suerte con eso."
+msgstr "El inmenso conjunto de tetas llamado Amber vende leche. Puedes encontrar a Amber al otro lado del camino, pero ten cuidado: lo único más grueso que su acento es su cuerpo. Buena suerte con eso."
 
 #. Key:	3A8C32C44AAB9702B680029FE2C6DAD8
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchStartShySex.Default__MonarchStartShySex_C.SessionData.LinesToFemale(1).LinesToFemale
@@ -3124,7 +3124,7 @@ msgstr "*Sonrojo extremo*"
 #: /Game/Dialogue/Neela/Default/NeelaGreeting01.Default__NeelaGreeting01_C.SessionData.Lines(2).Lines
 msgctxt ",3AB82ACD4DE402E534B94C83E44F5A2C"
 msgid "Neela, warden of the Void, keybearer of pussy portals, at your service."
-msgstr "Neela, guardiana del Vacío, portadora de llaves de los coño-portales, a tu servicio."
+msgstr "Neela, guardiana del Vacío, portadora de llaves de los Coño Portales, a tu servicio."
 
 #. Key:	3AD149F249D46CC8CCB146B464F0C53D
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_TastyHuman.Default__NeelaDefault01_TastyHuman_C.SessionData.Lines(0).Lines
@@ -3145,7 +3145,7 @@ msgstr "¡Los @MONSTER_RACE@ que atrapes no serán bendecidos como yo!"
 #: /Game/Dialogue/Petra/Default/PetraTaskFulfilled.Default__PetraTaskFulfilled_C.SessionData.Lines(1).Lines
 msgctxt ",3AEC10F04A7A17CC79668DBE56DADBEA"
 msgid "It was a dragon all along. How could I not have guessed that!"
-msgstr "Fue un dragón todo el tiempo. ¡Cómo no pude haberlo adivinado!"
+msgstr "Fue un dragón todo el tiempo. ¡Cómo pude no haberlo adivinado!"
 
 #. Key:	3B3FB5184F1E276BF9EE46AB7835441D
 #. SourceLocation:	/Game/Characters/Procedural/Variants/Starfallen/Harvest/StarfallenHarvest.Default__StarfallenHarvest_C.Harvest.Description
@@ -3159,7 +3159,7 @@ msgstr "Fluidos corporales de Starfallen."
 #: /Game/Dialogue/Fern/DefaultP3/FernDefault03_R02.Default__FernDefault03_R02_C.SessionData.Lines(4).Lines
 msgctxt ",3B447AD04300826ECFC550A03A3AA0BC"
 msgid "My lower body is filled with nectar just waiting to surround your body as you cum again... and again."
-msgstr "La parte inferior de mi cuerpo está llena de néctar solo esperando rodear tu cuerpo mientras te corres otra una... y otra vez."
+msgstr "La parte inferior de mi cuerpo está llena de néctar solo esperando a rodear tu cuerpo mientras te corres una... y otra vez."
 
 #. Key:	3B686C7E477142920CF64F8119EC7E6F
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_FloatRhyme.Default__ParvatiDefault01_FloatRhyme_C.SessionData.Lines(6).Lines
@@ -3180,7 +3180,7 @@ msgstr "Atrapa a un macho vulwarg si aún no lo has hecho, y luego vuelve a mí.
 #: /Game/Dialogue/Fesssi/Default/FesssiHowLong.Default__FesssiHowLong_C.SessionData.Lines(4).Lines
 msgctxt ",3B7564A547A46D41C60CB999DCC9B845"
 msgid "But by far the best surprises came from behind... or they did before that confounded Cockblock Gate sealed itself a few days ago."
-msgstr "Pero, con mucho, las mejores sorpresas vinieron desde atrás... o lo hicieron antes de que el confuso Portón Bloque-polla se sellara hace unos días."
+msgstr "Pero de lejos las mejores sorpresas vinieron por detrás... o lo hicieron antes de que el confuso Portón Cockblock se sellara hace unos días."
 
 #. Key:	3B79840D47C6CCB278E40AB26C3546E7
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_StartMIssionary.Default__ParvatiDefault01_StartMIssionary_C.SessionData.Lines(0).Lines
@@ -3194,14 +3194,14 @@ msgstr "..."
 #: /Game/Dialogue/Widow/Default/WidowGreeting01.Default__WidowGreeting01_C.SessionData.Lines(0).Lines
 msgctxt ",3B83735E49E0C65B9C47E19DEE0B3417"
 msgid "*Strange moans and squishy noises can be heard within.*"
-msgstr "*Se pueden escuchar extraños gemidos y ruidos blandos en el interior.*"
+msgstr "*Se pueden escuchar extraños gemidos y ruidos suaves en el interior.*"
 
 #. Key:	3B85C4B1437679C67EE00DB4AEA10E96
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcBrashDumb.Default__OrcBrashDumb_C.SessionData.Lines(7).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcBrashDumb.Default__OrcBrashDumb_C.SessionData.Lines(7).Lines
 msgctxt ",3B85C4B1437679C67EE00DB4AEA10E96"
 msgid "Me chieftain because I use my dick the most, so watch out!"
-msgstr "Yo cacique porque uso más mi pene, ¡así que ten cuidado!"
+msgstr "Yo la cacique porque uso más mi pene, ¡así que ten cuidado!"
 
 #. Key:	3C151FC94376B799967B11AAA342949E
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDungeon_RL.Default__LeylannaDungeon_RL_C.ResponseData(0).ResponseData.BreederPrompt
@@ -3336,7 +3336,7 @@ msgstr "Eso es humana, me has molestado lo suficiente. ¡Inclínate y prepárate
 #: /Game/Dialogue/Emissary/Default/EmissaryCockblockGates.Default__EmissaryCockblockGates_C.SessionData.Lines(2).Lines
 msgctxt ",3E5B1CA94E6EB9CC180AE3A6F9EC5439"
 msgid "Seek the keystones hidden throughout the world, for one is required per gate."
-msgstr "Busca las piedras-llave escondidas en todo el mundo, ya que se requiere una por portón."
+msgstr "Busca las Keystones escondidas en todo el mundo, ya que se requiere una por portón."
 
 #. Key:	3EAFC53348C0B793D4BF32A6B78F4E3F
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_Forgot_RL.Default__ParvatiDefault01_Forgot_RL_C.ResponseData(4).ResponseData.BreederPrompt
@@ -3350,7 +3350,7 @@ msgstr "¡Levantado!"
 #: /Game/Dialogue/Fesssi/Default/FesssiStuck.Default__FesssiStuck_C.SessionData.Lines(5).Lines
 msgctxt ",3EB71DED4BE3050E6199E7B8D96DD53B"
 msgid "Hiss! Perhaps it's finally time I did something about thisss, so that I might share my ass with the world."
-msgstr "¡Sss! Quizás finalmente es hora de que haga algo al respecto, para poder compartir mi culo con el mundo."
+msgstr "¡Sss! Quizás es hora finalmente de que haga algo al respecto, para poder compartir mi culo con el mundo."
 
 #. Key:	3ECED49B42C93D52237EFFBEAB033F9A
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeDefault01.Default__BeeDefault01_C.SessionData.LinesToMale(1).LinesToMale
@@ -3449,14 +3449,14 @@ msgstr "A pesar de mis constantes intentos de complacerla y amarla, ella no dijo
 #: /Game/Dialogue/Emissary/Default/EmissaryGreeting01.Default__EmissaryGreeting01_C.SessionData.Lines(1).Lines
 msgctxt ",4019AADD47513B243D987E8810645FAD"
 msgid "Before you is an emissary of the Goddess, and your archangel servant. Let these words pierce your heart, for I speak on Her behalf."
-msgstr "Ante ti está una emisaria de la Diosa y tu arcángel sirviente. Deja que estas palabras traspasen tu corazón, porque hablo en Su nombre."
+msgstr "Está ante ti una emisaria de la Diosa, y tu arcángel sirviente. Deja que estas palabras traspasen tu corazón, pues hablo en Su nombre."
 
 #. Key:	4021F6674834D5C495A7E59231DB4FA4
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R03.Default__FaleneDefault01_R03_C.SessionData.Lines(12).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R03.Default__FaleneDefault01_R03_C.SessionData.Lines(12).Lines
 msgctxt ",4021F6674834D5C495A7E59231DB4FA4"
 msgid "If you aren't in the mood, you can also catch them by rubbing @MONSTER_RACE@ semen on their skin, or feeding them @MONSTER_RACE@ milk."
-msgstr "Si no está de humor, también puede atraparlos frotando semen de @MONSTER_RACE@ en su piel o alimentándolos con leche de @MONSTER_RACE@."
+msgstr "Si no está de humor, también puedes atraparlos frotando semen de @MONSTER_RACE@ en su piel o alimentándolos con leche de @MONSTER_RACE@."
 
 #. Key:	402496A44933EE13233F8E8A45D06E47
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchDefault01_RL.Default__MonarchDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
@@ -3484,7 +3484,7 @@ msgstr "Si. ¡Por cualquier medio necesario!"
 #: /Game/Dialogue/Petra/Default/PetraDefault01_RL.Default__PetraDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",409211234F50BB3CC5987D94FC8463AA"
 msgid "Can you help me get that keystone?"
-msgstr "¿Puedes ayudarme a conseguir esa piedra-llave?"
+msgstr "¿Puedes ayudarme a conseguir esa Keystone?"
 
 #. Key:	40FFE44B48699F620EAC16A81249A058
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeHadSex01.Default__MegaSlimeHadSex01_C.SessionData.LinesToFuta(3).LinesToFuta
@@ -3603,7 +3603,7 @@ msgstr "Nos encanta reproducirnos con todos los demás @MONSTER_RACE@."
 #: /Game/Dialogue/AmberMae/SexScenes/AmberMilkyF.Default__AmberMilkyF_C.SessionData.Lines(3).Lines
 msgctxt ",42666B4E478FE544AD7A4B91FD65DE82"
 msgid "Aye don't stop 'lil human! It's thick and creamy... ahhh!"
-msgstr "¡Seh, no pareh peke humana! Eh ehpesa y cremosa... ¡ahhh!"
+msgstr "¡Seh, no pareh peke humano! Eh ehpesa y cremosa... ¡ahhh!"
 
 #. Key:	42E4526948669BCD5AFBD29DC9583D3C
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R06.Default__FaleneDefault01_R06_C.SessionData.Lines(7).Lines
@@ -3631,7 +3631,7 @@ msgstr "¡Ahora arregla el portón humana, o haré que la polla rellene bajando 
 #: /Game/Dialogue/DragonMatriarch/Default/DMNapSomewhereElse.Default__DMNapSomewhereElse_C.SessionData.Lines(1).Lines
 msgctxt ",433691C34A0864415618B78808993A0E"
 msgid "For hundreds of years I have come to this rock to rest, it's quite comfortable."
-msgstr "Durante cientos de años he venido a descansar a esta roca, es bastante cómodo."
+msgstr "Durante cientos de años he venido a descansar a esta roca, es bastante cómoda."
 
 #. Key:	434F3EDD4D71E19F342B9FB4B2780A63
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaHadSex01.Default__NeelaHadSex01_C.SessionData.Lines(0).Lines
@@ -3645,7 +3645,7 @@ msgstr "Oh, sí, eso fue increíble."
 #: /Game/Dialogue/Cassie/Default/CassieDungeon2.Default__CassieDungeon2_C.SessionData.Lines(4).Lines
 msgctxt ",434FF9C34E180AC6724D628D8E2EB07A"
 msgid "*Purr* You made me feel so good... so Cassie fixed it for you!"
-msgstr "*Ronronea* Me hiciste sentir tan bien... ¡así que Cassie te lo arregló!"
+msgstr "*Ronronea* Me hiciste sentir tan bien... ¡así que Cassie lo arregló para ti!"
 
 #. Key:	4360D9A3483F76A70B34C59BF0B5B019
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiAreYouOk.Default__FesssiAreYouOk_C.SessionData.Lines(0).Lines
@@ -3744,7 +3744,7 @@ msgstr "Gordito"
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_WhatGoddessDoes.Default__EmissaryDefault01_WhatGoddessDoes_C.SessionData.Lines(0).Lines
 msgctxt ",44F952984F6E2F20583500AA72B0067A"
 msgid "Such is for Her to decide. Rest, for She is all-powerful and all-loving. Their care and wellness could not be in better hands."
-msgstr "Tal es para que Ella decida. Descansa, porque Ella es todopoderosa y amorosa. Su cuidado y bienestar no podrían estar en mejores manos."
+msgstr "Tal es para que Ella decida. Descansa, pues Ella es todopoderosa y amorosa. Su cuidado y bienestar no podrían estar en mejores manos."
 
 #. Key:	44FB7A2943203A7912B1F5B22C5B6DCA
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(19).LinesToFemale
@@ -3793,7 +3793,7 @@ msgstr "Gestiona tus Nekos"
 #: /Game/Dialogue/Kybele/Default/KybeleCentaur.Default__KybeleCentaur_C.SessionData.Lines(6).Lines
 msgctxt ",46018B7B49E8F91F3AB3B5A9002485B1"
 msgid "External \"help\" is required, and you are looking tasty at the moment."
-msgstr "Se requiere \"ayuda\" externa y te ves delicioso en este momento."
+msgstr "Se requiere \"ayuda\" externa, y te ves delicioso en este momento."
 
 #. Key:	464B0F3B450345A0F3EA8E98C67A5248
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(6).LinesToMale
@@ -3821,7 +3821,7 @@ msgstr "Mi madre es una kraken magnífica, una hermosa y voluptuosa doncella del
 #: /Game/Dialogue/Autumn/Default/DryadHadSex01.Default__DryadHadSex01_C.SessionData.Lines(0).Lines
 msgctxt ",46745F5D451EF7EB89BFE58F57B364E3"
 msgid "Look at the size of it!"
-msgstr "¡Mira el tamaño!"
+msgstr "¡Mira el tamaño de esa!"
 
 #. Key:	46C09FA14157EC1F3D6608BB30F25A60
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon2.Default__AmberMaeLockedDungeon2_C.SessionData.Lines(3).Lines
@@ -3870,7 +3870,7 @@ msgstr "¡Guau, un centauro!"
 #: /Game/Dialogue/Fesssi/Default/FesssiHowLong.Default__FesssiHowLong_C.SessionData.Lines(5).Lines
 msgctxt ",47464D7B43F2BD56B082E8AB7F91F25E"
 msgid "Damn those Cockblock Gates... we never asked for those. Imagine if the ancient builders of the world made something useful, like a spell to give futas a scrotum."
-msgstr "Malditos sean esos Portones Bloque-polla... nunca los pedimos. Imagínese si los antiguos constructores del mundo hicieran algo útil, como un hechizo para dar a los futas un escroto."
+msgstr "Malditos sean esos Portones Cockblock... nunca los pedimos. Imagínate si los antiguos constructores del mundo hicieran algo útil, como un hechizo para dar a los futas un escroto."
 
 #. Key:	47621D134EBA27E9FF0A6888F1D9CF3D
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernGreeting03.Default__FernGreeting03_C.SessionData.LinesToFemale(2).LinesToFemale
@@ -4090,7 +4090,7 @@ msgstr "¡Puedes tener mi leche materna!"
 #: /Game/Dialogue/Petra/Default/PetraGetKeystone.Default__PetraGetKeystone_C.SessionData.Lines(7).Lines
 msgctxt ",4B400F8545DB288AE092E39BA2CD24BF"
 msgid "If you can find me something that fits Pawsmaati's request, I will get that keystone for you."
-msgstr "Si puedes encontrarme algo que se ajuste a la petición de Pawsmaati, te conseguiré esa piedra-llave."
+msgstr "Si puedes encontrarme algo que se ajuste a la petición de Pawsmaati, te conseguiré esa Keystone."
 
 #. Key:	4B96D56447562EBC8748929A5D3B51FD
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernGreeting02.Default__FernGreeting02_C.SessionData.LinesToFuta(3).LinesToFuta
@@ -4125,14 +4125,14 @@ msgstr "Debería castigarte, pero... ¡ohhh! Como puedes ver, estoy ocupada."
 #: /Game/Dialogue/Autumn/Default/DryadFatAssLamia.Default__DryadFatAssLamia_C.SessionData.Lines(4).Lines
 msgctxt ",4BEA745E46427D48E9DB48A470FF3A40"
 msgid "From that moment on I was fixed on her... I wanted to please her in ways I never before considered."
-msgstr "A partir de ese momento me fijé en ella... Quería complacerla de formas que nunca antes había considerado."
+msgstr "A partir de ese momento me fijé en ella... quería complacerla de formas que nunca antes había considerado."
 
 #. Key:	4C00C7F544226DAA1CBB4781B0CEB82F
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(3).Lines
 msgctxt ",4C00C7F544226DAA1CBB4781B0CEB82F"
 msgid "Aye, 'mai specialty is all things milk, and a quare good pair on me front. Bless me, hav'n jugs like these can really hurt 'mai back!"
-msgstr "Seh, mih espesialidadeh son toa lah cosah relasionadah con la leshe, y un buen pah cuadrado en la parte delantera. ¡Bendita sea, teneh cántaroh de leshe como ehtoh reahmente pueden lahtimarme la ehparda!"
+msgstr "Seh, mih espesialidadeh son toa lah cosah relasionadah con la leshe, y un buen pah cuadrao en mi delantera. ¡Bendita sea, teneh cántaroh de leshe como ehtoh reahmente pueden lahtimarme la ehparda!"
 
 #. Key:	4C1E56854BDDE954FC7ACA99874AB4C3
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaHadSex02.Default__CamillaHadSex02_C.SessionData.LinesToFemale(1).LinesToFemale
@@ -4167,7 +4167,7 @@ msgstr "No encontrarás serafines ni elfos ahí abajo... no. Es más probable qu
 #: /Game/Dialogue/Romy/Default/RomyDefault01_UpHere.Default__RomyDefault01_UpHere_C.SessionData.Lines(4).Lines
 msgctxt ",4D0B9DAB42EF8CA84E014A8298104E74"
 msgid "Only the Goddess will give you answers. Sadly, I cannot hear Her song, for it is much too great for my ears."
-msgstr "Solo la Diosa te dará respuestas. Lamentablemente, no puedo escuchar Su canción, porque es demasiado grande para mis oídos."
+msgstr "Solo la Diosa te dará respuestas. Lamentablemente, no puedo escuchar Su canción, ya que es demasiado grande para mis oídos."
 
 #. Key:	4D14F6284D4722E3384EB5A50BDD7ACC
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleCentaur.Default__KybeleCentaur_C.SessionData.Lines(1).Lines
@@ -4202,7 +4202,7 @@ msgstr "Mi teoría es que cuando semen y óvulo @MONSTER_RACE@ se unen, fractura
 #: /Game/Dialogue/AmberMae/Default/AmberMaeDefault01_RL.Default__AmberMaeDefault01_RL_C.ResponseData(3).ResponseData.BreederPrompt
 msgctxt ",4E27E33747B868644B436C9F77707525"
 msgid "May I suck on your jugs?"
-msgstr "¿Puedo chuparte los cántaros de leche?"
+msgstr "¿Puedo chupar tus cántaros de leche?"
 
 #. Key:	4E36B8A545FB7E25EE044C834B5EFC4D
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernHadSex02.Default__FernHadSex02_C.SessionData.Lines(0).Lines
@@ -4300,7 +4300,7 @@ msgstr "Suave y regordeta, con muchas protuberancias."
 #: /Game/Dialogue/Romy/Default/RomyHadSex01.Default__RomyHadSex01_C.SessionData.LinesGrungy(0).LinesGrungy
 msgctxt ",4F37D08C43E11EDF706D07998D86692F"
 msgid "Oh you dirty dirty human... what have you done to yourself?"
-msgstr "Oh, sucio, sucio humano... ¿Qué te has hecho a ti mismo?"
+msgstr "Oh, sucio, sucio humano... ¿qué te has hecho a ti mismo?"
 
 #. Key:	4F601DAA48F980A712CFA1A4888DDCBC
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToFuta(2).LinesToFuta
@@ -4342,7 +4342,7 @@ msgstr "¡Ahh, planta tu deliciosa semilla en mi cuerpecito! ¡Dámelo... ohhh�
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R07.Default__FaleneDefault01_R07_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",4FD31BBE4149189F2C525B911BC63025"
 msgid "Aww! Someone wants their labia licked!"
-msgstr "¡Amm! ¡Alguien quiere le laman sus labios!"
+msgstr "¡Amm! ¡Alguien quiere que le laman sus labios!"
 
 #. Key:	502500DE40F982D4BC3BC1AB282D2040
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(17).LinesToFemale
@@ -4570,7 +4570,7 @@ msgstr "¡Ahora arregla el portón humano, o tu polla es mía!"
 #: /Game/Dialogue/Widow/Default/WidowSpiders.Default__WidowSpiders_C.SessionData.Lines(2).Lines
 msgctxt ",550D874045EED9CAB4096BB51CD7C32A"
 msgid "Patiently we will wait for our mates to come to us... this world is full of lumbering morons oozing with delicious fluids."
-msgstr "Esperaremos pacientemente a que nuestros compañeros vengan a nosotros... este mundo está lleno de torpes idiotas rezumando deliciosos fluidos."
+msgstr "Esperaremos pacientemente a que nuestros compañeros vengan a nosotras... este mundo está lleno de torpes idiotas rezumando deliciosos fluidos."
 
 #. Key:	554D996445578E57126935A57AEBB8F3
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_R03.Default__FernDefault02_R03_C.SessionData.Lines(0).Lines
@@ -4854,7 +4854,7 @@ msgstr "¡Enséñame una nueva posición sexual!"
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(6).Lines
 msgctxt ",5AA8E62541EFA61D3ED30CAD3E1D0946"
 msgid "Demons crawled out of the darkness, and immediately started having sex with the Seraphim."
-msgstr "Los demonios salieron de la oscuridad e inmediatamente comenzaron a tener sexo con las Serafines."
+msgstr "Los demonios salieron de la oscuridad e inmediatamente comenzaron a tener sexo con las serafines."
 
 #. Key:	5ACEB47B4DC474437836D1BE5DF53CC7
 #. SourceLocation:	/Game/Dialogue/Blossom/Default/BlossomDefault01_RL_F.Default__BlossomDefault01_RL_F_C.ResponseData(1).ResponseData.BreederPrompt
@@ -4938,7 +4938,7 @@ msgstr "Los orígenes de los @MONSTER_RACE@ son antiguos y desconocidos, pero de
 #: /Game/Dialogue/AmberMae/Default/AmberMaeDungeon_RL.Default__AmberMaeDungeon_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",5C98DE6F491C2551F3E059B7839548B4"
 msgid "You couldn't fit in the dungeon?!"
-msgstr "¡¿No cabías en la mazmorra ?!"
+msgstr "¡¿No cabías en la mazmorra?!"
 
 #. Key:	5D1189D248873A7E95BA20AA8EADCF1C
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_Daze.Default__EmissaryDefault01_Daze_C.SessionData.Lines(0).Lines
@@ -5001,7 +5001,7 @@ msgstr "Lanzaste taaanto semen aquí, me encanta."
 #: /Game/Dialogue/QueenBee/Default/BeeKneel.Default__BeeKneel_C.SessionData.Lines(0).Lines
 msgctxt ",5E8F33C74DE660C4911FD98A332F6BDE"
 msgid "Ahhh yes... place your mouth upon my teat, for it is custom for all subjects to taste of my honey."
-msgstr "Ahhh, sí... coloca tu boca sobre mi pezón, porque es costumbre que todos los sujetos prueben mi miel."
+msgstr "Ahhh, sí... coloca tu boca sobre mi pezón, pues es costumbre que todos prueben mi miel."
 
 #. Key:	5F41B5A04451E1F4E959DA86D6846CB4
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R04.Default__FaleneDefault01_R04_C.SessionData.Lines(6).Lines
@@ -5121,7 +5121,7 @@ msgstr "¡Ahhh, tan dulce y cremoso! No me había sentido tan bien en décadas."
 #: /Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon.Default__AmberMaeLockedDungeon_C.SessionData.Lines(4).Lines
 msgctxt ",61A8146D43CCAA9D468CCC9D2CB22F42"
 msgid "If I recall... they rigged up some switch 'an pulley system."
-msgstr "Si mah no recuerdo... inhtalaron un interrustor y sihtema de poleah."
+msgstr "Si mar no recuerdo... inhtalaron un interrustor y sihtema de poleah."
 
 #. Key:	61C3C47B425E2ACFE03921A38EDBD93D
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.CBGate_Glade.PlaceMessage
@@ -5331,7 +5331,7 @@ msgstr "Te amamos demasiado y, a veces, ¡nuestros deseos se descontrolan!"
 #: /Game/Dialogue/Parvati/Default/ParvatiGreeting01.Default__ParvatiGreeting01_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",646F99EA498DD1E54CCB8AB5413F39DB"
 msgid "Different ways of seducing your mates, but all with the same goal."
-msgstr "Diferentes formas de seducir tus compañeros/as buscas, pero todas con el mismo final."
+msgstr "Diferentes formas de seducir a tus compañeros, pero todas con la misma meta."
 
 #. Key:	6472B92C4C77BC77E4D51599F203425B
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_RL.Default__CamillaDefault01_RL_C.ResponseData(5).ResponseData.BreederPrompt
@@ -5366,7 +5366,7 @@ msgstr "Como reina, tengo derecho al placer constante. Sin embargo, mis hijas es
 #: /Game/Dialogue/Yasmine/Default/YasmineDefault01.Default__YasmineDefault01_C.SessionData.Lines(0).Lines
 msgctxt ",64D03AEC41B764C9BCFB0CAAED5A58DD"
 msgid "*Strange moans and squishy noises can be heard within.*"
-msgstr "*Se pueden escuchar extraños gemidos y ruidos blandos en el interior.*"
+msgstr "*Se pueden escuchar extraños gemidos y ruidos suaves en el interior.*"
 
 #. Key:	64DDB04B426866024F9EFC98D34E99E5
 #. SourceLocation:	/Game/Dialogue/Blossom/Default/BlossomDefault01_RL_F.Default__BlossomDefault01_RL_F_C.ResponseData(0).ResponseData.BreederPrompt
@@ -5444,14 +5444,14 @@ msgstr "Qué encantador helecho parlante..."
 #: /Game/Dialogue/Romy/Default/RomyDefault01_RL.Default__RomyDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",668D13F146AB0A33AF196F814E2CAA98"
 msgid "Bathe."
-msgstr "Bañarse."
+msgstr "Bañar."
 
 #. Key:	6692103B4B53269229DB388B380B520F
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiIdiots.Default__FesssiIdiots_C.SessionData.Lines(7).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiIdiots.Default__FesssiIdiots_C.SessionData.Lines(7).Lines
 msgctxt ",6692103B4B53269229DB388B380B520F"
 msgid "Do hurry human, I am very horny and ready to mate with the world... starting with you."
-msgstr "Date prisa humana, estoy muy cachonda y dispuesta a aparearme con el mundo... empezando por ti."
+msgstr "Date prisa humano, estoy muy cachonda y dispuesta a aparearme con el mundo... empezando por ti."
 
 #. Key:	66E2EA9044A750BB60AD308B87FE3071
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadHaveKeystone.Default__DryadHaveKeystone_C.SessionData.Lines(3).Lines
@@ -5500,7 +5500,7 @@ msgstr "¡Soy Amber-Mae, tu mosa leshera bovaur!"
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_Formuria.Default__MirruDefault01_Formuria_C.SessionData.Lines(5).Lines
 msgctxt ",679174774B8AE81A6C98AE933C6D1BF3"
 msgid "Let me just say, \"experience\" what you drylanders have to offer."
-msgstr "Permíteme sólo decir, \"experimenta\" lo que tienen para ofrecer los de suelo firme."
+msgstr "Permíteme sólo decir, \"experimenta\" lo que tienen para ofrecer los de tierra firme."
 
 #. Key:	679B9CA8446900121B93359B9CD3CC08
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01_YourMusic_ToneDeaf.Default__RomyDefault01_YourMusic_ToneDeaf_C.SessionData.Lines(0).Lines
@@ -5620,7 +5620,7 @@ msgstr "Contempla por un momento mientras aplico un poco de lubricante."
 #: /Game/Dialogue/Kybele/Default/KybeleDefault01_RL.Default__KybeleDefault01_RL_C.ResponseData(4).ResponseData.BreederPrompt
 msgctxt ",698288A146113C1492125B891EA3456D"
 msgid "Can I have that keystone?"
-msgstr "¿Puedo tener esa piedra-llave?"
+msgstr "¿Puedo tener esa Keystone?"
 
 #. Key:	6993DD7B4964C190B75F98AABA008FAA
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieGreeting01.Default__CassieGreeting01_C.SessionData.Lines(0).Lines
@@ -5655,7 +5655,7 @@ msgstr "¿Barra de mantequilla? ¿En serio?"
 #: /Game/Dialogue/Cassie/SexScenes/CassieSplintersT.Default__CassieSplintersT_C.SessionData.Lines(0).Lines
 msgctxt ",6AAA8DC54239107FC4E476B1F67AD574"
 msgid "Ohhh... big human dick feels amazing!"
-msgstr "¡Ohhh... el gran pene humano se siente increíble!"
+msgstr "Ohhh... ¡el gran pene humano se siente increíble!"
 
 #. Key:	6AADAD5D41D98C207B7FEB993604434A
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.EM_Keystone_QueenBee.FailMessage
@@ -5746,7 +5746,7 @@ msgstr "A los foxen y los vulwarg les gusta la sombra y los árboles del Bosque 
 #: /Game/Dialogue/Fesssi/Default/FesssiCave.Default__FesssiCave_C.SessionData.Lines(3).Lines
 msgctxt ",6D1219CB453AA152B8E0548996E8123B"
 msgid "Apparently, if you go deep enough, you will find hell itself. Filled to the brim with lusty demons and dark magic."
-msgstr "Aparentemente, si profundizas lo suficiente, encontrarás el infierno mismo. Lleno hasta el borde de lujuriosos demonios y magia oscura."
+msgstr "Aparentemente, si profundizas lo suficiente, encontrarás el infierno mismo. Lleno hasta los topes de lujuriosos demonios y magia oscura."
 
 #. Key:	6D1431474F1C713E9D755F93772C653C
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(15 - Value).TraitIcons.HelpText
@@ -5824,7 +5824,7 @@ msgstr "Si no abandonas este lugar, ¡me montarás con esa polla de tamaño mode
 #: /Game/Dialogue/Kybele/Default/KybeleHaveKeystone.Default__KybeleHaveKeystone_C.SessionData.Lines(3).Lines
 msgctxt ",6DFA50D843F564F540771EAD2DCC848B"
 msgid "Just don't tell her if you see her! If you do, you will feel my wrath again!"
-msgstr "¡Simplemente no le digas si la ves! Si lo haces, ¡sentirás mi ira de nuevo!"
+msgstr "¡Simplemente no se lo digas si la ves! Si lo haces, ¡sentirás mi ira de nuevo!"
 
 #. Key:	6DFC948B4585FAC19AED8692ED4B45F2
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_RechargeSpiritForm_RL_F.Default__LeylannaDefault01_RechargeSpiritForm_RL_F_C.ResponseData(1).ResponseData.BreederPrompt
@@ -6028,7 +6028,7 @@ msgstr "Convertimos el semen que se desperdiciaría en una nueva vida, ¡incluso
 #: /Game/Dialogue/DragonMatriarch/Default/DMDefault_RL5_T.Default__DMDefault_RL5_T_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",709579B446D8D4D2C2F3EE98857ED27A"
 msgid "Bring it on dragon."
-msgstr "Tráela en dragón."
+msgstr "Tráelo en dragón."
 
 #. Key:	709C1A4748A9B0773A823DB8EB5B31E0
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeHadSex01.Default__BeeHadSex01_C.SessionData.Lines(2).Lines
@@ -6140,7 +6140,7 @@ msgstr "¡¿No es hermosa?!"
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_Forgot.Default__ParvatiDefault01_Forgot_C.SessionData.Lines(6).Lines
 msgctxt ",72570AA14FB2D285DAAB6584C841B08C"
 msgid "Which position shall we review?"
-msgstr "¿Qué posición revisaremos?"
+msgstr "¿Qué posición repasaremos?"
 
 #. Key:	725969164426D429929F949920B9A0BD
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadGreeting01.Default__DryadGreeting01_C.SessionData.Lines(2).Lines
@@ -6260,7 +6260,7 @@ msgstr "Me voy a correr... ahhh... será un desastre."
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePlay1.Default__MegaSlimePlay1_C.SessionData.LinesToFuta(0).LinesToFuta
 msgctxt ",744AC6EA4EF6E8F4298079829B209661"
 msgid "You are so kind! No one has ever been so nice to me!"
-msgstr "¡Eres muy amable! ¡Nadie ha sido tan amable conmigo!"
+msgstr "¡Eres muy amable! ¡Nadie ha sido tan bueno conmigo!"
 
 #. Key:	744F4E844CF281ADE05939B86FCE678E
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy_RL_T.Default__MirruDefault01_BodySexToy_RL_T_C.ResponseData(2).ResponseData.BreederPrompt
@@ -6345,7 +6345,7 @@ msgstr "Vuelve a verme cuando cambies de opinión."
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_RL.Default__NeelaDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",758A181D4F348EDE373A33ADB8F3CB08"
 msgid "Pussy portals... really?"
-msgstr "Coño portales... ¿en serio?"
+msgstr "Coño Portales... ¿en serio?"
 
 #. Key:	7618202D4A38C8CACBFF19A33C3F1E02
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyDefault01.Default__RomyDefault01_C.SessionData.Lines(1).Lines
@@ -6388,14 +6388,14 @@ msgstr "Atípico: heredó un inusual tamaño para su variante."
 #: /Game/Dialogue/Falene/Default/FaleneDefault02.Default__FaleneDefault02_C.SessionData.Lines(3).Lines
 msgctxt ",76DCFBB44EA9841F910FB9BE2CBD16B7"
 msgid "Of course we make love! What else are assistants for?"
-msgstr "¡Por supuesto que hacemos el amor! ¿Para qué más son los asistentes?"
+msgstr "¡Por supuesto que hacemos el amor! ¿Para qué si no sirven los asistentes?"
 
 #. Key:	76DD724248BA7178346EC59171F3BDF4
 #. SourceLocation:	/Game/Dialogue/Romy/Default/RomyGreeting01.Default__RomyGreeting01_C.SessionData.LinesGrungy(5).LinesGrungy
 #: /Game/Dialogue/Romy/Default/RomyGreeting01.Default__RomyGreeting01_C.SessionData.LinesGrungy(5).LinesGrungy
 msgctxt ",76DD724248BA7178346EC59171F3BDF4"
 msgid "No I want to. Trust me... I want to feel every corner of that human body."
-msgstr "No, yo quiero. Confía en mí... Quiero sentir cada rincón de ese cuerpo humano."
+msgstr "No, yo quiero. Confía en mí... quiero sentir cada rincón de ese cuerpo humano."
 
 #. Key:	7738600347E52873B1AB5D8B148524AC
 #. SourceLocation:	/Game/Dialogue/Leylanna/SexScenes/LeylannaLeyCov.Default__LeylannaLeyCov_C.SessionData.LinesToFemale(1).LinesToFemale
@@ -6488,21 +6488,21 @@ msgstr "¡¡¡¿No es eso simplemente fantástico y adorable?!!!"
 #: /Game/Dialogue/Kybele/Default/KybeleHadSex01.Default__KybeleHadSex01_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",7989199A4B0BA24F0B904493FCC965AC"
 msgid "Still... you took my fat horse cock well. That's amazing for one of your size!"
-msgstr "Aún así... tomaste bien mi gruesa polla de caballo. ¡Eso es asombroso para alguien de tu tamaño!"
+msgstr "Aún así... tomaste bien mi gorda polla de caballo. ¡Eso es asombroso para alguien de tu tamaño!"
 
 #. Key:	7A0924884575833B8154E88AE733B3E4
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.EM_Keystone_Kybele.FailMessage
 #: /Game/World/Overworld.Overworld:PersistentLevel.EM_Keystone_Kybele.FailMessage
 msgctxt ",7A0924884575833B8154E88AE733B3E4"
 msgid "Kybele fiercely guards this keystone."
-msgstr "Kybele guarda ferozmente esta piedra-llave."
+msgstr "Kybele guarda ferozmente esta Keystone."
 
 #. Key:	7A22D0874255FC1001174C8C01466911
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimePearl.Default__MegaSlimePearl_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePearl.Default__MegaSlimePearl_C.SessionData.Lines(3).Lines
 msgctxt ",7A22D0874255FC1001174C8C01466911"
 msgid "My beloved orb wishes to move on, and I want you to take it."
-msgstr "Mi amado orbe desea seguir adelante y quiero que lo aceptes."
+msgstr "Mi amado orbe desea seguir adelante, y quiero que lo aceptes."
 
 #. Key:	7A37639548189268575986A48C480863
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_TheVoid.Default__NeelaDefault01_TheVoid_C.SessionData.Lines(2).Lines
@@ -6558,7 +6558,7 @@ msgstr "No toques esto."
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_RL.Default__NeelaDefault01_RL_C.ResponseData(4).ResponseData.BreederPrompt
 msgctxt ",7B46D37346081D01CB0C9B8C6CAEE2DF"
 msgid "I want to traverse your pussy... portal."
-msgstr "Quiero atravesar tu coño... portal."
+msgstr "Quiero atravesar tu Coño... Portal."
 
 #. Key:	7B5F72194EE494B66BEC5CAD05253722
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(15 - Value).TraitIcons.DisplayName
@@ -6678,7 +6678,7 @@ msgstr "Háblame de Pawsmatti."
 #: /Game/Dialogue/Emissary/Default/EmissaryCockblockGates.Default__EmissaryCockblockGates_C.SessionData.Lines(0).Lines
 msgctxt ",7D4DC0064FB622869AA3E3B8CFCF2444"
 msgid "Ah you mean the Cockblock Gates."
-msgstr "Ah, te refieres a los Portones Bloque-polla."
+msgstr "Ah, te refieres a los Portones Cockblock."
 
 #. Key:	7D9B8CD848A3DAA68B924CA2B1E60858
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToFemale(2).LinesToFemale
@@ -6841,7 +6841,7 @@ msgstr "Baño tibio, música dulce y ahora la agradable compañía del humano."
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePlay1.Default__MegaSlimePlay1_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",809919A3474406E99443B39588E9EAE7"
 msgid "You are so kind! No one has ever been so nice to me!"
-msgstr "¡Eres muy amable! ¡Nadie ha sido tan amable conmigo!"
+msgstr "¡Eres muy amable! ¡Nadie ha sido tan bueno conmigo!"
 
 #. Key:	80E41C3F423650528E6EDA8372C9D9E8
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMAboutDragons.Default__DMAboutDragons_C.SessionData.Lines(0).Lines
@@ -6954,7 +6954,7 @@ msgstr "La mayoría de las veces, termino metida en todos los agujeros."
 #: /Game/Dialogue/Camilla/Default/CamillaHadSex02.Default__CamillaHadSex02_C.SessionData.LinesToFuta(0).LinesToFuta
 msgctxt ",83B1D0DD4F37A2E70289CEAAC491EB74"
 msgid "Wow human, you must have been desperate to give this nugget your love."
-msgstr "Guau, humana, debes haber estado desesperada por darle a esta pepita tu amor."
+msgstr "Guau, humana, debes haber estado desesperada para darle a esta pepita tu amor."
 
 #. Key:	83C8B41F462880323A7E26B8AE678AA1
 #. SourceLocation:	/Game/Dialogue/Mirru/SexScenes/MirruSnatchT.Default__MirruSnatchT_C.SessionData.Lines(6).Lines
@@ -6968,7 +6968,7 @@ msgstr "Sí, ohh... alimenta a mi voluptuoso cuerpo con toda tu semilla. Ahhhhh.
 #: /Game/Dialogue/Kybele/Default/KybeleHaveKeystone.Default__KybeleHaveKeystone_C.SessionData.Lines(1).Lines
 msgctxt ",83F4F4214C815B64605575ADD36AEAC7"
 msgid "Tell you what, since you're a breeder, if you give me one of your best offspring, I will let you use the keystone."
-msgstr "Te diré algo, ya que eres un criador, si me das uno de tus mejores descendientes, te dejaré usar la piedra-llave."
+msgstr "Te diré algo, ya que eres un criador, si me das uno de tus mejores descendientes, te dejaré usar la Keystone."
 
 #. Key:	83F96FD847C509C2689331A208A49D12
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault02.Default__EmissaryDefault02_C.SessionData.Lines(5).Lines
@@ -6990,7 +6990,7 @@ msgstr "Bosque de la Lujuria"
 #: /Game/Dialogue/Monarch/Default/MonarchDefault01_RL.Default__MonarchDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
 msgctxt ",84434E3542D0C07128FBC2B58AED1250"
 msgid "Can I have that keystone?"
-msgstr "¿Puedo tener esa piedra-llave?"
+msgstr "¿Puedo tener esa Keystone?"
 
 #. Key:	844B2E20423E6D2A12D638A2DC6596BE
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_RL.Default__FaleneDefault01_RL_C.ResponseData(0).ResponseData.BreederPrompt
@@ -7118,7 +7118,7 @@ msgstr "Portón abierto"
 #: /Game/Dialogue/Cassie/Default/CassieDefault01_Meow.Default__CassieDefault01_Meow_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",8583D0EF44A4998B0C96F2AD09B65314"
 msgid "Look what you did, I'm horny now."
-msgstr "Mira lo que hiciste, estoy cachonda ahora."
+msgstr "Mira lo que hiciste, ya estoy cachonda."
 
 #. Key:	859B4BA447F1B280EC046E90944CED54
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaDefault01_BlueSmoke2.Default__LeylannaDefault01_BlueSmoke2_C.SessionData.Lines(2).Lines
@@ -7202,7 +7202,7 @@ msgstr "¡Oh... ah... sí! Humano... ohhhh."
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R02.Default__FaleneDefault01_R02_C.SessionData.Lines(15).Lines
 msgctxt ",86705CF240B11C01C39F05BA7F02F512"
 msgid "Be sure to look out for needy blessed @MONSTER_RACE@, just be vigilant as you venture around the world, you can't miss them!"
-msgstr "Asegúrate de estar atento a los @MONSTER_RACE@ bendecidos necesitados, solo mantente alerta mientras te aventuras por el mundo, ¡no los puedes perder!"
+msgstr "Asegúrate de estar atento a los @MONSTER_RACE@ bendecidos necesitados, solo mantente alerta mientras te aventuras por el mundo, ¡no les puedes fallar!"
 
 #. Key:	86818D694AB04782DD1A299E28AC5BAF
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R03.Default__FaleneDefault01_R03_C.SessionData.Lines(11).Lines
@@ -7216,14 +7216,14 @@ msgstr "O... puedes vencerlos y salirte con la tuya."
 #: /Game/Dialogue/MegaSlime/Default/MegaSlimePearl.Default__MegaSlimePearl_C.SessionData.Lines(0).Lines
 msgctxt ",86BA29A64B876404EC611EBF5E4E3F55"
 msgid "Wow! It's so beautiful."
-msgstr "¡Guau! Es tan hermoso."
+msgstr "¡Guau! Es tan hermosa."
 
 #. Key:	86C230E147542961EF516C854DF91DDB
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiGreeting01.Default__ParvatiGreeting01_C.SessionData.LinesToFemale(9).LinesToFemale
 #: /Game/Dialogue/Parvati/Default/ParvatiGreeting01.Default__ParvatiGreeting01_C.SessionData.LinesToFemale(9).LinesToFemale
 msgctxt ",86C230E147542961EF516C854DF91DDB"
 msgid "Now let's make love, or you shall find the Her ire."
-msgstr "Ahora hagamos el amor, o encontrarás la ira de Ella."
+msgstr "Ahora hagamos el amor, o te encontrarás con Su ira."
 
 #. Key:	86DA9E6A4C65102E4B28A3968C3DA8FC
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_Teach.Default__ParvatiDefault01_Teach_C.SessionData.Lines(4).Lines
@@ -7244,7 +7244,7 @@ msgstr "¿Quieres ver todo lo mío?"
 #: /Game/World/Overworld.Overworld:PersistentLevel.DemonPool.ManageActionMessage
 msgctxt ",86DE4E4645DF60181C48AD85C95C97BA"
 msgid "Manage your Demons"
-msgstr "Gestiona tus Demons"
+msgstr "Gestiona tus Demonios"
 
 #. Key:	86F7371A4137035AE44922A31E9A0F25
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeVerySad.Default__MegaSlimeVerySad_C.SessionData.Lines(3).Lines
@@ -7286,7 +7286,7 @@ msgstr "¿Bueno, qué estás esperando? ¡Venga!"
 #: /Game/Dialogue/Kybele/Default/KybeleDragonMatriarch.Default__KybeleDragonMatriarch_C.SessionData.Lines(1).Lines
 msgctxt ",876C0AAA40651DB0D464218A41FDE0CB"
 msgid "A centaur never backs down from her duty. I have sworn an oath and nothing will sway me!"
-msgstr "Un centauro nunca se echa atrás en su deber. ¡He hecho un juramento y nada me influirá!"
+msgstr "Un centauro nunca se echa atrás en su deber. ¡He hecho un juramento y nada me hará cambiar de opinión!"
 
 #. Key:	8778E21C45BEF3475418C79BD3B95062
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeGreeting01.Default__MegaSlimeGreeting01_C.SessionData.Lines(2).Lines
@@ -7307,7 +7307,7 @@ msgstr "Qué triste... no han crecido en cientos de años. ¡Esas pobres abejas!
 #: /Game/Dialogue/Autumn/Default/DryadFlowers.Default__DryadFlowers_C.SessionData.Lines(5).Lines
 msgctxt ",87AE8529473D2DEE9E580591D88F1EE5"
 msgid "As you might have guessed from the name, ejaculum-phallis are famous for producing tons of nectar."
-msgstr "Como habrás adivinado por el nombre, los ejaculum-phallis son famosos por producir toneladas de néctar."
+msgstr "Como habrás adivinado por el nombre, las ejaculum-phallis son famosas por producir toneladas de néctar."
 
 #. Key:	87F01F0B48F45D7E461449960ED82A56
 #. SourceLocation:	/Game/Dialogue/Leylanna/Default/LeylannaGreeting01.Default__LeylannaGreeting01_C.SessionData.Lines(1).Lines
@@ -7547,21 +7547,21 @@ msgstr "Pero creo que le gusta tener un acceso más fácil a mi entrepierna..."
 #: /Game/Dialogue/Cassie/SexScenes/CassieButterButtF.Default__CassieButterButtF_C.SessionData.Lines(3).Lines
 msgctxt ",8C159EEF4934350128EF61B587714DE0"
 msgid "Meow! It feels so good! Kitty cum for you soon ohhh!"
-msgstr "¡Miau! ¡Se siente tan bien! ¡Gatita correrse para ti pronto ohhh!"
+msgstr "¡Miau! ¡Se siente tan bien! ¡La gatita se correrá para ti pronto, ohhh!"
 
 #. Key:	8C3EC08A4B6E0CBD02C0D9A1DF7CF43E
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R01.Default__FaleneDefault01_R01_C.SessionData.Lines(16).Lines
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R01.Default__FaleneDefault01_R01_C.SessionData.Lines(16).Lines
 msgctxt ",8C3EC08A4B6E0CBD02C0D9A1DF7CF43E"
 msgid "But, the dominant @MONSTER_RACE@ half ensures that the offspring is always @MONSTER_RACE@ and reproduction works the @MONSTER_RACE@ way."
-msgstr "Pero, la mitad @MONSTER_RACE@ dominante asegura que la descendencia sea siempre @MONSTER_RACE@ y la reproducción funcione del modo @MONSTER_RACE@."
+msgstr "Pero, la mitad @MONSTER_RACE@ dominante asegura que la descendencia sea siempre @MONSTER_RACE@ y la reproducción funciona del modo @MONSTER_RACE@."
 
 #. Key:	8C5FB38741A249FFD19CB3AB1EDFCC3D
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.CBGate_Breaks.BlockMessage
 #: /Game/World/Overworld.Overworld:PersistentLevel.CBGate_Breaks.BlockMessage
 msgctxt ",8C5FB38741A249FFD19CB3AB1EDFCC3D"
 msgid "Kybele guards this Cockblock Gate."
-msgstr "Kybele protege este Portón Bloque-polla."
+msgstr "Kybele protege este Portón Cockblock."
 
 #. Key:	8C93DBB64045A67B0309ACB46E0AD026
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimePlay1.Default__MegaSlimePlay1_C.SessionData.LinesToFemale(3).LinesToFemale
@@ -7610,7 +7610,7 @@ msgstr "Una oportunidad de aparearme con un humano está haciendo que mi corazó
 #: /Game/Dialogue/QueenBee/Default/BeeAboutBees.Default__BeeAboutBees_C.SessionData.Lines(4).Lines
 msgctxt ",8CDBFE6141B0505672CA5BAAD842B1B4"
 msgid "Ahhh... the milking process is... quite pleasurable trust me human."
-msgstr "Ahhh... el proceso de ordeño es... bastante placentero confía en mí humano."
+msgstr "Ahhh... el proceso de ordeño es... bastante placentero confía en mí, humano."
 
 #. Key:	8D055D5140B28DADFD055EA100CF2F32
 #. SourceLocation:	/Game/Characters/Procedural/Variants/Vulwarg/Harvest/VulwargHarvest.Default__VulwargHarvest_C.Harvest.Description
@@ -7708,7 +7708,7 @@ msgstr "Pensándolo bien, no tengo sed."
 #: /Game/Dialogue/Kybele/Default/KybeleAnyMeans.Default__KybeleAnyMeans_C.SessionData.LinesToFemale(5).LinesToFemale
 msgctxt ",8E670FBC49A79D7C192CB5916E7E2B4B"
 msgid "If you do not leave this place, your little human pussy will become aquainted with it!"
-msgstr "Si no abandonas este lugar, ¡tu pequeño coño humano se familiarizará con él!"
+msgstr "Si no abandonas este lugar, ¡tu pequeño coño humano se familiarizará con ella!"
 
 #. Key:	8E6A9EEC45D5EC9F679747AFFA8DA855
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchHaveKeystone.Default__MonarchHaveKeystone_C.SessionData.Lines(6).Lines
@@ -8012,7 +8012,7 @@ msgstr "Granero de Nephelym"
 #: /Game/Dialogue/QueenBee/Default/BeeDefault02_RL.Default__BeeDefault02_RL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",939FC3974789211249F6CB84A4A9FCB8"
 msgid "Can I have that keystone?"
-msgstr "¿Puedo tener esa piedra-llave?"
+msgstr "¿Puedo tener esa Keystone?"
 
 #. Key:	93ACD44B44EFF7C20AF15E9D718C3166
 #. SourceLocation:	/Game/Breeding/Positions/Missionary.Default__Missionary_C.SessionData.PositionName
@@ -8111,7 +8111,7 @@ msgstr "Pagaste el precio, ahora tu pequeña eyaculación humana es toda mía."
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_AboutLamias.Default__NeelaDefault01_AboutLamias_C.SessionData.Lines(4).Lines
 msgctxt ",94FAC38648F37068EA98D4BEB220AA61"
 msgid "Apparently, the males and futas had two dicks."
-msgstr "Al parecer, los machos y las futas tenían dos vergas."
+msgstr "Al parecer, los machos y las futas tenían dos penes."
 
 #. Key:	954CCB0A40A176E6B34A32A8E4590B0A
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchStartShySexT.Default__MonarchStartShySexT_C.SessionData.Lines(0).Lines
@@ -8189,7 +8189,7 @@ msgstr "A diferencia de la nephnip, el humo azul destruye tu mente... solo mira 
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(30).LinesToMale
 msgctxt ",96824C894B9B4241DBDFEEB68C760057"
 msgid "If you want to learn about how to catch @MONSTER_RACE@, head to the town located up the plateau ahead and speak to my assistant Camilla. You can't miss her... actually wait you might, she's so tiny and cute hehehe."
-msgstr "Si quieres aprender cómo atrapar @MONSTER_RACE@, dirígete a la ciudad ubicada en la meseta más adelante y habla con mi asistente Camilla. No puedes perderla... en realidad, espera, es posible, es tan pequeña y linda jejeje."
+msgstr "Si quieres aprender cómo atrapar @MONSTER_RACE@, dirígete a la ciudad ubicada en la meseta más adelante y habla con mi asistente Camilla. No puedes fallarle... en realidad, espera, es posible, es tan pequeña y linda jejeje."
 
 #. Key:	9697386D4E5433DC67FA228576AC58B4
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernBeeFlowers3.Default__FernBeeFlowers3_C.SessionData.Lines(0).Lines
@@ -8238,7 +8238,7 @@ msgstr "*Ronronea*"
 #: /Game/Ranch/Upgrades/FoxenHouse.Default__FoxenHouse_C.Upgrade.Description
 msgctxt ",9717FEC243A7CD17EDAAD89765F8E2A8"
 msgid "This allows you to catch and store all variants of Foxen."
-msgstr "Esto te permite capturar y almacenar todas las variantes de foxens."
+msgstr "Esto te permite capturar y almacenar todas las variantes de Foxens."
 
 #. Key:	97244FB84D6D7CC0273CD3BB89B847D9
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(22 - Value).TraitIcons.DisplayName
@@ -8421,7 +8421,7 @@ msgstr "El humano viene por fin a buscar mi sabiduría."
 #: /Game/Dialogue/Widow/Default/WidowDefault01_RL.Default__WidowDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
 msgctxt ",99D4A5E745FE69C8C652C6AC80533D2D"
 msgid "Can I have that keystone?"
-msgstr "¿Puedo tener esa piedra-llave?"
+msgstr "¿Puedo tener esa Keystone?"
 
 #. Key:	99E0E26846BB80B4206E7DB11488DCC4
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernBeeFlowers.Default__FernBeeFlowers_C.SessionData.Lines(2).Lines
@@ -8456,7 +8456,7 @@ msgstr "¡Oh! Ejem..."
 #: /Game/Dialogue/Camilla/Default/CamillaHadSex01.Default__CamillaHadSex01_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",9A872CD1493BC95421F01C946AF0F7E4"
 msgid "Wow human, you must have been desperate to give this nugget your love."
-msgstr "Guau, humana, debes haber estado desesperada por darle a esta pepita tu amor."
+msgstr "Guau, humana, debes haber estado desesperada para darle a esta pepita tu amor."
 
 #. Key:	9A9EDF3448107C0855BB35BBD9D849F5
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(23).LinesToFemale
@@ -8540,7 +8540,7 @@ msgstr "Mientras medito, todo lo que quiero es hacer el amor contigo."
 #: /Game/Dialogue/DragonMatriarch/Default/DMYourChildren.Default__DMYourChildren_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",9C0628944A08387197D344B7CBC502FB"
 msgid "The dragon race will reign supreme over all of @WORLD_NAME@!"
-msgstr "¡La raza dragón reinará sobre todo @WORLD_NAME@!"
+msgstr "¡La raza dragón reinará sobre toda @WORLD_NAME@!"
 
 #. Key:	9C25CF834B78D0D105D4C98D2D869441
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiHadSex01.Default__FesssiHadSex01_C.SessionData.LinesToFemale(0).LinesToFemale
@@ -8603,7 +8603,7 @@ msgstr "¿A dónde lleva esa cueva?"
 #: /Game/Dialogue/Kybele/Default/KybeleDefault01_RL.Default__KybeleDefault01_RL_C.ResponseData(3).ResponseData.BreederPrompt
 msgctxt ",9DCE82F542FEDB443D7432A9C8EE7AF6"
 msgid "By any means necessary..."
-msgstr "Por cualquier medio necesario..."
+msgstr "Por cualquier medio que sea necesario..."
 
 #. Key:	9E0F2A7F4F6510D820FB12BE4580D421
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_EnlightenedOne.Default__NeelaDefault01_EnlightenedOne_C.SessionData.Lines(3).Lines
@@ -8726,7 +8726,7 @@ msgstr "Inmenso: aproximadamente 15 pies (4,5 m) de altura."
 #: /Game/Dialogue/Kybele/Default/KybeleTittyPony_T.Default__KybeleTittyPony_T_C.SessionData.LinesToFuta(0).LinesToFuta
 msgctxt ",9F883FFA4CA5D4B34A5726989E26C6C5"
 msgid "That's it human, you have annoyed me long enough. Get against that rock and prepare to be smashed."
-msgstr "Eso es humano, me has molestado lo suficiente. Ponte contra esa roca y prepárate para ser aplastado."
+msgstr "Eso es humana, me has molestado lo suficiente. Ponte contra esa roca y prepárate para ser aplastada."
 
 #. Key:	9F8F75924886323A16353D90FDCB1B1C
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernBeeFlowers.Default__FernBeeFlowers_C.SessionData.Lines(0).Lines
@@ -8838,7 +8838,7 @@ msgstr "Quiero sentir tus suaves pechos... encima de los míos... ahhh."
 #: /Game/Dialogue/Leylanna/Default/LeylannaGreeting01.Default__LeylannaGreeting01_C.SessionData.Lines(3).Lines
 msgctxt ",A208709240369AEC212F70B1CEFE7BE8"
 msgid "Let us make love to form a covenant in Her holy temple, and you can meet your spirit form."
-msgstr "Hagamos el amor para formar un convenio en Su santo templo, y podrás encontrar tu forma espiritual."
+msgstr "Hagamos el amor para formar un pacto en Su templo sagrado, y podrás encontrar tu forma espiritual."
 
 #. Key:	A21511DE4632808A0555608E6F6880C6
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowScary.Default__WidowScary_C.SessionData.Lines(2).Lines
@@ -8866,7 +8866,7 @@ msgstr "Bueno, debo irme, ¡buena suerte criador!"
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R03.Default__CamillaDefault01_R03_C.SessionData.Lines(2).Lines
 msgctxt ",A2EE900942F55DC4C6AA92BC44E482E4"
 msgid "Most dicks in this world are larger than me! As someone who collects and studies cum, you can't imagine how miserable it is stroking dick after dick and never being able to feel them penetrate me."
-msgstr "¡La mayoría de las pollas de este mundo son más grandes que yo! Como alguien que recolecta y estudia semen, no te imaginas lo miserable que es acariciar un pene tras otro y nunca pudiendo sentirlos penetrarme."
+msgstr "¡La mayoría de los penes de este mundo son más grandes que yo! Como alguien que recolecta y estudia semen, no te imaginas lo miserable que es acariciar un pene tras otro y nunca ser capaz de sentirlos penetrarme."
 
 #. Key:	A350122B4286C7BCFA490982F8390CB1
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieGreeting01.Default__CassieGreeting01_C.SessionData.Lines(2).Lines
@@ -8880,7 +8880,7 @@ msgstr "¿Rancho? ¡Ah claro, y tu rancho también!"
 #: /Game/Dialogue/OrcChief/Default/OrcGoneWorse.Default__OrcGoneWorse_C.SessionData.Lines(1).Lines
 msgctxt ",A3546DAB440D5D09BE7F809541FB90C3"
 msgid "Chieftain very horny, you will regret this. Come here!"
-msgstr "Cacique muy cachonda, te arrepentirás de esto. ¡Ven aquí!"
+msgstr "La cacique muy cachonda, te arrepentirás de esto. ¡Ven aquí!"
 
 #. Key:	A3A36F6A453B245F5CA58C97B791509D
 #. SourceLocation:	/Game/Dialogue/Cassie/SexScenes/CassieButterButtF.Default__CassieButterButtF_C.SessionData.Lines(0).Lines
@@ -8901,7 +8901,7 @@ msgstr "¡El pecho de Mastah tan suave! A Fern gustarle."
 #: /Game/Dialogue/Parvati/Default/ParvatiDefault01_Teach.Default__ParvatiDefault01_Teach_C.SessionData.Lines(2).Lines
 msgctxt ",A40264BD4BB3E658212ECE987CC24B4A"
 msgid "Don't worry, for I can change my size."
-msgstr "No te preocupes, porque puedo cambiar mi tamaño."
+msgstr "No te preocupes, puedo cambiar mi tamaño."
 
 #. Key:	A41D55094C37585E241DB98D76B52F65
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToFemale(6).LinesToFemale
@@ -8936,7 +8936,7 @@ msgstr "Pawsmaati es anciana, mucho mayor que yo o cualquier otra persona que ha
 #: /Game/Dialogue/Widow/Default/WidowHadSex01.Default__WidowHadSex01_C.SessionData.LinesGrungy(0).LinesGrungy
 msgctxt ",A4B99F3C407E9C094C137DAF9E60A51F"
 msgid "Oh you dirty dirty human... what have you done to yourself?"
-msgstr "Oh, sucio, sucio humano... ¿Qué te has hecho a ti mismo?"
+msgstr "Oh, sucio, sucio humano... ¿qué te has hecho a ti mismo?"
 
 #. Key:	A4C22B3045E8159B66E47CB636E23172
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(18 - Value).TraitIcons.DisplayName
@@ -8958,7 +8958,7 @@ msgstr "¡Este rincón es a-a-agradable y seguro!"
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R02.Default__CamillaDefault01_R02_C.SessionData.Lines(3).Lines
 msgctxt ",A4E670824F11C45EC16FA29BAF6EB6E1"
 msgid "Bovaur can be found sleeping in the soft grass of Pleasure Pastures."
-msgstr "Se puede encontrar a bovaur durmiendo en la suave hierba de los Pastos del Placer."
+msgstr "Se puede encontrar a bovaurs durmiendo en la suave hierba de los Pastos del Placer."
 
 #. Key:	A4F79CC74333E2131FC34EBBF3796A56
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchDefault01.Default__MonarchDefault01_C.SessionData.LinesToFemale(2).LinesToFemale
@@ -8972,7 +8972,7 @@ msgstr "¡Menos mal que tengo mi juguete!"
 #: /Game/Dialogue/DragonMatriarch/Default/DMGreeting01.Default__DMGreeting01_C.SessionData.Lines(3).Lines
 msgctxt ",A5496AE246B786D1E975C6A2F4004B43"
 msgid "That useless titty pony failed again I see. She will feel my wrath."
-msgstr "Veo que esa pony tetudita inútil falló de nuevo. Ella sentirá mi ira."
+msgstr "Veo que esa inútil pony tetudita falló de nuevo. Ella sentirá mi ira."
 
 #. Key:	A56B0F264A329DF192CE53B3DBA118EB
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiWantAss.Default__FesssiWantAss_C.SessionData.Lines(2).Lines
@@ -9007,7 +9007,7 @@ msgstr "¡Ohhh! Ahhh... esa fue una buena."
 #: /Game/Dialogue/Fesssi/Default/FesssiStuck.Default__FesssiStuck_C.SessionData.Lines(4).Lines
 msgctxt ",A5C9D438443FEDCB4CF41985385B02E1"
 msgid "Such is how I learned of my buxom genetics, few blessed ones possess the trait and it is highly coveted."
-msgstr "Así es como me enteré de mi genética exuberante, pocos benditos poseen el rasgo y es muy codiciado."
+msgstr "Así es como me enteré de mi genética exuberante, pocos bendecidos poseen el rasgo y es muy codiciado."
 
 #. Key:	A6D19C3141AF406B6318CA8CB0A72613
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R02.Default__FaleneDefault01_R02_C.SessionData.Lines(0).Lines
@@ -9063,7 +9063,7 @@ msgstr "Tal... ahhh... desviación..."
 #: /Game/Dialogue/Monarch/Default/MonarchDefault01_RL.Default__MonarchDefault01_RL_C.ResponseData(3).ResponseData.BreederPrompt
 msgctxt ",A794490B471FFA8A958C3BA3B3BFDB9C"
 msgid "How adorable, may I have the keystone now?"
-msgstr "Qué adorable, ¿puedo tener la piedra-llave ahora?"
+msgstr "Qué adorable, ¿puedo tener la Keystone ahora?"
 
 #. Key:	A7C8404E4B6C68006478148076380602
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R01.Default__FaleneDefault01_R01_C.SessionData.Lines(14).Lines
@@ -9168,7 +9168,7 @@ msgstr "Sobre esa mazmorra de allí..."
 #: /Game/Dialogue/Kybele/Default/KybeleDefault01_RL.Default__KybeleDefault01_RL_C.ResponseData(5).ResponseData.BreederPrompt
 msgctxt ",A931FB674A22AA9E31C00B9F0762AF5C"
 msgid "Too much information... now, the keystone."
-msgstr "Demasiada información... ahora, la piedra-llave."
+msgstr "Demasiada información... ahora, la Keystone."
 
 #. Key:	A95B76C9415993E5F52ECDA4492EBE73
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiDefault03_RL_T.Default__FesssiDefault03_RL_T_C.ResponseData(1).ResponseData.BreederPrompt
@@ -9224,14 +9224,14 @@ msgstr "¡Ahora humano repara el portón!"
 #: /Game/Dialogue/Romy/Default/RomyGreeting01.Default__RomyGreeting01_C.SessionData.Lines(0).Lines
 msgctxt ",AA16BE3B4732F407329ED6B450557C71"
 msgid "A strange song approaches me, a tune not heard in this land."
-msgstr "Una extraña canción se me acerca, una melodía que no se escucha en esta tierra."
+msgstr "Una extraña canción se acerca a mi, una melodía no escuchada en esta tierra."
 
 #. Key:	AA18E8094B0BEABB8C6A948FC36B6552
 #. SourceLocation:	/Game/Dialogue/Yasmine/Default/YasmineHadSex01.Default__YasmineHadSex01_C.SessionData.LinesGrungy(0).LinesGrungy
 #: /Game/Dialogue/Yasmine/Default/YasmineHadSex01.Default__YasmineHadSex01_C.SessionData.LinesGrungy(0).LinesGrungy
 msgctxt ",AA18E8094B0BEABB8C6A948FC36B6552"
 msgid "Oh you dirty dirty human... what have you done to yourself?"
-msgstr "Oh, sucio, sucio humano... ¿Qué te has hecho a ti mismo?"
+msgstr "Oh, sucio, sucio humano... ¿qué te has hecho a ti mismo?"
 
 #. Key:	AA19D8F246FE5FAD5F7E9D8BEEDF10E3
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeHadSex01.Default__MegaSlimeHadSex01_C.SessionData.LinesToFemale(3).LinesToFemale
@@ -9259,7 +9259,7 @@ msgstr "Ella puede polinizarme todo el día y juntos haremos una fruta increíbl
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R02.Default__FaleneDefault01_R02_C.SessionData.Lines(6).Lines
 msgctxt ",AAD8CEA34AE6DE13A8683089046598D3"
 msgid "Not that you could anyway, we will just take the collar off if you try to put it on us!"
-msgstr "No es que pudieras de todos modos, ¡solo nos quitaremos el collar si intentas ponérnoslo!"
+msgstr "No es que pudieras de todos modos, ¡simplemente nos quitaremos el collar si intentas ponérnoslo!"
 
 #. Key:	AB0597744358BD82828774A65E812AEE
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.EM_HedonDungeonSwitch.ActivateMessage
@@ -9273,7 +9273,7 @@ msgstr "Palanca de Tiro"
 #: /Game/Dialogue/OrcChief/Default/OrcFixOwnGate.Default__OrcFixOwnGate_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",AB0F23814A695DE61DBE5DB8FFDFC3EA"
 msgid "No one says no to chieftain!"
-msgstr "¡Nadie dice que no a cacique!"
+msgstr "¡Nadie dice que no a la cacique!"
 
 #. Key:	AB33AE4E444B3C498B0DFF9C8B60192F
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.CBGate_Crag.PlaceMessage
@@ -9322,7 +9322,7 @@ msgstr "*Chupa* *Besa*"
 #: /Game/Dialogue/OrcChief/Default/OrcTribeSucks.Default__OrcTribeSucks_C.SessionData.Lines(3).Lines
 msgctxt ",AC0651B441F4DE497F64ABAC64E703E2"
 msgid "Elves are soft and easy, they like making offspring with us."
-msgstr "Los elfos son suaves y fáciles, les gusta tener descendencia con nosotros."
+msgstr "Los elfos son blandos y fáciles, les gusta tener descendencia con nosotros."
 
 #. Key:	AC30709F43155DB485B91FA519412629
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleTittyPony_T.Default__KybeleTittyPony_T_C.SessionData.LinesToMale(0).LinesToMale
@@ -9357,7 +9357,7 @@ msgstr "Sin embargo, nuestro semen y óvulos son donde ocurre la \"magia\"."
 #: /Game/Dialogue/Cassie/Default/CassieGreeting01.Default__CassieGreeting01_C.SessionData.Lines(1).Lines
 msgctxt ",AD1829A4465DB79DEB4829B81F4E7A03"
 msgid "Meow! That's a fine piece o' property ya got down there..."
-msgstr "¡Miau! Esa es un buen pedazo de propiedad lo que tienes ahí abajo..."
+msgstr "¡Miau! Esa es una buena pedazo de propiedad la que tienes ahí abajo..."
 
 #. Key:	AD224A514AC35938B00457BC8B2C7422
 #. SourceLocation:	/Game/Dialogue/Blossom/Default/BlossomDefault01_R02.Default__BlossomDefault01_R02_C.SessionData.Lines(2).Lines
@@ -9371,7 +9371,7 @@ msgstr "¡Blossom necesssita fluidosss!"
 #: /Game/Dialogue/Kybele/Default/KybeleCentaur.Default__KybeleCentaur_C.SessionData.Lines(3).Lines
 msgctxt ",AD478B234D74F4166BEDE6A5C70593F6"
 msgid "And believe me human... it has been awhile."
-msgstr "Y créeme humana... ha pasado un tiempo."
+msgstr "Y créeme humano... ha pasado un tiempo."
 
 #. Key:	AD4B293B4D8F1432446C92924F59456E
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(22).LinesToFemale
@@ -9434,7 +9434,7 @@ msgstr "Si te sorprenden con sexo, perderás toda tu energía y te verás obliga
 #: /Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(29).LinesToFemale
 msgctxt ",AE61589245BE1F5DEB7163B4C2AD2756"
 msgid "A world of sex and adventures awaits!"
-msgstr "¡Un mundo de sexo y aventuras te espera!"
+msgstr "¡Te espera un mundo de sexo y aventuras!"
 
 #. Key:	AE940C0E4203F3605E98088D0827EA0B
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMYourChildren.Default__DMYourChildren_C.SessionData.LinesToFemale(2).LinesToFemale
@@ -9483,7 +9483,7 @@ msgstr "Uh... ¿estás bien?"
 #: /Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",AF6126694453EEB0A7AA7787649EC605"
 msgid "Perhaps you would like to stick that dick in my sparkly elf pussy? Ahhh I would love that..."
-msgstr "¿Quizás te gustaría meter ese pene en mi brillante coño de elfa? Ahhh me encantaría eso..."
+msgstr "¿Quizás te gustaría meter ese pene en mi brillante coño de elfa? Ahhh, me encantaría eso..."
 
 #. Key:	AFBF754C422E5E00DF8BB7A37B956DFB
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(10 - Value).TraitIcons.HelpText
@@ -9519,7 +9519,7 @@ msgstr "Sin embargo, ¡son meros simplones que sirven como mi ganado reproductor
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R03.Default__FaleneDefault01_R03_C.SessionData.Lines(0).Lines
 msgctxt ",B071E1E04B9EA4D9C227C2935955161A"
 msgid "Wild @MONSTER_RACE@ are what you will be catching and breeding."
-msgstr "@MONSTER_RACE@ silvestres son los que atraparás y te reproducirás."
+msgstr "Los @MONSTER_RACE@ silvestres son los que atraparás y te reproducirás."
 
 #. Key:	B088E0624E17857FAE8AE4B893251DA2
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(0 - Value).TraitIcons.DisplayName
@@ -9534,7 +9534,7 @@ msgstr "Humanoide"
 #: /Game/Dialogue/QueenBee/Default/BeeHaveKeystone1.Default__BeeHaveKeystone1_C.SessionData.Lines(1).Lines
 msgctxt ",B0D63ADB45CCFD884D1581A5725EA8BF"
 msgid "Should you manage to do it, the keystone will be granted to you and I shall instruct my workers to remove the honey blocking Sultry Plateau."
-msgstr "Si logras hacerlo, se te otorgará la piedra-llave y daré instrucciones a mis trabajadoras para que retiren la miel que bloquea la Meseta Bochornosa."
+msgstr "Si logras hacerlo, se te otorgará la Keystone y daré instrucciones a mis trabajadoras para que retiren la miel que bloquea la Meseta Bochornosa."
 
 #. Key:	B0F5CCC741FEDFC39587579F638D56DC
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeMasturbate.Default__BeeMasturbate_C.SessionData.Lines(3).Lines
@@ -9555,7 +9555,7 @@ msgstr "¡Ohhh, pero lo hice!"
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R07.Default__FaleneDefault01_R07_C.SessionData.LinesToFuta(1).LinesToFuta
 msgctxt ",B11026CD462D3D9C5256F4A490A45911"
 msgid "Errrr, I can't stand it anymore, I'm going to milk you dry! I have never tasted human cum before!"
-msgstr "Errrr, no puedo soportarlo más, ¡voy a ordeñarte hasta secarte! ¡Nunca antes había probado semen humano!"
+msgstr "Errrr, no puedo soportarlo más, ¡voy a ordeñarte hasta dejarte seca! ¡Nunca antes había probado semen humano!"
 
 #. Key:	B12A342547F0295A52457D814E45C485
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_AreYouBlessed.Default__EmissaryDefault01_AreYouBlessed_C.SessionData.Lines(0).Lines
@@ -9569,7 +9569,7 @@ msgstr "Sí @BREEDER_NAME@."
 #: /Game/Dialogue/DragonMatriarch/Default/DMDefault_RL2.Default__DMDefault_RL2_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",B1435DF7419D2F4948DD9B9EFF8E628E"
 msgid "Are all of these wild dragons your children?"
-msgstr "¿Son todos estos dragones silvestres tus hijos?"
+msgstr "¿Todos estos dragones silvestres son tus hijos?"
 
 #. Key:	B146211A43E4F159EC3A0C85790314DD
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimePlay1.Default__MegaSlimePlay1_C.SessionData.LinesToFuta(5).LinesToFuta
@@ -9590,7 +9590,7 @@ msgstr "Ha pasado algún tiempo desde que me montaron, ¡así que podría ponerm
 #: /Game/Dialogue/Autumn/Default/DryadCherryHelp.Default__DryadCherryHelp_C.SessionData.LinesToFemale(3).LinesToFemale
 msgctxt ",B17C429C4AE53B8CA98F5E8166D598D2"
 msgid "Come closer human..."
-msgstr "Acércate humana..."
+msgstr "Acércate humano..."
 
 #. Key:	B18F6EA040A16FCFD95EB3894A067B79
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeAboutOrb.Default__MegaSlimeAboutOrb_C.SessionData.Lines(5).Lines
@@ -9647,7 +9647,7 @@ msgstr "Mientras tanto... he sido una conejita muy traviesa. ¿Tal vez te gustar
 #: /Game/Dialogue/Fesssi/Default/FesssiCave.Default__FesssiCave_C.SessionData.Lines(0).Lines
 msgctxt ",B22CBCF74EE8D6771B1E7987993911F6"
 msgid "The cave leads to Amorous Hallows. Hiss!"
-msgstr "La cueva conduce a Reliquias Amorosas. ¡Sss!"
+msgstr "La cueva conduce a las Reliquias Amorosas. ¡Sss!"
 
 #. Key:	B2323665415F7EE8A74204A9FD52D914
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(7).Lines
@@ -9710,7 +9710,7 @@ msgstr "¡Un humano! Un humano super lindo... este es mi día de suerte. He esta
 #: /Game/Dialogue/Fern/Default/FernDefault01_R03.Default__FernDefault01_R03_C.SessionData.Lines(1).Lines
 msgctxt ",B36EC36B46E4D040A92BF09236F605F9"
 msgid "Fern need human cum to grow into big Alraune! Hissss, Fern suck dick now!"
-msgstr "¡Fern necesita semen humano para convertirse en una gran alraune! ¡Sssss, Fern chupa pene ahora!"
+msgstr "¡Fern necesita semen humano para convertirse en una gran alraune! ¡Sssss, Fern ahora chupa pene!"
 
 #. Key:	B3953BA1451F630DE2CF019EB4CB6A69
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(23 - Value).TraitIcons.DisplayName
@@ -9795,14 +9795,14 @@ msgstr "Así que quieres aprender nuevas posiciones sexuales, ya veo..."
 #: /Game/Dialogue/OrcChief/Default/OrcDefault01.Default__OrcDefault01_C.SessionData.Lines(2).Lines
 msgctxt ",B5A2F9CD41C677116ECB32818AB2D2D7"
 msgid "Take them to Homestead and make offspring."
-msgstr "Llévalos a la Granja y haz descendencia."
+msgstr "Llévalas a la Granja y engendra descendencia."
 
 #. Key:	B5AD6A9A40AB4528FFC0BCBCD051C66B
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowDefault01.Default__WidowDefault01_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/Widow/Default/WidowDefault01.Default__WidowDefault01_C.SessionData.Lines(1).Lines
 msgctxt ",B5AD6A9A40AB4528FFC0BCBCD051C66B"
 msgid "Ah little one... you are now mine. Don't be afraid, for I only wish to please."
-msgstr "Ah, pequeña... ahora eres mía. No tengas miedo, pues solo deseo complacer."
+msgstr "Ah, pequeña... ahora eres mía. No temas, pues solo deseo complacer."
 
 #. Key:	B5B8312540B0C71F1DDBCEADEF6C3E02
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeGreeting01.Default__AmberMaeGreeting01_C.SessionData.Lines(10).Lines
@@ -9844,7 +9844,7 @@ msgstr "¿Qué más debería hacer una almeja?"
 #: /Game/Dialogue/Emissary/Default/EmissaryRaiseTraitLvl_Decline.Default__EmissaryRaiseTraitLvl_Decline_C.SessionData.Lines(0).Lines
 msgctxt ",B601DE914360E4E4962B9BAE17334C67"
 msgid "A pity indeed human... I suppose such low standards are fitting."
-msgstr "Una lástima, de hecho, humano... supongo que unos estándares tan bajos son adecuados."
+msgstr "Una lástima de hecho, humano... supongo que unos estándares tan bajos son adecuados."
 
 #. Key:	B628775D4659A3C72D73DAAB3B931832
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraPracticeMe.Default__PetraPracticeMe_C.SessionData.Lines(1).Lines
@@ -9886,7 +9886,7 @@ msgstr "La gente del pueblo viene aquí para relajarse y hacer el amor, es hermo
 #: /Game/Dialogue/Autumn/Default/DryadFlowers.Default__DryadFlowers_C.SessionData.Lines(3).Lines
 msgctxt ",B72B154840C9EFADCC67BE89C1C467AA"
 msgid "I can feel the roots of many cuminus flowers, but no ejaculum-phallis. Hmm..."
-msgstr "Puedo sentir las raíces de muchas flores de comino, pero no del ejaculum-phallis. Mmm..."
+msgstr "Puedo sentir las raíces de muchas flores de comino, pero no de ejaculum-phallis. Mmm..."
 
 #. Key:	B740BA7F4ADFB18E32DFE99606B483B3
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeDefault01_SuckJugs.Default__AmberMaeDefault01_SuckJugs_C.SessionData.Lines(0).Lines
@@ -9935,7 +9935,7 @@ msgstr "Ah, la roca brillante atrapada en mi telaraña."
 #: /Game/Dialogue/Camilla/Default/CamillaHadSex02.Default__CamillaHadSex02_C.SessionData.LinesToFemale(0).LinesToFemale
 msgctxt ",B7A8AD6E44A41AB54281548D1A882FFC"
 msgid "Wow human, you must have been desperate to give this nugget your love."
-msgstr "Guau, humana, debes haber estado desesperada por darle a esta pepita tu amor."
+msgstr "Guau, humana, debes haber estado desesperada para darle a esta pepita tu amor."
 
 #. Key:	B7AB851641C9ABEE4A178B9DFFD50B0B
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(33 - Value).TraitIcons.DisplayName
@@ -10014,7 +10014,7 @@ msgstr "Qué encantador helecho parlante..."
 #: /Game/World/Architecture/CockblockGate/EM_CBGate.Default__EM_CBGate_C.ActivateMessage
 msgctxt ",B82BF1F5413587624AD2A6919AF2A0BA"
 msgid "Place Keystone"
-msgstr "Coloca la piedra-llave"
+msgstr "Coloca la Keystone"
 
 #. Key:	B832AA994DBADAA17A15049B206652C5
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R02.Default__CamillaDefault01_R02_C.SessionData.Lines(9).Lines
@@ -10091,7 +10091,7 @@ msgstr "A cuatro patas, la receptora es golpeada por detrás."
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_YourVoid.Default__NeelaDefault01_YourVoid_C.SessionData.LinesToFuta(6).LinesToFuta
 msgctxt ",B8D5DBD04A2C66CA06A044B457DC1B92"
 msgid "Stick that lovely human dick deep into my Lamia body... yes..."
-msgstr "Mete ese hermoso pene humano profundamente en mi cuerpo de lamia... sí..."
+msgstr "Mete ese encantador pene humano profundamente en mi cuerpo de lamia... sí..."
 
 #. Key:	B8E34EF44104C91D147557A4F02B0AD7
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiHadSex01.Default__FesssiHadSex01_C.SessionData.LinesToFuta(0).LinesToFuta
@@ -10105,7 +10105,7 @@ msgstr "Ahhh... otra carga más para mi culo gigante. ¡Sss!"
 #: /Game/Dialogue/QueenBee/Default/BeeAboutBees.Default__BeeAboutBees_C.SessionData.Lines(1).Lines
 msgctxt ",B92677C94581B16A61827CA24E811637"
 msgid "To harvest it, a queen will produce worker bee daughters who then mix the nectar with their breast milk."
-msgstr "Para cosecharla, una reina producirá hijas de abejas obreras que luego mezclan el néctar con su leche materna."
+msgstr "Para cosecharla, una reina producirá hijas abejas obreras que luego mezclan el néctar con su leche materna."
 
 #. Key:	B98DBFC944D984D0B00D708EE1B9AB94
 #. SourceLocation:	/Game/Dialogue/Emissary/SexScenes/EmissaryAngelGroinLove.Default__EmissaryAngelGroinLove_C.SessionData.LinesToFuta(0).LinesToFuta
@@ -10126,7 +10126,7 @@ msgstr "Una vez que la planta haya almacenado suficiente néctar, esperará a qu
 #: /Game/Dialogue/Fesssi/Default/FesssiHowLong.Default__FesssiHowLong_C.SessionData.Lines(2).Lines
 msgctxt ",B9EEB95A4D8ACD7FAC9BD4AE769758FE"
 msgid "Occasionally, random travellers would try to get around me, but they soon found their genitals on the receiving end of my tongue."
-msgstr "De vez en cuando, viajeros aleatorios intentaban rodearme, pero pronto encontraron sus genitales en el extremo receptor de mi lengua."
+msgstr "De vez en cuando, viajeros aleatorios intentaban rodearme, pero pronto se encontraron con sus genitales en el extremo receptor de mi lengua."
 
 #. Key:	B9F630DD484439D0C2B6EFBC3D01D2C5
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_FutaBalls.Default__FaleneDefault01_FutaBalls_C.SessionData.Lines(1).Lines
@@ -10161,7 +10161,7 @@ msgstr "Desde el Vacío, Ella creó este universo y comenzó a disfrutar de la c
 #: /Game/Dialogue/Cassie/Default/CassieGreeting01.Default__CassieGreeting01_C.SessionData.Lines(7).Lines
 msgctxt ",BB0E7B2D4F49CAAB00A884BE87ED9F44"
 msgid "Or if ya wanna really butter my butt and let me see your \"property\"."
-msgstr "O si realmente quieres untarme el trasero y dejarme ver tu \"propiedad\"."
+msgstr "O si realmente quieres untame el trasero y dejame ver tu \"propiedad\"."
 
 #. Key:	BB111DD44D5B70DED7DD519DD967FEC8
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimePlay.Default__MegaSlimePlay_C.SessionData.LinesToFuta(0).LinesToFuta
@@ -10266,7 +10266,7 @@ msgstr "¿Qué es el aturdimiento infinito?"
 #: /Game/Dialogue/Yasmine/Default/YasmineHadSex01.Default__YasmineHadSex01_C.SessionData.Lines(1).Lines
 msgctxt ",BD326ED44A2732523BC286AA438967A7"
 msgid "Waves of ecstasy still course through my body."
-msgstr "Oleadas de éxtasis todavía recorren mi cuerpo."
+msgstr "Las oleadas de éxtasis todavía recorren mi cuerpo."
 
 #. Key:	BD61F6BE4278688EEA2B878F6E8C6994
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(14).LinesToFemale
@@ -10294,7 +10294,7 @@ msgstr "Pero si me llegara el encuentro sexual..."
 #: /Game/Dialogue/Autumn/Default/DryadBossomCherries.Default__DryadBossomCherries_C.SessionData.Lines(1).Lines
 msgctxt ",BDF0CA7D47EE073120067A9FCE686C17"
 msgid "They are for the Ayrshires that roam around here, and oh my can they eat!"
-msgstr "Son para las ayrshires que deambulan por aquí, y ¡oh Dios, lo que pueden comer!"
+msgstr "Son para las ayrshires que deambulan por aquí, ¡y oh cielos, lo que pueden comer!"
 
 #. Key:	BDF9214F4D266A69032FE9921524969C
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFuta(2).LinesToFuta
@@ -10337,14 +10337,14 @@ msgstr "A veces, Falene me hace montar en su espalda por la ciudad."
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01.Default__CamillaDefault01_C.SessionData.Lines(1).Lines
 msgctxt ",BE9F677046DE7F9AE5246FB18D7F8FFB"
 msgid "Once she threw me into that pussy portal when Neela wasn't looking!"
-msgstr "¡Una vez me arrojó a ese coño portal cuando Neela no estaba mirando!"
+msgstr "¡Una vez me arrojó a ese Coño Portal cuando Neela no estaba mirando!"
 
 #. Key:	BED6E4EB4536C7A1E1D8EF8C6FA3F149
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryCockblockGates.Default__EmissaryCockblockGates_C.SessionData.Lines(3).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryCockblockGates.Default__EmissaryCockblockGates_C.SessionData.Lines(3).Lines
 msgctxt ",BED6E4EB4536C7A1E1D8EF8C6FA3F149"
 msgid "But beware, other blessed @MONSTER_RACE@ have collected the keystones over the years."
-msgstr "Pero cuidado, otros @MONSTER_RACE@ bendecidos han recolectado las piedras-llave a lo largo de los años."
+msgstr "Pero cuidado, otros @MONSTER_RACE@ bendecidos han recolectado las Keystones a lo largo de los años."
 
 #. Key:	BEDA154E4410DE62211DBFA48872ED35
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchHadSex01.Default__MonarchHadSex01_C.SessionData.LinesToFemale(0).LinesToFemale
@@ -10365,7 +10365,7 @@ msgstr "¿Falene dijo que podrías decirme cómo atrapar @MONSTER_RACE@?"
 #: /Game/Dialogue/QueenBee/Default/BeeTaskFulfilled.Default__BeeTaskFulfilled_C.SessionData.Lines(3).Lines
 msgctxt ",BF0DF5C24AC9872B58BA689D790CE436"
 msgid "The keystone now belongs to you."
-msgstr "La piedra-llave ahora te pertenece."
+msgstr "La Keystone ahora te pertenece."
 
 #. Key:	BF4DCF6B4CBF1E3FAE0D139E494C7673
 #. SourceLocation:	/Game/Characters/Procedural/Variants/Demon/Harvest/DemonHarvest.Default__DemonHarvest_C.Harvest.RaceName
@@ -10400,7 +10400,7 @@ msgstr "Meh... ¡eres uno más de los que piensan que soy linda porque soy peque
 #: /Game/Dialogue/OrcChief/Default/OrcBrashDumb.Default__OrcBrashDumb_C.SessionData.Lines(5).Lines
 msgctxt ",BF975F284EF533BA005E9DB9E53ED275"
 msgid "Orc who wins the most fights and makes the most offspring becomes chieftain."
-msgstr "El orco que gana más peleas y tiene más descendientes se convertir en cacique."
+msgstr "El orco que gana más peleas y tiene más descendientes se convierte en el cacique."
 
 #. Key:	BFA3EA894BDCD8476E3C3E83125BF435
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R04.Default__FaleneDefault01_R04_C.SessionData.Lines(3).Lines
@@ -10478,7 +10478,7 @@ msgstr "Hicimos el amor durante horas, ¡y ella me enseñó a colocar mi cuerpo 
 #: /Game/World/Overworld.Overworld:PersistentLevel.EM_Keystone_Widow.FailMessage
 msgctxt ",C0E8ACF94F6090E346B6B3BFDB6536AF"
 msgid "It's wrapped in webs."
-msgstr "Está envuelto en telarañas."
+msgstr "Está envuelta en telarañas."
 
 #. Key:	C1169E76415C88B42A1C1EAA53F38266
 #. SourceLocation:	/Game/Dialogue/Neela/Default/NeelaDefault01_EnlightenedOne.Default__NeelaDefault01_EnlightenedOne_C.SessionData.Lines(2).Lines
@@ -10506,7 +10506,7 @@ msgstr "Si debo..."
 #: /Game/Dialogue/Emissary/Default/EmissaryGreeting01.Default__EmissaryGreeting01_C.SessionData.Lines(2).Lines
 msgctxt ",C156402F4738F87B9C9392A5443BE29F"
 msgid "You are unique in this world, for all other living things, myself included, are @MONSTER_RACE@. We are merely half human, crossed with... something else."
-msgstr "Eres único en este mundo, pues todos los demás seres vivos, incluida yo misma, somos @MONSTER_RACE@. Somos simplemente mitad humanos, cruzados con... algo más."
+msgstr "Eres único en este mundo, todos los demás seres vivos, incluida yo misma, somos @MONSTER_RACE@. Somos simplemente mitad humanos, cruzados con... algo más."
 
 #. Key:	C18558714C7A7B697778D68CFD03FAF0
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_AboutKrakens.Default__MirruDefault01_AboutKrakens_C.SessionData.Lines(4).Lines
@@ -10534,7 +10534,7 @@ msgstr "Esto te permite capturar y almacenar todas las variantes de Formurians."
 #: /Game/Dialogue/Autumn/Default/DryadFatAssLamia.Default__DryadFatAssLamia_C.SessionData.Lines(6).Lines
 msgctxt ",C25D4CE34387E86F32C4E28046D053D3"
 msgid "Ohhh it felt so good.... as I buried my face into her ass and she thrusted her tongue deep into my pussy."
-msgstr "Ohhh, se sintió tan bien... mientras enterraba mi cara en su culo y ella empujaba su lengua profundamente en mi coño."
+msgstr "Ohhh, se sintió tan bien... mientras enterraba mi cara en su culo y ella empujaba su lengua profundamente dentro de mi coño."
 
 #. Key:	C29993C74D67F8AE960E44826013B47C
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_AboutKrakens.Default__MirruDefault01_AboutKrakens_C.SessionData.Lines(1).Lines
@@ -10583,7 +10583,7 @@ msgstr "¡Baile Erótico!"
 #: /Game/Dialogue/OrcChief/Default/OrcHadSex01.Default__OrcHadSex01_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",C396D17343484B5599E940B3CD9E0AF1"
 msgid "Grrrrr... chieftain horny again. Human shouldn't stay long, things might happen."
-msgstr "Grrrrr... cacique cachonda de nuevo. El humano no debería quedarse mucho tiempo, podrían pasar cosas."
+msgstr "Grrrrr... la cacique cachonda de nuevo. El humano no debería quedarse mucho tiempo, podrían pasar cosas."
 
 #. Key:	C45BFAF14EABF8D1BD3502825C5C1560
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_FloatRhyme.Default__ParvatiDefault01_FloatRhyme_C.SessionData.Lines(1).Lines
@@ -10639,7 +10639,7 @@ msgstr "Formurian"
 #: /Game/Dialogue/Romy/Default/RomyHadSex01.Default__RomyHadSex01_C.SessionData.Lines(0).Lines
 msgctxt ",C5113B72490FFD8142C52EBDED0B4656"
 msgid "Oh the songs of pleasure we sang, how good they felt."
-msgstr "Oh, las canciones de placer que cantabamos, qué bien se sentían."
+msgstr "Oh, las canciones de placer que cantábamos, qué bien se sentían."
 
 #. Key:	C52FEFD44780735A14B2A78C9F57D862
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiGreeting01.Default__ParvatiGreeting01_C.SessionData.LinesToFemale(6).LinesToFemale
@@ -10688,7 +10688,7 @@ msgstr "Un trato es un trato, tómala."
 #: /Game/Dialogue/Fern/Default/FernDefault01_R02.Default__FernDefault01_R02_C.SessionData.Lines(1).Lines
 msgctxt ",C5E724D9440EB6AC1E01458A6325FC39"
 msgid "Me like this name Fern. Hiss!"
-msgstr "Mi gustar este nombre Fern. ¡Sss!"
+msgstr "Yo gustar este nombre, Fern. ¡Sss!"
 
 #. Key:	C5F9CCA94803FF5DA8A42E947B60C68D
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(12).LinesToMale
@@ -10737,7 +10737,7 @@ msgstr "Una canción muy triste irradia desde dentro..."
 #: /Game/Dialogue/Falene/SexScenes/FaleneBlowJob.Default__FaleneBlowJob_C.SessionData.LinesToMale(6).LinesToMale
 msgctxt ",C6D9B8644431D431610683A58FC57B84"
 msgid "Yes! I can feel you're about to cum... I want it all. Mmmm..."
-msgstr "¡Si! Puedo sentir que estás a punto de correrte... Lo quiero todo. Mmmm..."
+msgstr "¡Si! Puedo sentir que estás a punto de correrte... lo quiero todo. Mmmm..."
 
 #. Key:	C6E5F355439A82543536AA974313674B
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadHaveKeystone2.Default__DryadHaveKeystone2_C.SessionData.Lines(0).Lines
@@ -10795,7 +10795,7 @@ msgstr "Sorpresa"
 #: /Game/Dialogue/Widow/Default/WidowDefault01.Default__WidowDefault01_C.SessionData.Lines(4).Lines
 msgctxt ",C7F43006419AE76ADB041AA7B3BB8DD1"
 msgid "Yes come with me, deeper into my nest of love. You will feel wave after wave of pleasure as I suck on you for every last drop."
-msgstr "Sí, ven conmigo, más profundo en mi nido de amor. Sentirás ola tras ola de placer mientras te chupo hasta la última gota."
+msgstr "Sí, ven conmigo, más profundo en mi nido de amor. Sentirás oleada tras oleada de placer mientras te chupo hasta la última gota."
 
 #. Key:	C80F35DE492B934FC30FBE82A653139B
 #. SourceLocation:	/Game/Dialogue/Yasmine/Default/YasmineAwake.Default__YasmineAwake_C.SessionData.Lines(0).Lines
@@ -10858,7 +10858,7 @@ msgstr "Hay mucho sexo alrededor de Hedon para ocupar mi pequeña capacidad de a
 #: /Game/Dialogue/Widow/Default/WidowKeystone.Default__WidowKeystone_C.SessionData.Lines(2).Lines
 msgctxt ",C94B41FA4308FFD8A8F985BFB7D0411F"
 msgid "She landed in my web with a thunderous crash, and ruined the whole thing."
-msgstr "Aterrizó en mi telaraña con un estruendo atronador y arruinó todo."
+msgstr "Aterrizó en mi telaraña con un estruendo atronador y lo arruinó todo."
 
 #. Key:	C98355D84D2C12D36A73BC8F7D73D2B1
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToFemale(3).LinesToFemale
@@ -10880,7 +10880,7 @@ msgstr "Sé que no tienes recuerdos antes de ese momento, así que déjalo hundi
 #: Value).TraitIcons.DisplayName
 msgctxt ",C9DFA1EB40C3BF78D4B015AC82833310"
 msgid "Normal Size"
-msgstr "Tamaño Normal"
+msgstr "Tamaño Mediano"
 
 #. Key:	CA7A7B57487A850B58D2F18581846801
 #. SourceLocation:	/Game/Dialogue/Autumn/Default/DryadFlowers.Default__DryadFlowers_C.SessionData.Lines(2).Lines
@@ -10964,7 +10964,7 @@ msgstr "¡Arregla tu propio portón!"
 #: /Game/Dialogue/Widow/Default/WidowScary.Default__WidowScary_C.SessionData.Lines(3).Lines
 msgctxt ",CB9F33B74B20BE432B5B2D991CAF7A38"
 msgid "My kind are so feared, yet we are the same. I seek only love and companionship here in my web of solitude."
-msgstr "Los de mi especie son tan temidas, pero somos iguales. Solo busco amor y compañerismo aquí en mi telaraña de soledad."
+msgstr "Las de mi especie son tan temidas, pero somos iguales. Solo busco amor y compañerismo aquí en mi telaraña de soledad."
 
 #. Key:	CBCA7A624672A12A721B83B16D8F5A02
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruDefault01_BodySexToy.Default__MirruDefault01_BodySexToy_C.SessionData.LinesToMale(4).LinesToMale
@@ -11013,7 +11013,7 @@ msgstr "¡Bebihte musho para un moso pequeñito!"
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R05.Default__FaleneDefault01_R05_C.SessionData.Lines(1).Lines
 msgctxt ",CCFE0CB04C0DD4BC550FE6AF03BFABB3"
 msgid "Elves are part of the Sylvan race, a large @MONSTER_RACE@ family that spans all sorts! There's lots of different types of elves, but my kind are the cutest I think!"
-msgstr "¡Los elfos son parte de la raza silvana, una gran familia @MONSTER_RACE@ que abarca de todo tipo! ¡Hay muchos tipos diferentes de elfos, pero creo que los míos son las más lindos!"
+msgstr "¡Los elfos son parte de la raza silvana, una gran familia @MONSTER_RACE@ que abarca de todo tipo! ¡Hay muchos tipos diferentes de elfos, pero creo que los míos son los más lindos!"
 
 #. Key:	CD24CE384C0548CF493A43A0F88CB7A2
 #. SourceLocation:	/Game/Dialogue/Emissary/SexScenes/EmissaryAngelGroinLove.Default__EmissaryAngelGroinLove_C.SessionData.LinesToMale(0).LinesToMale
@@ -11091,7 +11091,7 @@ msgstr "Crianza: la descendencia hereda estadísticas un 20% más altas."
 #: /Game/Dialogue/OrcChief/Default/OrcHaveKeystone.Default__OrcHaveKeystone_C.SessionData.Lines(1).Lines
 msgctxt ",CE59EDA9407017D7F23359822FA77A1D"
 msgid "Serve tribe first, or even better bring my tribe mates!"
-msgstr "¡Servir a la tribu primero, o mejor aún traer a mis compañeras de tribu!"
+msgstr "¡Sirve a la tribu primero, o mejor aún trae a mis compañeras de tribu!"
 
 #. Key:	CE6754D34D354921713D50B1F67C0F01
 #. SourceLocation:	/Game/Dialogue/Parvati/Default/ParvatiDefault01_RL.Default__ParvatiDefault01_RL_C.ResponseData(2).ResponseData.BreederPrompt
@@ -11105,7 +11105,7 @@ msgstr "Yo... eh... \"olvidé\" una enseñanza."
 #: /Game/Dialogue/DragonMatriarch/Default/DMWantHuman.Default__DMWantHuman_C.SessionData.Lines(5).Lines
 msgctxt ",CE86D5D34609962D9883CD82312DAC88"
 msgid "Are you sure you can handle this human?"
-msgstr "¿Estás seguro de que puedes manejar esto humano?"
+msgstr "¿Estás seguro de que puedes manejar esto, humano?"
 
 #. Key:	CEB5AB8346357320346305B899A9C7BB
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeHaveKeystone.Default__BeeHaveKeystone_C.SessionData.Lines(3).Lines
@@ -11147,7 +11147,7 @@ msgstr "No solo con un placer intenso, sino también con elementos útiles que t
 #: /Game/Dialogue/OrcChief/Default/OrcHaveKeystone.Default__OrcHaveKeystone_C.SessionData.Lines(3).Lines
 msgctxt ",CF2AA32C438E34A279D2A599B0899492"
 msgid "Breed my tribe a fertile female that we can share. A soft cow, but not lazy one from pastures!"
-msgstr "Criar para mi tribu una hembra fértil que podamos compartir. ¡Una vaca blanda, pero no perezosa de los pastos!"
+msgstr "Cría para mi tribu una hembra fértil que podamos compartir. ¡Una vaca blanda, pero no perezosa de los pastos!"
 
 #. Key:	CF30D7124F42031F52DA0DA6849D4457
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFemale(6).LinesToFemale
@@ -11182,7 +11182,7 @@ msgstr "Ya sabes, las estatuas aladas y tetonas flotantes con los destellos... �
 #: /Game/Dialogue/Petra/Default/PetraAboutPawsmaati.Default__PetraAboutPawsmaati_C.SessionData.Lines(7).Lines
 msgctxt ",CFBBDFD5421C17E7EB1CBBB86EEBD93C"
 msgid "Through orgasm, she can impart a tiny fraction of her knowlege to her partner."
-msgstr "A través del orgasmo, puede impartir una pequeña fracción de sus conocimientos a su pareja."
+msgstr "A través del orgasmo, puede impartir una pequeña fracción de sus conocimientos a su socio."
 
 #. Key:	CFDBD54945D68B87A04B7B9DDE06F521
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R07.Default__CamillaDefault01_R07_C.SessionData.LinesToMale(1).LinesToMale
@@ -11254,7 +11254,7 @@ msgstr "Eso debería enseñarte a cruzar esta poni tet-: ¡otra vez, me refiero 
 #: Value).TraitIcons.HelpText
 msgctxt ",D0FA90CC4E9378DF7150FB881B18DC60"
 msgid "Normal: Roughly 6ft in height."
-msgstr "Normal: aproximadamente 6 pies (1,8 m) de altura."
+msgstr "Mediano: aproximadamente 6 pies (1,8 m) de altura."
 
 #. Key:	D15AF6D44FBD9FB7572622AE572A21D7
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(33 - Value).TraitIcons.HelpText
@@ -11297,7 +11297,7 @@ msgstr "Es la fruta roja gigante que ves por todos los pastos. Todas fueron crea
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_Formuria.Default__MirruDefault01_Formuria_C.SessionData.Lines(1).Lines
 msgctxt ",D1984E71418CEF4F3D39AC911B217790"
 msgid "Many aquatic @MONSTER_RACE@ inhabit our fair kingdom, but only Krakens have the might and will to rule."
-msgstr "Muchos @MONSTER_RACE@ acuáticos habitan nuestro bello reino, pero solo krakens tiene el poder y la voluntad de gobernar."
+msgstr "Muchos @MONSTER_RACE@ acuáticos habitan nuestro bello reino, pero solo los krakens tiene el poder y la voluntad de gobernar."
 
 #. Key:	D1B21A3544F4242222944E97EA03E1BB
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMHadSex01.Default__DMHadSex01_C.SessionData.LinesToFemale(3).LinesToFemale
@@ -11423,7 +11423,7 @@ msgstr "La mitad inferior del donante se eleva mientras que la receptora se bala
 #: /Game/Dialogue/Fern/DefaultP2/FernDefault02_R04.Default__FernDefault02_R04_C.SessionData.Lines(1).Lines
 msgctxt ",D456D54240773E6C7DA921A0B4BDBA16"
 msgid "I need human milk to grow into my final form. Your soft breasts will be emptied as I suck every drop."
-msgstr "Necesito leche materna para crecer hasta mi forma final. Tus suaves pechos se vaciarán mientras chupo cada gota."
+msgstr "Necesito leche humana para crecer hasta mi forma final. Tus suaves pechos se vaciarán mientras chupo cada gota."
 
 #. Key:	D48D138B4D55F9A604E2E0AFFACE1674
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernGreeting02.Default__FernGreeting02_C.SessionData.LinesToFemale(1).LinesToFemale
@@ -11472,7 +11472,7 @@ msgstr "Pocos @MONSTER_RACE@ son mayores que yo, pero Pawsmaati es una excepció
 #: /Game/Dialogue/Autumn/Default/DryadDefault01_RL.Default__DryadDefault01_RL_C.ResponseData(4).ResponseData.BreederPrompt
 msgctxt ",D52E88834BD47EFB47BD74839CEEB65D"
 msgid "Can I have that keystone?"
-msgstr "¿Puedo tener esa piedra-llave?"
+msgstr "¿Puedo tener esa Keystone?"
 
 #. Key:	D535E0D84F73A7E07CA72DA2ED4F1B11
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(17 - Value).TraitIcons.HelpText
@@ -11662,7 +11662,7 @@ msgstr "*Bosteza* Puede que necesite una siesta después de que hagamos el amor 
 #: /Game/Dialogue/OrcChief/Default/OrcWantWrestle.Default__OrcWantWrestle_C.SessionData.Lines(2).Lines
 msgctxt ",D7D29FFE4A41A6DA230B80B0832CBC28"
 msgid "Chieftain very horny, you will regret this. Come here!"
-msgstr "Cacique muy cachonda, te arrepentirás de esto. ¡Ven aquí!"
+msgstr "La cacique muy cachonda, te arrepentirás de esto. ¡Ven aquí!"
 
 #. Key:	D7F8B9C2431BFB6ED28ECAAF83BAE062
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03.Default__FernDefault03_C.SessionData.LinesToFemale(1).LinesToFemale
@@ -11683,7 +11683,7 @@ msgstr "Amm, que adorable poni tetudita."
 #: /Game/Dialogue/DragonMatriarch/Default/DMAboutDragons.Default__DMAboutDragons_C.SessionData.Lines(1).Lines
 msgctxt ",D839985345EFF273DA362C9BB07DA471"
 msgid "Don't be fooled by those Titans. They might seem like they own the place with their massive size and strength."
-msgstr "No te deje engañar por esos titanes. Puede parecer que son dueños del lugar con su enorme tamaño y fuerza."
+msgstr "No te dejes engañar por esos titanes. Puede parecer que son dueños del lugar con su inmenso tamaño y fuerza."
 
 #. Key:	D857E31D47711B85E634029A4E3EB6E7
 #. SourceLocation:	/Game/World/Overworld.Overworld:PersistentLevel.CBGate_Breaks.PlaceMessage
@@ -11718,7 +11718,7 @@ msgstr "Realmente es un diseño superior cuando lo piensas: la siguiente etapa d
 #: /Game/Dialogue/Petra/Default/PetraGetKeystone.Default__PetraGetKeystone_C.SessionData.Lines(2).Lines
 msgctxt ",D8ADF7FF4D4119D1628F44BF0E97521A"
 msgid "Pawsmaati tasked me with practicing my recent lesson with a \"winged mountain maiden\"."
-msgstr "Pawsmaati me asignó la tarea de practicar mi reciente lección con una \"doncella de la montaña alada\"."
+msgstr "Pawsmaati me asignó la tarea de practicar mi reciente lección con una \"doncella alada de la montaña\"."
 
 #. Key:	D8D64A6444112501D1C4728A0BB65EB7
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_R02.Default__FernDefault02_R02_C.SessionData.Lines(1).Lines
@@ -11746,7 +11746,7 @@ msgstr "*Ronronea*"
 #: /Game/Dialogue/AmberMae/Default/AmberMaeHadSex01.Default__AmberMaeHadSex01_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",D9124E55481B91E85A0884AA58197D19"
 msgid "'Mai milk was tasty aye? Plenty more where that came from!"
-msgstr "Mi leshe ehtaba zabrosa, ¿no? ¡Musho máh de donde vino eso!"
+msgstr "Mi leshe ehtaba zabrosa, ¿no? ¡Toavía queda musha máh!"
 
 #. Key:	D913C6254D30AA08E8B01787AE3D1B68
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TravelShrines(4 - Value).TravelShrines.ShrineName
@@ -11859,7 +11859,7 @@ msgstr "¡Me compras semen! Soy una alquimista de semen de primera clase, ¡y na
 #: /Game/Dialogue/Fern/Default/FernDefault01_R01.Default__FernDefault01_R01_C.SessionData.Lines(1).Lines
 msgctxt ",DA8A389840F92C11D80A20A1593273B7"
 msgid "Me grow in thisss soil... hiss. Still sapling... need mastah to grow into big Alraune!"
-msgstr "Yo crecer en essste suelo... ssss. Todavía retoño... ¡necesito Mastah para crecer en una gran alraune!"
+msgstr "Yo crecer en essste suelo... ssss. Todavía retoño... ¡necesito a Mastah para crecer en una gran alraune!"
 
 #. Key:	DA9BB43342773BD3A51CEC9C5A48CA82
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01_RL_T.Default__FernDefault01_RL_T_C.ResponseData(3).ResponseData.BreederPrompt
@@ -11873,7 +11873,7 @@ msgstr "¡Puedes tener mi semen!"
 #: /Game/Dialogue/OrcChief/Default/OrcDefault03_RL.Default__OrcDefault03_RL_C.ResponseData(1).ResponseData.BreederPrompt
 msgctxt ",DAA21E23412F638CF86C45BDFEF403A9"
 msgid "Uh... so... want to wrestle?"
-msgstr "Uh... entonces... ¿querer luchar?"
+msgstr "Uh... entonces... ¿quieres luchar?"
 
 #. Key:	DAC926244203A48C0547B89807D93FA8
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R01.Default__FaleneDefault01_R01_C.SessionData.Lines(6).Lines
@@ -11894,7 +11894,7 @@ msgstr "@WORLD_NAME@ es mi mundo."
 #: /Game/Dialogue/Yasmine/Default/YasmineHadSex01.Default__YasmineHadSex01_C.SessionData.Lines(0).Lines
 msgctxt ",DAF3ABC54412C70DC128659F2DB1098C"
 msgid "Oh the songs of pleasure we sang, how good they felt."
-msgstr "Oh, las canciones de placer que cantamos, qué bien se sentían."
+msgstr "Oh, las canciones de placer que cantábamos, qué bien se sentían."
 
 #. Key:	DB00D91D4420A5D9D4F3FBB7DD1AC099
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_R02_R01.Default__FernDefault02_R02_R01_C.SessionData.Lines(0).Lines
@@ -11971,7 +11971,7 @@ msgstr "Crecí en tu suelo, y ahora es mi hogar permanente. ¡Ojalá te guste tu
 #: /Game/Dialogue/Blossom/Default/BlossomDefault01_R02.Default__BlossomDefault01_R02_C.SessionData.Lines(1).Lines
 msgctxt ",DC0025004492CEEAE0F8D1A26E169F34"
 msgid "Me like this name Blossom. Hiss!"
-msgstr "Yo gusta este nombre Blossom. ¡Sss!"
+msgstr "Yo gustar este nombre, Blossom. ¡Sss!"
 
 #. Key:	DC23BE8C475FA9FCC7F22596C3D47F3F
 #. SourceLocation:	/Game/Dialogue/Fern/Default/FernDefault01_R02.Default__FernDefault01_R02_C.SessionData.Lines(2).Lines
@@ -11999,7 +11999,7 @@ msgstr "¿Estás bien?"
 #: /Game/Dialogue/Kybele/Default/KybeleHadSex01.Default__KybeleHadSex01_C.SessionData.LinesToFuta(2).LinesToFuta
 msgctxt ",DC3FF6AD41D27D03E1D980BAD76F4897"
 msgid "Still... you pleased me like a stallion. That's amazing for one of your size!"
-msgstr "Aún así... me complaciste como un semental. ¡Eso es increíble para uno de tu tamaño!"
+msgstr "Aún así... me complaciste como un semental. ¡Eso es asombroso para alguien de tu tamaño!"
 
 #. Key:	DC59A07E4D2FC78409E32EA7A64B7007
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneHadSex01.Default__FaleneHadSex01_C.SessionData.LinesToFemale(7).LinesToFemale
@@ -12056,7 +12056,7 @@ msgstr "¡¿En serio?! ¡Estos son verdaderamente los mejores días de mi vida!"
 #: /Game/Dialogue/Leylanna/Default/LeylannaDefault01.Default__LeylannaDefault01_C.SessionData.Lines(0).Lines
 msgctxt ",DCBFA42D4FD9520CA7F586A84DCF3921"
 msgid "Make love with me @BREEDER_NAME@, let us writhe in pleasure before Her gaze."
-msgstr "Haz el amor conmigo @BREEDER_NAME@, nos dejamos retorcer de placer ante Su mirada."
+msgstr "Hazme el amor @ BREEDER_NAME @, retorciéndonos de placer ante Su mirada."
 
 #. Key:	DCFCF2FF45351BEF9BAEACA9BE408F9A
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R03.Default__FaleneDefault01_R03_C.SessionData.Lines(13).Lines
@@ -12133,7 +12133,7 @@ msgstr "Ha pasado tanto tiempo desde que le di limo."
 #: /Game/Dialogue/Leylanna/Default/LeylannaDefault01_Emissary.Default__LeylannaDefault01_Emissary_C.SessionData.Lines(2).Lines
 msgctxt ",DE7B484C4224680737F160881A189942"
 msgid "She only spoke one phrase to me: \"I must speak with the human.\""
-msgstr "Ella solo me dijo una frase: \"Debo hablar con el humano\"."
+msgstr "Ella solo me dijo una frase: \"debo hablar con el humano\"."
 
 #. Key:	DED16C92469A536D38021EBB9437E929
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R05.Default__CamillaDefault01_R05_C.SessionData.Lines(2).Lines
@@ -12210,14 +12210,14 @@ msgstr "Después de décadas de crecimiento, el fruto se caerá y surgirá una d
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_R07.Default__FaleneDefault01_R07_C.SessionData.LinesToMale(1).LinesToMale
 msgctxt ",E0699FC749A0DDDF3E385CA8D6F3E80E"
 msgid "Errrr, I can't stand it anymore, I'm going to milk you dry! I have never tasted human cum before!"
-msgstr "Errrr, no puedo soportarlo más, ¡voy a ordeñarte hasta secarte! ¡Nunca antes había probado semen humano!"
+msgstr "Errrr, no puedo soportarlo más, ¡voy a ordeñarte hasta dejarte seco! ¡Nunca antes había probado semen humano!"
 
 #. Key:	E082A93948F5919CEB7D19BF935DA14E
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_Leylanna.Default__EmissaryDefault01_Leylanna_C.SessionData.Lines(2).Lines
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_Leylanna.Default__EmissaryDefault01_Leylanna_C.SessionData.Lines(2).Lines
 msgctxt ",E082A93948F5919CEB7D19BF935DA14E"
 msgid "All were in vain, for I am an archangel, but her kindess and loyatly to the Goddess are unquestionable."
-msgstr "Todos fueron en vano, porque soy una arcángel, pero su amabilidad y lealtad a la Diosa son incuestionables."
+msgstr "Todos fueron en vano, ya que soy una arcángel, pero su amabilidad y lealtad a la Diosa son incuestionables."
 
 #. Key:	E0B9E9894DD5921A03759097168DF006
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_RL_T.Default__FernDefault02_RL_T_C.ResponseData(4).ResponseData.BreederPrompt
@@ -12287,7 +12287,7 @@ msgstr "Con mi voluptuoso cuerpo de sirena, tocaré tu pene como un instrumento"
 #: /Game/Dialogue/Mirru/SexScenes/MirruSnatchF.Default__MirruSnatchF_C.SessionData.Lines(1).Lines
 msgctxt ",E1E5995441F81E5B6E79E8A5481789F0"
 msgid "Ahh... ohhhh... yes! Please both of my tentacle heads..."
-msgstr "¡Ahh... ohhhh... sí! Por favor, mis dos cabezales de tentáculo..."
+msgstr "¡Ahh... ohhhh... sí! Por favor, ambas puntas de mis tentáculos..."
 
 #. Key:	E1FD0C3A455475E0E474A0A50646DBA8
 #. SourceLocation:	/Game/Dialogue/AmberMae/Default/AmberMaeLockedDungeon.Default__AmberMaeLockedDungeon_C.SessionData.Lines(3).Lines
@@ -12351,14 +12351,14 @@ msgstr "Eso debería enseñarte a cruzar esta poni tet-: ¡otra vez, me refiero 
 #: /Game/Dialogue/Camilla/SexScenes/CamillaAdorableLump.Default__CamillaAdorableLump_C.SessionData.LinesToFemale(2).LinesToFemale
 msgctxt ",E29F5BAA40F6C8758245C58555D4F73E"
 msgid "Ahhhh, your fingers are magical, go deeper! Deeper human, oh yesss."
-msgstr "Ahhhh, tus dedos son mágicos, ¡ve más profundo! Humana más profundo, oh sí."
+msgstr "Ahhhh, tus dedos son mágicos, ¡ve más profundo! Humana más profundo, oh sííí."
 
 #. Key:	E2D78DC6488712103CF0A59E6DE95E47
 #. SourceLocation:	/Game/Dialogue/AmberMae/SexScenes/AmberMilkyF.Default__AmberMilkyF_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/AmberMae/SexScenes/AmberMilkyF.Default__AmberMilkyF_C.SessionData.Lines(1).Lines
 msgctxt ",E2D78DC6488712103CF0A59E6DE95E47"
 msgid "Oh yer hand feels so good. Don't stop strok'n me box!"
-msgstr "Oh, tu mano se siente tan bien. No dejeh de acarisiarme el ehtushe!"
+msgstr "Oh, tu mano se siente tan bien. ¡No dejeh de acarisiarme el ehtushe!"
 
 #. Key:	E2F13B714EEE6046C9069A8F6F71DA0B
 #. SourceLocation:	/Game/Dialogue/DragonMatriarch/Default/DMAboutDragons.Default__DMAboutDragons_C.SessionData.Lines(5).Lines
@@ -12442,7 +12442,7 @@ msgstr "¿Es un sentimiento reconfortante?"
 #: /Game/Dialogue/Emissary/Default/EmissaryBlessedInquiry01_R01.Default__EmissaryBlessedInquiry01_R01_C.SessionData.Lines(2).Lines
 msgctxt ",E499F0E4452FBC3AAE82E18BCF77B28B"
 msgid "My senses detect your desires @BREEDER_NAME@. You see my exposed body before you, and you wish to please yourself with it."
-msgstr "Mis sentidos detectan tus deseos, @BREEDER_NAME@. Ves mi cuerpo expuesto delante de ti y deseas complacerte con él."
+msgstr "Mis sentidos detectan tus deseos, @BREEDER_NAME@. Ves mi cuerpo expuesto ante ti y deseas complacerte con él."
 
 #. Key:	E4AA6F334E8152CCB55879A1FD73219D
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaFaleneWeek.Default__CamillaFaleneWeek_C.SessionData.Lines(0).Lines
@@ -12534,7 +12534,7 @@ msgstr "Qué dulce abejita de la miel."
 #: /Game/Dialogue/Romy/Default/RomyDefault01_YourMusic_Start.Default__RomyDefault01_YourMusic_Start_C.SessionData.Lines(0).Lines
 msgctxt ",E5B7F2E2469864C41253FC892250ED92"
 msgid "Yes! Sing with me human."
-msgstr "¡Si! Canta conmigo humana."
+msgstr "¡Si! Canta conmigo humano."
 
 #. Key:	E5ED1DF6437395916BD42CBCD355E384
 #. SourceLocation:	/Game/Dialogue/Mirru/Default/MirruHadSex01.Default__MirruHadSex01_C.SessionData.LinesToFemale(2).LinesToFemale
@@ -12576,7 +12576,7 @@ msgstr "Los elfos saben como soñé que serían... y esta pequeña es toda mía.
 #: /Game/Dialogue/Emissary/Default/EmissaryRaiseTraitLvl_Accept.Default__EmissaryRaiseTraitLvl_Accept_C.SessionData.Lines(0).Lines
 msgctxt ",E63E125C4A07D646D1BFD48E816B5B37"
 msgid "A wise choice human, for the Goddess has further endowed wild @MONSTER_RACE@."
-msgstr "Una sabia elección humana, pues la Diosa ha dotado aún más a @MONSTER_RACE@ silvestres."
+msgstr "Una sabia elección humano, pues la Diosa ha dotado aún más a los @MONSTER_RACE@ silvestres."
 
 #. Key:	E663A2A8494081C671EA74A317740FAD
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(31 - Value).TraitIcons.DisplayName
@@ -12633,7 +12633,7 @@ msgstr "La receptora rebota hacia arriba y hacia abajo mientras mira en direcci�
 #: /Game/Dialogue/Romy/Default/RomyHadSex01.Default__RomyHadSex01_C.SessionData.Lines(1).Lines
 msgctxt ",E785DF8A4F91C040EC352CA7D80C247E"
 msgid "Waves of ecstasy still course through my body."
-msgstr "Oleadas de éxtasis todavía recorren mi cuerpo."
+msgstr "Las oleadas de éxtasis todavía recorren mi cuerpo."
 
 #. Key:	E786C6B44314BBD71D79DA9FE5AF0C96
 #. SourceLocation:	/Game/Dialogue/Cassie/Default/CassieDungeon.Default__CassieDungeon_C.SessionData.Lines(3).Lines
@@ -12697,7 +12697,7 @@ msgstr "Por cualquier medio que sea necesario, no dejaré que pases humano."
 #: /Game/Dialogue/Petra/Default/PetraTaskFulfilled.Default__PetraTaskFulfilled_C.SessionData.Lines(2).Lines
 msgctxt ",E887131048CFFB8EF5A2E0A1DA1194FE"
 msgid "I got the keystone for you as promised, take it. Don't be a stranger though!"
-msgstr "Tengo la piedra-llave para ti como prometí, tómala. ¡Aunque no seas un extraño!"
+msgstr "Tengo la Keystone para ti como prometí, tómala. ¡Aunque no seas un extraño!"
 
 #. Key:	E89A6BB74D15111C98632A99F45745CC
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(17 - Value).TraitIcons.DisplayName
@@ -12733,7 +12733,7 @@ msgstr "Quizás debería hacer esto de ahora en adelante en lugar de perder los 
 #: /Game/World/Overworld.Overworld:PersistentLevel.DragonHoard.ManageActionMessage
 msgctxt ",E91EF4164FCD12832A52B095A8557B4A"
 msgid "Manage your Dragons"
-msgstr "Gestiona tus Dragons"
+msgstr "Gestiona tus Dragones"
 
 #. Key:	E9306878425673698C22F9AA8CD2A8CC
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToFemale(9).LinesToFemale
@@ -12811,14 +12811,14 @@ msgstr "Soy yo, Mirru, la que será la siguiente en la línea para convertirse e
 #: /Game/Dialogue/Kybele/Default/KybeleHadSex01.Default__KybeleHadSex01_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",EAB6EBE14AAB0E16FF7079998969A562"
 msgid "What a massive release, it's been far too many days."
-msgstr "Qué descarga inmensa, han pasado demasiados días."
+msgstr "Qué inmensa descarga, han pasado demasiados días."
 
 #. Key:	EAC5867744C78DCB09760896409A7850
 #. SourceLocation:	/Game/Dialogue/OrcChief/Default/OrcTribeSucks.Default__OrcTribeSucks_C.SessionData.Lines(5).Lines
 #: /Game/Dialogue/OrcChief/Default/OrcTribeSucks.Default__OrcTribeSucks_C.SessionData.Lines(5).Lines
 msgctxt ",EAC5867744C78DCB09760896409A7850"
 msgid "Take my tribe sisters back to Homestead... breed them well!"
-msgstr "Llevar mis hermanas de tribu de vuelta a Granja... ¡críalas bien!"
+msgstr "Lleva mis hermanas de tribu de vuelta a la Granja... ¡críalas bien!"
 
 #. Key:	EAE306A64EE7F2719CB1719962D3F107
 #. SourceLocation:	/Game/Ranch/Upgrades/DemonPool.Default__DemonPool_C.Upgrade.Description
@@ -12853,7 +12853,7 @@ msgstr "Sorpresa"
 #: /Game/Dialogue/Widow/Default/WidowScary.Default__WidowScary_C.SessionData.Lines(5).Lines
 msgctxt ",EB6E4330432136A859E45AAF024E2DC0"
 msgid "And perhaps to suck my companion dry when the hunger arises... but I always strive to make it feel good."
-msgstr "Y tal vez para chupar a mi compañera hasta secarla cuando surja el hambre... pero siempre me esfuerzo por hacer que se sienta bien."
+msgstr "Y tal vez para chupar a mi compañera hasta dejarla seca cuando surja el hambre... pero siempre me esfuerzo en hacer que se sienta bien."
 
 #. Key:	EB717BA44A439427B1DE6CA60FA650A2
 #. SourceLocation:	/Game/Dialogue/Mirru/SexScenes/MirruKrakVag.Default__MirruKrakVag_C.SessionData.Lines(2).Lines
@@ -12896,7 +12896,7 @@ msgstr "Polludo: heredó un pene más grande."
 #: /Game/Dialogue/Autumn/Default/DryadDefault01.Default__DryadDefault01_C.SessionData.Lines(0).Lines
 msgctxt ",EC505AF645F08A603F4BDF98F4F09BAC"
 msgid "So many bosom cherries to make, the cows are always ready to eat them."
-msgstr "Tantas cerezas de seno para hacer, las vacas siempre están listas para comerlas."
+msgstr "Tantas cerezas de seno por hacer, las vacas siempre están listas para comerlas."
 
 #. Key:	EC6BFF394580DB5B2B148096C2994439
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP2/FernDefault02_RL_M.Default__FernDefault02_RL_M_C.ResponseData(0).ResponseData.BreederPrompt
@@ -12980,7 +12980,7 @@ msgstr "..."
 #: /Game/Dialogue/Parvati/Default/ParvatiGreeting01.Default__ParvatiGreeting01_C.SessionData.LinesToFemale(8).LinesToFemale
 msgctxt ",EDA3DF9D4C1774AA8DDFC69C0EFD0035"
 msgid "Favor from the Goddess will you require."
-msgstr "Favor de la Diosa tu requerirás."
+msgstr "El Favor de la Diosa tu requerirás."
 
 #. Key:	EDB37C414F34D2DB942D46BC07E82687
 #. SourceLocation:	/Game/Dialogue/Petra/Default/PetraGetKeystone.Default__PetraGetKeystone_C.SessionData.Lines(3).Lines
@@ -13121,7 +13121,7 @@ msgstr "*Chupa* *Lame*"
 #: /Game/Dialogue/Autumn/Default/DryadBossomCherries.Default__DryadBossomCherries_C.SessionData.Lines(4).Lines
 msgctxt ",F04A18AC479B4181D244928A4D159C06"
 msgid "Most of the time they fall, and then immediately sleep from over exertion."
-msgstr "La mayoría de las veces se caen y luego duermen inmediatamente debido al esfuerzo excesivo."
+msgstr "La mayoría de las veces se caen y luego se duermen inmediatamente debido al esfuerzo excesivo."
 
 #. Key:	F05FD1324ABB81C7141ED7A41A996723
 #. SourceLocation:	/Game/Dialogue/Camilla/Default/CamillaDefault01_R02.Default__CamillaDefault01_R02_C.SessionData.Lines(7).Lines
@@ -13135,7 +13135,7 @@ msgstr "Por último, pero no menos importante, puedes encontrar a las serafines 
 #: /Game/Dialogue/Emissary/Default/EmissaryDefault01_GreatConception.Default__EmissaryDefault01_GreatConception_C.SessionData.Lines(15).Lines
 msgctxt ",F06D080B472FAC8F39770EB5B3818956"
 msgid "Outraged, the Goddess Herself descended and cursed the demons for their sins."
-msgstr "Indignada, la Diosa Misma descendió y maldijo a los demonios por sus pecados."
+msgstr "Indignada, la Mismísima Diosa descendió y maldijo a los demonios por sus pecados."
 
 #. Key:	F091EDAA4504CD138BB740BD4D4EBCB6
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneGreeting01.Default__FaleneGreeting01_C.SessionData.LinesToMale(14).LinesToMale
@@ -13198,7 +13198,7 @@ msgstr "¡Extraño a mi hermana pequeña! Ella s-s-sigue siendo una oruga."
 #: /Game/Dialogue/Autumn/Default/DryadFlowers.Default__DryadFlowers_C.SessionData.Lines(7).Lines
 msgctxt ",F1C0D9374BF1D4EC73102080D4855555"
 msgid "Ejaculum-phallis is the product of dragon semen. If you bring me a large amount of it, I can use it to heal the Hivelands."
-msgstr "Ejaculum-phallis es el producto del semen de dragón. Si me traes una gran cantidad de el, puedo usarlo para curar las Tierras-Colmena."
+msgstr "La ejaculum-phallis es el producto del semen de dragón. Si me traes una gran cantidad de el, puedo usarlo para curar las Tierras-Colmena."
 
 #. Key:	F1D3A2E044E22D62A15FD2A3C291C751
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(6 - Value).TraitIcons.HelpText
@@ -13248,7 +13248,7 @@ msgstr "Entonces los @MONSTER_RACE@ son realmente cachondos..."
 #: /Game/Dialogue/AmberMae/Default/AmberMaeHadSex01.Default__AmberMaeHadSex01_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",F2106FBD47C33358DD8CBE9C4F4ABE40"
 msgid "Ahhh... I sure do appreciate tak'n yer time to please this old milkmaid."
-msgstr "Ahhh... Rearmente apresio tomahte tu tiempo para complaseh a esta vieja leshera."
+msgstr "Ahhh... rearmente apresio que te tomeh tu tiempo para complaseh a esta vieja leshera."
 
 #. Key:	F21C5AFA463E6FCE44980EAAEE23498C
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchDefault01_RL.Default__MonarchDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
@@ -13276,7 +13276,7 @@ msgstr "¡Humano! *gruñe*"
 #: /Game/Dialogue/Blossom/Default/BlossomDefault01_R03.Default__BlossomDefault01_R03_C.SessionData.Lines(0).Lines
 msgctxt ",F37DF7694328A3895D54B3BC4DB0147D"
 msgid "Blossom help mastah! Blossom harvest fluidssss for you!"
-msgstr "¡Blossom ayuda Mastah! ¡Blossom cosecha fluidossss para ti!"
+msgstr "¡Blossom ayuda a Mastah! ¡Blossom cosecha fluidossss para ti!"
 
 #. Key:	F39F0EAF49B80BDC208978900604CC74
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R03.Default__FaleneDefault01_R03_C.SessionData.Lines(10).Lines
@@ -13325,7 +13325,7 @@ msgstr "Vuelve a verme cuando hayas atrapado un macho vulwarg."
 #: /Game/Dialogue/Leylanna/Default/LeylannaDefault01_SmokeRL.Default__LeylannaDefault01_SmokeRL_C.ResponseData(0).ResponseData.BreederPrompt
 msgctxt ",F4CADE7A441CE6B749B76B9F7EC26371"
 msgid "So it makes you high?"
-msgstr "¿Entonces eso te hace \"volar\"?"
+msgstr "¿Entonces eso te hace \"elevarte\"?"
 
 #. Key:	F5276F72433DAADC3348C9937061AB06
 #. SourceLocation:	/Game/Ranch/Upgrades/StarfallenMonolith.Default__StarfallenMonolith_C.Upgrade.Description
@@ -13402,7 +13402,7 @@ msgstr "¡Ohhh, cómo he esperado para envolver mis suaves labios alrededor de u
 #: /Game/Dialogue/Romy/Default/RomyDefault01.Default__RomyDefault01_C.SessionData.LinesGrungy(0).LinesGrungy
 msgctxt ",F743D4EB4B4F3333AEE950BA4458ECE8"
 msgid "Oh you dirty dirty human... what have you done to yourself?"
-msgstr "Oh, sucio, sucio humano... ¿Qué te has hecho a ti mismo?"
+msgstr "Oh, sucio, sucio humano... ¿qué te has hecho a ti mismo?"
 
 #. Key:	F74E8BFF48A0493236F0C6B2CDD1F4DB
 #. SourceLocation:	/Game/Dialogue/Leylanna/SexScenes/LeylannaLeyCov.Default__LeylannaLeyCov_C.SessionData.LinesToFemale(2).LinesToFemale
@@ -13465,7 +13465,7 @@ msgstr "Quién sabe cuáles son míos, y no me importa. Esta matriarca seguirá 
 #: /Game/Dialogue/Kybele/Default/KybeleCentaur.Default__KybeleCentaur_C.SessionData.Lines(4).Lines
 msgctxt ",F80CC71F49A124229467EC98902D86F9"
 msgid "Count yourself fortunate, in case you haven't noticed the challenge present for a centuar to please herself."
-msgstr "Considérese afortunado, en caso de que no hayas notado el desafío que presenta para complacerse a sí mismo un centauro."
+msgstr "Considérate afortunado, en caso de que no hayas notado el desafío que presenta para un centauro complacerse a sí mismo."
 
 #. Key:	F84550BD45785F99DC5ACC9F2C125EDF
 #. SourceLocation:	/Game/Dialogue/Kybele/Default/KybeleDefault01_RL.Default__KybeleDefault01_RL_C.ResponseData(1).ResponseData.BreederPrompt
@@ -13528,7 +13528,7 @@ msgstr "¿Mastah?"
 #: /Game/Dialogue/Petra/Default/PetraAboutPawsmaati.Default__PetraAboutPawsmaati_C.SessionData.Lines(5).Lines
 msgctxt ",F98CD43545B39F2F962E56AF0DC2ADAA"
 msgid "I never wanted it to end! She was in complete control the entire time, not releasing until I came ten times."
-msgstr "¡Nunca quise que terminara! Ella tuvo el control total todo el tiempo, no descargó hasta que me corrí diez veces."
+msgstr "¡Nunca quise que terminara! Ella tuvo el control total todo el tiempo, y no descargó hasta que me corrí diez veces."
 
 #. Key:	F9C66FA74BAA102FE1238A952823D3D9
 #. SourceLocation:	/Game/Dialogue/Falene/Default/FaleneDefault01_R01.Default__FaleneDefault01_R01_C.SessionData.Lines(17).Lines
@@ -13621,7 +13621,7 @@ msgstr "Ohhh, @BREEDER_NAME@... estuviste increíble."
 #: /Game/Dialogue/Neela/Default/NeelaDefault01_TheVoid.Default__NeelaDefault01_TheVoid_C.SessionData.Lines(3).Lines
 msgctxt ",FAC3B1AA48B55AC22C81BABA4025A329"
 msgid "However, by stepping into a sacred pussy portal one can enter the Void from this plane."
-msgstr "Sin embargo, al entrar en un coño portal sagrado, uno puede entrar al Vacío desde este plano."
+msgstr "Sin embargo, al entrar en un Coño Portal sagrado, uno puede entrar al Vacío desde este plano."
 
 #. Key:	FAD4B31949B0D1AC3DE5B3A79B8048C6
 #. SourceLocation:	/Game/Dialogue/Mirru/SexScenes/MirruSnatchF.Default__MirruSnatchF_C.SessionData.Lines(5).Lines
@@ -13705,7 +13705,7 @@ msgstr "A pesar de más de 4,000 años atravesando el Vacío, todavía tengo que
 #: /Game/Dialogue/Autumn/Default/DryadCherryHelp.Default__DryadCherryHelp_C.SessionData.LinesToFemale(1).LinesToFemale
 msgctxt ",FBC59E69493451F2A30A66818584F9BC"
 msgid "Ohhh how I've waited for this."
-msgstr "Ohhh, cómo he esperado esto."
+msgstr "Ohhh, cómo he esperado para esto."
 
 #. Key:	FBDDB80F480F00F6DF7E1BA03EC927F6
 #. SourceLocation:	/Game/Dialogue/Widow/Default/WidowTaskFullfilled2.Default__WidowTaskFullfilled2_C.SessionData.Lines(2).Lines
@@ -13726,7 +13726,7 @@ msgstr "Veo esa mirada en tus ojos, deseas usar a los habitantes de Rupturas Ví
 #: /Game/Dialogue/Camilla/Default/CamillaHadSex02.Default__CamillaHadSex02_C.SessionData.LinesToMale(0).LinesToMale
 msgctxt ",FBF536C949746784E2045981A88739F6"
 msgid "Wow human, you must have been desperate to give this nugget your love."
-msgstr "Guau, humano, debes haber estado desesperado por darle a esta pepita tu amor."
+msgstr "Guau, humano, debes haber estado desesperado para darle a esta pepita tu amor."
 
 #. Key:	FC2E4BC244CE7A4471B402A207DCB5C4
 #. SourceLocation:	/Game/Dialogue/Fern/DefaultP3/FernDefault03.Default__FernDefault03_C.SessionData.LinesToFuta(0).LinesToFuta
@@ -13754,7 +13754,7 @@ msgstr "*Sorbe* *Lame*"
 #: /Game/Dialogue/Romy/Default/RomyGreeting01.Default__RomyGreeting01_C.SessionData.Lines(1).Lines
 msgctxt ",FCD1F71F4D144F31FDAB9F89767AC8E7"
 msgid "Yes it sounds so sweet, it is the sound of human desire. Ahhh... it grows louder as your gaze turns upon my breasts."
-msgstr "Sí, suena tan dulce, es el sonido del deseo humano. Ahhh... se hace más fuerte cuando tu mirada se vuelve hacia mis pechos."
+msgstr "Sí, suena tan dulce, es el sonido del deseo humano. Ahhh... se hace más fuerte cuando tu mirada se vuelve sobre mis pechos."
 
 #. Key:	FCEBBA094930884E07B0A38C1FC062B8
 #. SourceLocation:	/Game/Dialogue/Monarch/Default/MonarchHadSex01.Default__MonarchHadSex01_C.SessionData.LinesToFemale(2).LinesToFemale
@@ -13768,14 +13768,14 @@ msgstr "Espero que mi juguete te haya hecho sentir bien. ¿Tal vez... p-p-podemo
 #: /Game/Dialogue/Yasmine/Default/YasmineAwake.Default__YasmineAwake_C.SessionData.Lines(1).Lines
 msgctxt ",FCFE3B3D4F76E0D8BBC19BBF1F504CC6"
 msgid "It happens every time I open, you think I would have learned by now."
-msgstr "Sucede cada vez que me abro, crees que ya lo habría aprendido."
+msgstr "Sucede cada vez que me abro, tu crees que ya lo hubiera sabido."
 
 #. Key:	FD102648460B4847C187CA85C454705B
 #. SourceLocation:	/Game/Dialogue/QueenBee/Default/BeeMoreHoney.Default__BeeMoreHoney_C.SessionData.Lines(1).Lines
 #: /Game/Dialogue/QueenBee/Default/BeeMoreHoney.Default__BeeMoreHoney_C.SessionData.Lines(1).Lines
 msgctxt ",FD102648460B4847C187CA85C454705B"
 msgid "Kneel and suck human. Engorge yourself on my honey, for it pleases me greatly."
-msgstr "Arrodíllate y chupa humano. Atibórrate de mi miel, porque me complace inmensamente."
+msgstr "Arrodíllate y chupa humano. Atibórrate de mi miel, pues eso me complace inmensamente."
 
 #. Key:	FD257CB04C6B3AB420244298D2C33047
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(14 - Value).TraitIcons.DisplayName
@@ -13811,14 +13811,14 @@ msgstr "¿Te gustan mis tentáculos gruesos y suaves? Siente cómo penetran tus 
 #: /Game/Dialogue/Falene/Default/FaleneDefault01_Pregnancy.Default__FaleneDefault01_Pregnancy_C.SessionData.Lines(2).Lines
 msgctxt ",FD469A5A4E24AF221A0C9E85AFEECED7"
 msgid "Swelling of the belly represents the newborn's progress toward development in the Void!"
-msgstr "¡La hinchazón del vientre representa el progreso del recién nacido hacia su desarrollo en el Vacío!"
+msgstr "¡La hinchazón del vientre representa el progreso del nonato hacia su desarrollo en el Vacío!"
 
 #. Key:	FD60314C4ADEEDC7A454ECA6AA29E42A
 #. SourceLocation:	/Game/Dialogue/Fesssi/Default/FesssiHowLong.Default__FesssiHowLong_C.SessionData.Lines(9).Lines
 #: /Game/Dialogue/Fesssi/Default/FesssiHowLong.Default__FesssiHowLong_C.SessionData.Lines(9).Lines
 msgctxt ",FD60314C4ADEEDC7A454ECA6AA29E42A"
 msgid "A lamia's body is very sensitive in certain places, and if massaged correctly can induce a nice orgasm."
-msgstr "El cuerpo de una lamia es muy sensible en ciertos lugares y, si se masajea correctamente, puede inducir un orgasmo agradable."
+msgstr "El cuerpo de una lamia es muy sensible en ciertos lugares y, si se masajea correctamente, puede inducir un buen orgasmo."
 
 #. Key:	FD6F8B5B4B3A96B1EC5B4D838FCA8599
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimeSlimesMade.Default__MegaSlimeSlimesMade_C.SessionData.LinesToFemale(7).LinesToFemale
@@ -13854,7 +13854,7 @@ msgstr "Soy una alraune en crecimiento, ¿tal vez te sobran fluidos?"
 #: /Game/Dialogue/Camilla/Default/CamillaDefault02.Default__CamillaDefault02_C.SessionData.Lines(4).Lines
 msgctxt ",FDB79BD24E2E79AD2A532E8378563FD0"
 msgid "Not to eat me, it did other things to my little body... it felt amazing actually."
-msgstr "No comerme, le hizo otras cosas a mi cuerpecito... en realidad se sintió increíble."
+msgstr "No para comerme, le hizo otras cosas a mi cuerpecito... en realidad se sintió increíble."
 
 #. Key:	FDBDE7714A97FE255B38A0BACEC479DB
 #. SourceLocation:	/Game/UI/DefaultTheme.DefaultTheme.StyleData.TraitIcons(7 - Value).TraitIcons.DisplayName
@@ -13904,7 +13904,7 @@ msgstr "*Ronronea*"
 #: /Game/Dialogue/OrcChief/Default/OrcGreeting01.Default__OrcGreeting01_C.SessionData.Lines(2).Lines
 msgctxt ",FE9D2CEF44200883BEC34F94279CA502"
 msgid "My tribe very horny, need elves for breeding."
-msgstr "Mi tribu muy cachonda, necesito elfos para reproducirnos."
+msgstr "Mi tribu muy cachonda, necesitamos elfos para la reproducción."
 
 #. Key:	FEB03B36414C543E3D3737B9AB198545
 #. SourceLocation:	/Game/Dialogue/MegaSlime/Default/MegaSlimePlay1.Default__MegaSlimePlay1_C.SessionData.LinesToFemale(2).LinesToFemale
@@ -13932,7 +13932,7 @@ msgstr "Ohhh, humano, sí... mi suave y carnosa ingle te espera."
 #: /Game/Dialogue/Mirru/Default/MirruDefault01_AboutKrakens.Default__MirruDefault01_AboutKrakens_C.SessionData.Lines(8).Lines
 msgctxt ",FEEAD6AA4B91EE463E366FBDCB397167"
 msgid "Even a drylander such as yourself can probably guess what purpose my two front tentacles serve."
-msgstr "Incluso alguien de suelo firme como tú probablemente pueda adivinar para qué sirven mis dos tentáculos delanteros."
+msgstr "Incluso alguien de tierra firme como tú probablemente pueda adivinar para qué sirven mis dos tentáculos delanteros."
 
 #. Key:	FF0D5A0E4AD29A5B9CCF59942CB94FFA
 #. SourceLocation:	/Game/Dialogue/Emissary/Default/EmissaryDefault01_RaiseTraitLvl.Default__EmissaryDefault01_RaiseTraitLvl_C.SessionData.Lines(0).Lines
@@ -13960,7 +13960,7 @@ msgstr "El Vacío se vuelve aburrido cuando lo has vagado durante incontables mi
 #: /Game/Dialogue/Camilla/Default/CamillaDefault01_R06.Default__CamillaDefault01_R06_C.SessionData.Lines(0).Lines
 msgctxt ",FF56CAFF482C5F43FF4C419DCB359C8A"
 msgid "Mean human! Girthy little lumps have feelings too!"
-msgstr "¡Humano mezquino! ¡ Los pequeño bultos orondos también tienen sentimientos!"
+msgstr "¡Humano mezquino! ¡Los pequeños bultos orondos también tienen sentimientos!"
 
 #. Key:	FF5A245B4A28E802C1A30CAC4B4DE4E5
 #. SourceLocation:	/Game/Characters/Procedural/Variants/Seraphim/Harvest/SeraphimHarvest.Default__SeraphimHarvest_C.Harvest.Description
@@ -13989,7 +13989,7 @@ msgstr "Tetona: heredó unos pechos muy grandes."
 #: /Game/Dialogue/Fesssi/Default/FesssiAreYouOk.Default__FesssiAreYouOk_C.SessionData.Lines(1).Lines
 msgctxt ",FFF6AE0C41E39194F413A28DAC8CD9F5"
 msgid "Give into your desires human. I know you want to mate with all of thisss."
-msgstr "Cede a tus deseos humanos. Sé que quieres emparejarte con todo esssto."
+msgstr "Cede a tus deseos humanos. Sé que quieres aparearte con todo esssto."
 
 #. Key:	SpiritFormActivate
 #. SourceLocation:	Source/Radiant/Public/Characters/SexyBreederCharacter.cpp:200
@@ -14017,7 +14017,7 @@ msgstr "No hay suficiente espíritu."
 #: Source/Radiant/Public/Characters/Breeder/SexyBreederController.cpp:784
 msgctxt "ASexyBreederController,NoKeystones"
 msgid "A keystone is required."
-msgstr "Se requiere una piedra-llave."
+msgstr "Se requiere una Keystone."
 
 #. Key:	IncestDisabledMessage
 #. SourceLocation:	Source/Radiant/Public/Game/Monsters/SexyBreedingSystem.cpp:399
@@ -14248,7 +14248,7 @@ msgstr "El silvestre quería más..."
 #: Source/Radiant/Public/Game/Monsters/SexyRoamingSystem.cpp:909
 msgctxt "ASexyRoamingSystem,BreederClimaxedFirst"
 msgid "{0} has climaxed first..."
-msgstr "{0} alcanzó el clímax primero..."
+msgstr "{0} ha llegado al clímax primero..."
 
 #. Key:	BreederLikedCum
 #. SourceLocation:	Source/Radiant/Public/Game/Monsters/SexyRoamingSystem.cpp:896
@@ -14346,7 +14346,7 @@ msgstr "Flores de Semen"
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:645
 msgctxt "ASexyWorldSystem,DryadMateTask"
 msgid "If you would, breed me a lusty little honey bee. She can \"pollinate\" me all day, and I can produce more bosom cherries for my adorable cows."
-msgstr "Si quieres, críame una pequeña abeja de la miel lujuriosa. Ella puede \"polinizarme\" todo el día y yo puedo producir más cerezas para mis adorables vacas."
+msgstr "Si quieres, críame una pequeña abeja de la miel lujuriosa. Ella puede \"polinizarme\" todo el día y yo puedo producir más cerezas de seno para mis adorables vacas."
 
 #. Key:	DryadMateTaskReward
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:643
@@ -14472,7 +14472,7 @@ msgstr "¡Grrr! ¡Críanos una hembra fértil! Queremos descendencia fuerte."
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:731
 msgctxt "ASexyWorldSystem,OrcMateTaskReward"
 msgid "Chieftain Xena wishes to speak with you."
-msgstr "La Chieftain Xena desea hablar contigo."
+msgstr "La Cacique Xena desea hablar contigo."
 
 #. Key:	PetraMate
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:753
@@ -14486,7 +14486,7 @@ msgstr "Dragón de Práctica"
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:756
 msgctxt "ASexyWorldSystem,PetraMateTask"
 msgid "Pawsmaati gave me the task of practicing her lesson with a \"winged mountain maiden\"!"
-msgstr "¡Pawsmaati me dio la tarea de practicar su lección con una \"doncella de la montaña alada\"!"
+msgstr "¡Pawsmaati me dio la tarea de practicar su lección con una \"doncella alada de la montaña\"!"
 
 #. Key:	PetraMateTaskReward
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:754
@@ -14557,7 +14557,7 @@ msgstr "Elfa Jugosa de Widow"
 #: Source/Radiant/Public/World/SexyWorldSystem.cpp:710
 msgctxt "ASexyWorldSystem,WidowElfTask"
 msgid "This lonely spider wishes for her own personal elf, both as a mate and a tasty morsel."
-msgstr "Esta araña solitaria desea tener su propia elfa personal, tanto como compañera como como un sabroso bocado."
+msgstr "Esta araña solitaria desea tener su propia elfa personal, tanto como pareja como para un sabroso bocado."
 
 #. Key:	WidowElfTaskReward
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:708
@@ -14620,7 +14620,7 @@ msgstr "Depurar"
 #: Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:369
 msgctxt "BreedingSession,IKBelly"
 msgid "Belly"
-msgstr "Barriga"
+msgstr "Vientre"
 
 #. Key:	IKDick
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:296
@@ -14753,7 +14753,7 @@ msgstr "Reserva de Semen"
 #: Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:109
 msgctxt "BreedingSession,SkipButtonTooltip"
 msgid "Proceed to the next phase of this scene."
-msgstr "Continúa con la siguiente fase de esta escena."
+msgstr "Continuar con la siguiente fase de esta escena."
 
 #. Key:	SpeedTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyBreedingSessionMenu.cpp:31
@@ -14795,7 +14795,7 @@ msgstr "Rápido"
 #: Source/Radiant/Public/UI/Menus/SexyBreedingSetupMenu.cpp:67
 msgctxt "BreedingSetup,QuickButtonTooltip"
 msgid "Breed this pair without starting a scene."
-msgstr "Reproducir esta pareja sin comenzar una escena."
+msgstr "Reproducir este par sin comenzar una escena."
 
 #. Key:	ReceiverWindowTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyBreedingSetupMenu.cpp:146
@@ -14851,7 +14851,7 @@ msgstr "La receptora debe ser seleccionada."
 #: Source/Radiant/Public/Game/Monsters/SexyBreedingSystem.cpp:1012
 msgctxt "BreedingSystem,NoRoomOffspring"
 msgid "Not enough space for offspring, it was released into the wild."
-msgstr "No hay suficiente espacio para la descendencia, se liberó en la naturaleza."
+msgstr "No hay suficiente espacio para el descendiente, fue liberado en la naturaleza."
 
 #. Key:	NoSexPosition
 #. SourceLocation:	Source/Radiant/Public/Game/Monsters/SexyBreedingSystem.cpp:198
@@ -14872,7 +14872,7 @@ msgstr "Atractivo"
 #: Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:176
 msgctxt "CharacterDetails,AllureTooltip"
 msgid "Allure is a measure of the pheromones given off by this one."
-msgstr "El Atractivo es una medida de las feromonas emitidas por éste/a."
+msgstr "El Atractivo es una medida de las feromonas emitidas por éste."
 
 #. Key:	Attributes
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:75
@@ -14963,7 +14963,7 @@ msgstr "Lealtad"
 #: Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:53
 msgctxt "CharacterDetails,LoyaltyTooltip"
 msgid "How happy this one is to stay on your ranch."
-msgstr "Qué feliz es éste de quedarse en tu rancho."
+msgstr "Cuán feliz es éste de quedarse en tu rancho."
 
 #. Key:	Lust
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterDetails.cpp:37
@@ -15170,7 +15170,7 @@ msgstr "Regresar a la pantalla anterior."
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:351
 msgctxt "CharacterEditor,BellyShape"
 msgid "Belly"
-msgstr "Barriga"
+msgstr "Vientre"
 
 #. Key:	BodyAttachments
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:495
@@ -15236,7 +15236,7 @@ msgid ""
 "Change this character's sex.\n"
 "WARNING: This will overwrite the current appearance."
 msgstr ""
-"Cambia el sexo de este personaje.\n"
+"Cambiar el sexo de este personaje.\n"
 "ADVERTENCIA: Esto sobrescribirá la apariencia actual."
 
 #. Key:	ChooseAnimationTooltip
@@ -15275,7 +15275,7 @@ msgid ""
 "Give this character its exotic trait if one exists.\n"
 "WARNING: This will overwrite the current appearance."
 msgstr ""
-"Dale a este personaje su rasgo exótico si existe.\n"
+"Dar a este personaje su rasgo exótico si existe.\n"
 "ADVERTENCIA: Esto sobrescribirá la apariencia actual."
 
 #. Key:	EyebrowMaterial
@@ -15363,7 +15363,7 @@ msgid ""
 "Give this character its hominal trait if one exists.\n"
 "WARNING: This will overwrite the current appearance."
 msgstr ""
-"Dale a este personaje su rasgo humanoide si existe.\n"
+"Dar a este personaje su rasgo humanoide si existe.\n"
 "ADVERTENCIA: Esto sobrescribirá la apariencia actual."
 
 #. Key:	LeaveButton
@@ -15431,7 +15431,7 @@ msgstr "Siguiente"
 #: Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:108
 msgctxt "CharacterEditor,NextButtonTooltip"
 msgid "Continue to the next screen."
-msgstr "Continúa a la siguiente pantalla."
+msgstr "Continúar a la siguiente pantalla."
 
 #. Key:	NippleMaterial
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyCharacterEditorMenu.cpp:408
@@ -15571,7 +15571,7 @@ msgid ""
 "Change this character's variant.\n"
 "WARNING: This will overwrite the current appearance."
 msgstr ""
-"Cambia la variante de este personaje.\n"
+"Cambiar la variante de este personaje.\n"
 "ADVERTENCIA: Esto sobrescribirá la apariencia actual."
 
 #. Key:	ErrorSavingPreset
@@ -15642,14 +15642,14 @@ msgstr "Se regalará el Nephelym seleccionado."
 #: Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:126
 msgctxt "ConfirmationBox,FulfillConfirmTitle"
 msgid "Fulfill Task?"
-msgstr "¿Cumplir Tarea?"
+msgstr "¿Cumplir la Tarea?"
 
 #. Key:	FulfillFluidConfirm
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:132
 #: Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:132
 msgctxt "ConfirmationBox,FulfillFluidConfirm"
 msgid "Fluids will be removed from your inventory."
-msgstr "Los fluidos se eliminarán de su inventario."
+msgstr "Los fluidos se eliminarán de tu inventario."
 
 #. Key:	NewGameConfirm
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:97
@@ -15677,7 +15677,7 @@ msgstr "Esto sobrescribirá permanentemente los datos en esta ranura."
 #: Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:101
 msgctxt "ConfirmationBox,OverwriteGameConfirmTitle"
 msgid "Overwrite Saved Game?"
-msgstr "¿Sobrescribir Juego Guardado?"
+msgstr "¿Sobrescribir el Juego Guardado?"
 
 #. Key:	PresetAttachmentConfirm
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:152
@@ -15768,7 +15768,7 @@ msgstr "¿Propagar el Color del Cabello?"
 #: Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:122
 msgctxt "ConfirmationBox,ReleaseConfirm"
 msgid "It will permanently leave your ranch and frolic once more."
-msgstr "Dejará permanentemente su rancho y se divertirá una vez más."
+msgstr "Dejará permanentemente tu rancho y se divertirá una vez más."
 
 #. Key:	ReleaseConfirmTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyConfirmationBox.cpp:121
@@ -15992,14 +15992,14 @@ msgstr ""
 #: Source/Radiant/Public/UI/Components/SexyHarvestWidget.cpp:419
 msgctxt "HarvestWidget,UseMilkTooltip"
 msgid "Use 15 ml of milk in attempt to stimulate this wild Nephelym."
-msgstr "Usar 15 ml de leche en un intento de estimular este Nephelym silvestre."
+msgstr "Usar 15 ml de leche en un intento de estimular a este Nephelym silvestre."
 
 #. Key:	UseSemenTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyHarvestWidget.cpp:404
 #: Source/Radiant/Public/UI/Components/SexyHarvestWidget.cpp:404
 msgctxt "HarvestWidget,UseSemenTooltip"
 msgid "Use 5 ml of semen in attempt to stimulate this wild Nephelym."
-msgstr "Usar 5 ml de semen en un intento de estimular este Nephelym silvestre."
+msgstr "Usar 5 ml de semen en un intento de estimular a este Nephelym silvestre."
 
 #. Key:	P
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyIKModifier.cpp:156
@@ -16370,7 +16370,7 @@ msgstr "Ranura de Guardado Vacia"
 #: Source/Radiant/Public/UI/Menus/SexyMainMenu.cpp:69
 msgctxt "MainMenu,DiscordButton"
 msgid "Discord"
-msgstr "Discord"
+msgstr ""
 
 #. Key:	ExitGameButton
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyMainMenu.cpp:77
@@ -16412,7 +16412,7 @@ msgstr "Iniciar"
 #: Source/Radiant/Public/UI/Menus/SexyMonsterMenu.cpp:62
 msgctxt "ManageMonster,ActionTooltip"
 msgid "Perform the selected action, starting a scene if one exists."
-msgstr "Realiza la acción seleccionada, comenzando una escena si existe."
+msgstr "Realizar la acción seleccionada, comenzando una escena si existe."
 
 #. Key:	HarvestDev
 #. SourceLocation:	Source/Radiant/Public/Game/Monsters/SexyMonsterSystem.cpp:608
@@ -16447,7 +16447,7 @@ msgstr "Rápido"
 #: Source/Radiant/Public/UI/Menus/SexyMonsterMenu.cpp:54
 msgctxt "ManageMonster,QuickActionTooltip"
 msgid "Perform the selected action without starting a scene."
-msgstr "Realiza la acción seleccionada sin comenzar una escena."
+msgstr "Realizar la acción seleccionada sin comenzar una escena."
 
 #. Key:	Giver
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyMateSizeChart.cpp:33
@@ -16503,7 +16503,7 @@ msgstr "Aceptar"
 #: Source/Radiant/Public/UI/Menus/SexyOffspringMenu.cpp:54
 msgctxt "Offspring,AcceptButtonTitleTooltip"
 msgid "Keep this offspring and add it to your ranch."
-msgstr "Quedarte con este descendiente y agrégalo a tu rancho."
+msgstr "Conservar este descendiente y añadirlo a tu rancho."
 
 #. Key:	BackButtonTitleTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyOffspringMenu.cpp:63
@@ -16552,7 +16552,7 @@ msgstr "Renombrar"
 #: Source/Radiant/Public/UI/Menus/SexyOffspringMenu.cpp:44
 msgctxt "Offspring,RenameButtonTooltip"
 msgid "Rename this offspring before adding it to your ranch."
-msgstr "Cambiar el nombre de este descendiente antes de agregarlo a tu rancho."
+msgstr "Cambiar el nombre de este descendiente antes de añadirlo a tu rancho."
 
 #. Key:	Female
 #. SourceLocation:	Source/Radiant/Public/World/SexyWorldSystem.cpp:442
@@ -16783,7 +16783,7 @@ msgstr "Reproducción Automática de Diálogo"
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:119
 msgctxt "SettingsMenu,AutoplayDialogueHelp"
 msgid "Automatically cycle through lines of dialogue without having to press next."
-msgstr "Ciclo automático a través de las líneas de diálogo sin tener que presionar siguiente."
+msgstr "Ciclo automático a través de las líneas de diálogo sin tener que presionar Siguiente."
 
 #. Key:	BulgeHelp
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:116
@@ -16867,7 +16867,7 @@ msgstr "Bulto del Pene"
 #: Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:435
 msgctxt "SettingsMenu,DickSheath"
 msgid "Dick Seam Blend"
-msgstr "Mezcla de la Juntura del Pene"
+msgstr "Mezclar la Juntura del Pene"
 
 #. Key:	EffectsVolume
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexySettingsMenu.cpp:516
@@ -16979,7 +16979,7 @@ msgstr "Master"
 #: Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:112
 msgctxt "SettingsMenu,MixHelp"
 msgid "Offspring colors will be blended from parents."
-msgstr "Los colores de la descendencia se mezclarán de los padres."
+msgstr "Los colores de la descendencia se mezclarán a partir de los padres."
 
 #. Key:	MixOffspring
 #. SourceLocation:	Source/Radiant/Public/UI/Settings/SexySettingsSystem.cpp:112
@@ -17168,14 +17168,14 @@ msgstr "Forma Espiritual"
 #: Source/Radiant/Public/UI/Components/SexyCharacterGalleryControls.cpp:46
 msgctxt "SSexyCharacterGalleryControls,ExoticTooltip"
 msgid "Give this character its exotic trait if one exists."
-msgstr "Dale a este personaje su rasgo exótico si existe."
+msgstr "Dar a este personaje su rasgo exótico si existe."
 
 #. Key:	HominalTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterGalleryControls.cpp:35
 #: Source/Radiant/Public/UI/Components/SexyCharacterGalleryControls.cpp:35
 msgctxt "SSexyCharacterGalleryControls,HominalTooltip"
 msgid "Give this character its hominal trait if one exists."
-msgstr "Dale a este personaje su rasgo humanoide si existe."
+msgstr "Dar a este personaje su rasgo humanoide si existe."
 
 #. Key:	UsrPresetTooltip
 #. SourceLocation:	Source/Radiant/Public/UI/Components/SexyCharacterGalleryControls.cpp:57
@@ -17280,7 +17280,7 @@ msgstr "Cumplir"
 #: Source/Radiant/Public/UI/Menus/SexyGenericMenu.cpp:220
 msgctxt "SSexyGenericMenu,FulfillButtonTooltip"
 msgid "Accept the reward for this task."
-msgstr "Acepta la recompensa por esta tarea."
+msgstr "Aceptar la recompensa por esta tarea."
 
 #. Key:	SpecialTasksTitle
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyGenericMenu.cpp:164
@@ -17322,7 +17322,7 @@ msgstr "Enlazar"
 #: Source/Radiant/Public/UI/Components/SexyKeyBind.cpp:56
 msgctxt "SSexyKeyBind,BindKey"
 msgid "Press Key"
-msgstr "Presiona la Tecla"
+msgstr "Presionar la Tecla"
 
 #. Key:	CollapseStats
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyMonsterMenu.cpp:149
@@ -17406,7 +17406,7 @@ msgstr "Capturar"
 #: Source/Radiant/Public/UI/Menus/SexyRoamerMenu.cpp:114
 msgctxt "SSexyRoamerMenu,CatchButtonTooltip"
 msgid "Add this wild Nephelym to your collection."
-msgstr "Agrega este Nephelym silvestre a tu colección."
+msgstr "Añade este Nephelym silvestre a tu colección."
 
 #. Key:	CollapseStats
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyRoamerMenu.cpp:161
@@ -17441,7 +17441,7 @@ msgstr "Salir"
 #: Source/Radiant/Public/UI/Menus/SexyRoamerMenu.cpp:71
 msgctxt "SSexyRoamerMenu,LeaveButtonTooltip"
 msgid "Leave this wild Nephelym alone."
-msgstr "Deja en paz a este Nephelym silvestre."
+msgstr "Dejar solo a este Nephelym silvestre."
 
 #. Key:	Nephelym
 #. SourceLocation:	Source/Radiant/Public/UI/Menus/SexyRoamerMenu.cpp:196


### PR DESCRIPTION
Translation up to Public Build 0.754.3

Changes in the previous version:

I have removed the bars for the genre because they mess up the text a lot and it becomes more difficult to read. I have tried to make it as neutral as possible.

The proper names are untranslated, except Dragon Matriarch and Queen Bee, as they are actually titles. It makes it easy to recognize the characters when they talk about them.
Mastah and Master (as Fern and Blossom call the breeder) are also untranslated to avoid gender.

The names of the races and variants are all in lower case for the dialogues. There are a lot of them, and although it is capitalized to highlight important information, the complete data appears on the task board.

I think that with these changes it is cleaner. For anything contact me on the Discord server.